### PR TITLE
Add initial office placeholders

### DIFF
--- a/Examples/Example-PlaceholderClasses.ps1
+++ b/Examples/Example-PlaceholderClasses.ps1
@@ -1,0 +1,8 @@
+Import-Module "$PSScriptRoot/../PSWriteOffice.psd1" -Force
+
+# Instantiate placeholder service and cmdlet
+$service = [PSWriteOffice.Services.Word.WordDocumentService]::new()
+$cmdlet = [PSWriteOffice.Cmdlets.Word.GetOfficeWordCommand]::new()
+
+$service
+$cmdlet

--- a/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelCommand.cs
@@ -1,0 +1,9 @@
+using System.Management.Automation;
+
+namespace PSWriteOffice.Cmdlets.Excel
+{
+    [Cmdlet(VerbsCommon.Get, "OfficeExcel")]
+    public class GetOfficeExcelCommand : PSCmdlet
+    {
+    }
+}

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointCommand.cs
@@ -1,0 +1,9 @@
+using System.Management.Automation;
+
+namespace PSWriteOffice.Cmdlets.PowerPoint
+{
+    [Cmdlet(VerbsCommon.Get, "OfficePowerPoint")]
+    public class GetOfficePowerPointCommand : PSCmdlet
+    {
+    }
+}

--- a/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordCommand.cs
@@ -1,0 +1,9 @@
+using System.Management.Automation;
+
+namespace PSWriteOffice.Cmdlets.Word
+{
+    [Cmdlet(VerbsCommon.Get, "OfficeWord")]
+    public class GetOfficeWordCommand : PSCmdlet
+    {
+    }
+}

--- a/Sources/PSWriteOffice/PSWriteOffice.csproj
+++ b/Sources/PSWriteOffice/PSWriteOffice.csproj
@@ -23,6 +23,11 @@
 		<ProjectReference Include="..\..\..\OfficeIMO\OfficeIMO.Word\OfficeIMO.Word.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<Compile Update="Cmdlets/**/*.cs" />
+		<Compile Update="Services/**/*.cs" />
+	</ItemGroup>
+
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
 		<DefineConstants>$(DefineConstants);FRAMEWORK</DefineConstants>
 	</PropertyGroup>

--- a/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.cs
@@ -1,0 +1,6 @@
+namespace PSWriteOffice.Services.Excel
+{
+    public class ExcelDocumentService
+    {
+    }
+}

--- a/Sources/PSWriteOffice/Services/PowerPoint/PowerPointDocumentService.cs
+++ b/Sources/PSWriteOffice/Services/PowerPoint/PowerPointDocumentService.cs
@@ -1,0 +1,6 @@
+namespace PSWriteOffice.Services.PowerPoint
+{
+    public class PowerPointDocumentService
+    {
+    }
+}

--- a/Sources/PSWriteOffice/Services/Word/WordDocumentService.cs
+++ b/Sources/PSWriteOffice/Services/Word/WordDocumentService.cs
@@ -1,0 +1,6 @@
+namespace PSWriteOffice.Services.Word
+{
+    public class WordDocumentService
+    {
+    }
+}

--- a/Tests/Placeholder.Tests.ps1
+++ b/Tests/Placeholder.Tests.ps1
@@ -1,0 +1,20 @@
+Describe 'Placeholder classes' {
+    It 'GetOfficeWordCommand exists' {
+        [Type]::GetType('PSWriteOffice.Cmdlets.Word.GetOfficeWordCommand', $false) | Should -Not -BeNullOrEmpty
+    }
+    It 'GetOfficeExcelCommand exists' {
+        [Type]::GetType('PSWriteOffice.Cmdlets.Excel.GetOfficeExcelCommand', $false) | Should -Not -BeNullOrEmpty
+    }
+    It 'GetOfficePowerPointCommand exists' {
+        [Type]::GetType('PSWriteOffice.Cmdlets.PowerPoint.GetOfficePowerPointCommand', $false) | Should -Not -BeNullOrEmpty
+    }
+    It 'WordDocumentService exists' {
+        [Type]::GetType('PSWriteOffice.Services.Word.WordDocumentService', $false) | Should -Not -BeNullOrEmpty
+    }
+    It 'ExcelDocumentService exists' {
+        [Type]::GetType('PSWriteOffice.Services.Excel.ExcelDocumentService', $false) | Should -Not -BeNullOrEmpty
+    }
+    It 'PowerPointDocumentService exists' {
+        [Type]::GetType('PSWriteOffice.Services.PowerPoint.PowerPointDocumentService', $false) | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold Cmdlets and Services directories for Excel, Word and PowerPoint
- add placeholder cmdlet and service classes
- wire folders into project and add simple example and Pester test

## Testing
- `dotnet build Sources/PSWriteOffice/PSWriteOffice.csproj`
- `pwsh PSWriteOffice.Tests.ps1` *(fails: The term 'Write-Color' is not recognized; The required module 'PSSharedGoods' is not loaded; The term 'Invoke-Pester' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_688f98301a4c832ebf646deb0e624665