### PR TITLE
Add PowerPoint presentation loader

### DIFF
--- a/Examples/ExamplePowerPoint05-Load.ps1
+++ b/Examples/ExamplePowerPoint05-Load.ps1
@@ -1,0 +1,7 @@
+Clear-Host
+# Create and load a PowerPoint presentation
+$path = "$PSScriptRoot\Documents\LoadExample.pptx"
+$presentation = New-OfficePowerPoint -FilePath $path
+Save-OfficePowerPoint -Presentation $presentation
+$loaded = Get-OfficePowerPoint -FilePath $path
+$loaded

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointCommand.cs
@@ -1,9 +1,32 @@
+using System;
+using System.IO;
 using System.Management.Automation;
+using ShapeCrawler;
+using PSWriteOffice.Services.PowerPoint;
 
-namespace PSWriteOffice.Cmdlets.PowerPoint
+namespace PSWriteOffice.Cmdlets.PowerPoint;
+
+[Cmdlet(VerbsCommon.Get, "OfficePowerPoint")]
+public class GetOfficePowerPointCommand : PSCmdlet
 {
-    [Cmdlet(VerbsCommon.Get, "OfficePowerPoint")]
-    public class GetOfficePowerPointCommand : PSCmdlet
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string FilePath { get; set; } = string.Empty;
+
+    protected override void ProcessRecord()
     {
+        try
+        {
+            var presentation = PowerPointDocumentService.LoadPresentation(FilePath);
+            WriteObject(presentation);
+        }
+        catch (FileNotFoundException ex)
+        {
+            WriteError(new ErrorRecord(ex, "FileNotFound", ErrorCategory.ObjectNotFound, FilePath));
+        }
+        catch (Exception ex)
+        {
+            WriteError(new ErrorRecord(ex, "PowerPointLoadFailed", ErrorCategory.InvalidOperation, FilePath));
+        }
     }
 }

--- a/Sources/PSWriteOffice/Services/PowerPoint/PowerPointDocumentService.cs
+++ b/Sources/PSWriteOffice/Services/PowerPoint/PowerPointDocumentService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.IO;
 using ShapeCrawler;
 
 namespace PSWriteOffice.Services.PowerPoint;
@@ -13,6 +14,18 @@ public static class PowerPointDocumentService
     {
         var presentation = new Presentation();
         Presentations[presentation] = (filePath, true);
+        return presentation;
+    }
+
+    public static Presentation LoadPresentation(string filePath)
+    {
+        if (!File.Exists(filePath))
+        {
+            throw new FileNotFoundException($"File {filePath} doesn't exist.", filePath);
+        }
+
+        var presentation = new Presentation(filePath);
+        Presentations[presentation] = (filePath, false);
         return presentation;
     }
 

--- a/Tests/GetOfficePowerPoint.Tests.ps1
+++ b/Tests/GetOfficePowerPoint.Tests.ps1
@@ -1,0 +1,13 @@
+Describe 'Get-OfficePowerPoint cmdlet' {
+    It 'throws when file does not exist' {
+        { Get-OfficePowerPoint -FilePath (Join-Path $TestDrive 'missing.pptx') -ErrorAction Stop } | Should -Throw
+    }
+
+    It 'loads existing presentation' {
+        $path = Join-Path $TestDrive 'test.pptx'
+        $pres = New-OfficePowerPoint -FilePath $path
+        Save-OfficePowerPoint -Presentation $pres
+        $loaded = Get-OfficePowerPoint -FilePath $path
+        $loaded | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- allow Get-OfficePowerPoint to load existing presentations from disk
- add service API for loading presentations
- cover loading scenario with a Pester test and example

## Testing
- `dotnet build Sources/PSWriteOffice/PSWriteOffice.csproj`
- `pwsh -NoLogo -NonInteractive -File ./PSWriteOffice.Tests.ps1` *(fails: The required module 'PSSharedGoods' is not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_6890d72ae7c0832ebe22af68724d6834