### PR TITLE
Add WhatIf support to Excel save and close commands

### DIFF
--- a/Sources/PSWriteOffice/Cmdlets/Excel/CloseOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/CloseOfficeExcelCommand.cs
@@ -4,7 +4,7 @@ using PSWriteOffice.Services.Excel;
 
 namespace PSWriteOffice.Cmdlets.Excel;
 
-[Cmdlet(VerbsCommon.Close, "OfficeExcel")]
+[Cmdlet(VerbsCommon.Close, "OfficeExcel", SupportsShouldProcess = true)]
 public class CloseOfficeExcelCommand : PSCmdlet
 {
     [Parameter(Mandatory = true)]
@@ -12,6 +12,9 @@ public class CloseOfficeExcelCommand : PSCmdlet
 
     protected override void ProcessRecord()
     {
-        ExcelDocumentService.CloseWorkbook(Workbook);
+        if (ShouldProcess("Workbook", "Close workbook"))
+        {
+            ExcelDocumentService.CloseWorkbook(Workbook);
+        }
     }
 }

--- a/Sources/PSWriteOffice/Cmdlets/Excel/SaveOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/SaveOfficeExcelCommand.cs
@@ -5,7 +5,7 @@ using PSWriteOffice.Services.Excel;
 
 namespace PSWriteOffice.Cmdlets.Excel;
 
-[Cmdlet(VerbsData.Save, "OfficeExcel")]
+[Cmdlet(VerbsData.Save, "OfficeExcel", SupportsShouldProcess = true)]
 public class SaveOfficeExcelCommand : PSCmdlet
 {
     [Parameter(Mandatory = true)]
@@ -21,7 +21,10 @@ public class SaveOfficeExcelCommand : PSCmdlet
     {
         try
         {
-            ExcelDocumentService.SaveWorkbook(Workbook, FilePath, Show);
+            if (ShouldProcess(FilePath, "Save workbook"))
+            {
+                ExcelDocumentService.SaveWorkbook(Workbook, FilePath, Show);
+            }
         }
         catch (Exception ex)
         {

--- a/Tests/ExcelWorkbook.Tests.ps1
+++ b/Tests/ExcelWorkbook.Tests.ps1
@@ -8,4 +8,13 @@ Describe 'Excel workbook cmdlets' {
         $loaded.Worksheets.Count | Should -Be 1
         Close-OfficeExcel -Workbook $loaded
     }
+
+    It 'supports -WhatIf parameter' {
+        $path = Join-Path $TestDrive 'test.xlsx'
+        $workbook = New-OfficeExcel
+        Save-OfficeExcel -Workbook $workbook -FilePath $path -WhatIf
+        Test-Path $path | Should -BeFalse
+        Close-OfficeExcel -Workbook $workbook -WhatIf
+        { $workbook.Worksheets.Count } | Should -Not -Throw
+    }
 }


### PR DESCRIPTION
## Summary
- enable ShouldProcess for Save-OfficeExcel and Close-OfficeExcel
- guard file operations behind ShouldProcess to support -WhatIf
- test -WhatIf behavior for Excel workbook commands

## Testing
- `dotnet build Sources/PSWriteOffice/PSWriteOffice.csproj`
- `pwsh PSWriteOffice.Tests.ps1` *(fails: The required module 'PSSharedGoods' is not loaded. The term 'Invoke-Pester' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6890d6f785a4832e8c5b1ab4f98bf968