### PR TITLE
Use AddEmbeddedFragment for Word HTML import

### DIFF
--- a/Examples/ExampleWord13-AddHtml.ps1
+++ b/Examples/ExampleWord13-AddHtml.ps1
@@ -1,0 +1,10 @@
+Clear-Host
+Import-Module .\PSWriteOffice.psd1 -Force
+
+$docAsIs = New-OfficeWord -FilePath "$PSScriptRoot\Documents\HtmlAsIs.docx"
+[PSWriteOffice.Services.Word.WordDocumentService]::AddHtml($docAsIs, '<p>Hello <b>World</b></p>', [PSWriteOffice.Services.Word.HtmlImportMode]::AsIs)
+Save-OfficeWord -Document $docAsIs -Show
+
+$docParsed = New-OfficeWord -FilePath "$PSScriptRoot\Documents\HtmlParsed.docx"
+[PSWriteOffice.Services.Word.WordDocumentService]::AddHtml($docParsed, '<p>Hello <b>World</b></p>')
+Save-OfficeWord -Document $docParsed -Show

--- a/Sources/PSWriteOffice/Services/Word/WordDocumentService.Html.cs
+++ b/Sources/PSWriteOffice/Services/Word/WordDocumentService.Html.cs
@@ -1,8 +1,6 @@
 using System;
-using System.IO;
 using System.Reflection;
 using DocumentFormat.OpenXml.Packaging;
-using DocumentFormat.OpenXml.Wordprocessing;
 using HtmlToOpenXml;
 using OfficeIMO.Word;
 
@@ -12,36 +10,17 @@ public static partial class WordDocumentService
 {
     public static void AddHtml(WordDocument document, string html, HtmlImportMode mode = HtmlImportMode.Parse)
     {
-        var field = typeof(WordDocument).GetField("_document", BindingFlags.NonPublic | BindingFlags.Instance);
-        if (field == null)
-        {
-            throw new InvalidOperationException("Unable to access underlying document.");
-        }
-
-        var wordDocument = field.GetValue(document) as WordprocessingDocument;
-        if (wordDocument == null)
-        {
-            throw new InvalidOperationException("Underlying document is null.");
-        }
-
-        var mainPart = wordDocument.MainDocumentPart ?? throw new InvalidOperationException("Main document part is missing.");
-
         if (mode == HtmlImportMode.AsIs)
         {
-            var altChunkId = "htmlChunk" + Guid.NewGuid().ToString("N");
-            var part = mainPart.AddAlternativeFormatImportPart(AlternativeFormatImportPartType.Html, altChunkId);
-            using (var stream = part.GetStream())
-            using (var writer = new StreamWriter(stream))
-            {
-                writer.Write(html);
-            }
-
-            var altChunk = new AltChunk { Id = altChunkId };
-            var body = mainPart.Document.Body ??= new Body();
-            body.Append(altChunk);
-            mainPart.Document.Save();
+            document.AddEmbeddedFragment(html, WordAlternativeFormatImportPartType.Html);
             return;
         }
+
+        var field = typeof(WordDocument).GetField("_document", BindingFlags.NonPublic | BindingFlags.Instance)
+                    ?? throw new InvalidOperationException("Unable to access underlying document.");
+        var wordDocument = field.GetValue(document) as WordprocessingDocument
+                           ?? throw new InvalidOperationException("Underlying document is null.");
+        var mainPart = wordDocument.MainDocumentPart ?? throw new InvalidOperationException("Main document part is missing.");
 
         var converter = new HtmlConverter(mainPart);
         converter.ParseHtml(html);


### PR DESCRIPTION
## Summary
- use OfficeIMO's `AddEmbeddedFragment` for `HtmlImportMode.AsIs`
- parse HTML via HtmlConverter when import mode is `Parse`
- add example showing HTML fragment import

## Testing
- `dotnet build Sources/PSWriteOffice/PSWriteOffice.csproj`
- `pwsh -NoLogo -Command ./PSWriteOffice.Tests.ps1` *(fails: Install-Package: No match was found for the specified search criteria and module name 'Pester')*


------
https://chatgpt.com/codex/tasks/task_e_68909f93a0c8832ead567123475d550b