### PR TITLE
Add path validation for Excel cmdlets

### DIFF
--- a/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Management.Automation;
 using ClosedXML.Excel;
 using PSWriteOffice.Services.Excel;
+using ValidateScriptAttribute = PSWriteOffice.Validation.ValidateScriptAttribute;
 
 namespace PSWriteOffice.Cmdlets.Excel;
 
@@ -12,6 +13,8 @@ namespace PSWriteOffice.Cmdlets.Excel;
 public class ExportOfficeExcelCommand : PSCmdlet
 {
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    [ValidateScript("{ Test-Path $_ }")]
     public string FilePath { get; set; } = string.Empty;
 
     [Parameter]

--- a/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelCommand.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Management.Automation;
 using ClosedXML.Excel;
 using PSWriteOffice.Services.Excel;
+using ValidateScriptAttribute = PSWriteOffice.Validation.ValidateScriptAttribute;
 
 namespace PSWriteOffice.Cmdlets.Excel;
 
@@ -10,6 +11,8 @@ namespace PSWriteOffice.Cmdlets.Excel;
 public class GetOfficeExcelCommand : PSCmdlet
 {
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    [ValidateScript("{ Test-Path $_ }")]
     public string FilePath { get; set; } = string.Empty;
 
     protected override void ProcessRecord()

--- a/Sources/PSWriteOffice/Cmdlets/Excel/ImportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ImportOfficeExcelCommand.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using PSWriteOffice.Services.Excel;
+using ValidateScriptAttribute = PSWriteOffice.Validation.ValidateScriptAttribute;
 
 namespace PSWriteOffice.Cmdlets.Excel;
 
@@ -12,6 +13,8 @@ public class ImportOfficeExcelCommand : PSCmdlet
 {
     [Alias("LiteralPath")]
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    [ValidateScript("{ Test-Path $_ }")]
     public string FilePath { get; set; } = string.Empty;
 
     [Parameter]

--- a/Sources/PSWriteOffice/Cmdlets/Excel/SaveOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/SaveOfficeExcelCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Management.Automation;
 using ClosedXML.Excel;
 using PSWriteOffice.Services.Excel;
+using ValidateScriptAttribute = PSWriteOffice.Validation.ValidateScriptAttribute;
 
 namespace PSWriteOffice.Cmdlets.Excel;
 
@@ -12,6 +13,8 @@ public class SaveOfficeExcelCommand : PSCmdlet
     public XLWorkbook Workbook { get; set; } = null!;
 
     [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    [ValidateScript("{ Test-Path $_ }")]
     public string FilePath { get; set; } = string.Empty;
 
     [Parameter]

--- a/Sources/PSWriteOffice/Support/ValidateScriptAttribute.cs
+++ b/Sources/PSWriteOffice/Support/ValidateScriptAttribute.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Management.Automation;
+
+namespace PSWriteOffice.Validation;
+
+public sealed class ValidateScriptAttribute : ValidateEnumeratedArgumentsAttribute
+{
+    private readonly ScriptBlock _scriptBlock;
+
+    public ValidateScriptAttribute(string script)
+    {
+        _scriptBlock = ScriptBlock.Create(script ?? throw new ArgumentNullException(nameof(script)));
+    }
+
+    protected override void ValidateElement(object element)
+    {
+        if (element == null)
+        {
+            throw new ValidationMetadataException("ValidateScriptFailure");
+        }
+
+        var result = _scriptBlock.InvokeReturnAsIs(element);
+        if (!LanguagePrimitives.IsTrue(result))
+        {
+            throw new ValidationMetadataException("ValidateScriptFailure");
+        }
+    }
+}

--- a/Tests/ExcelWorkbook.Tests.ps1
+++ b/Tests/ExcelWorkbook.Tests.ps1
@@ -1,11 +1,21 @@
 Describe 'Excel workbook cmdlets' {
     It 'creates, saves, and loads workbook' {
         $path = Join-Path $TestDrive 'test.xlsx'
+        New-Item -Path $path -ItemType File | Out-Null
         $workbook = New-OfficeExcel
         New-OfficeExcelWorkSheet -Workbook $workbook -WorksheetName 'Sheet1' -Option Replace | Out-Null
         Save-OfficeExcel -Workbook $workbook -FilePath $path
         $loaded = Get-OfficeExcel -FilePath $path
         $loaded.Worksheets.Count | Should -Be 1
         Close-OfficeExcel -Workbook $loaded
+    }
+
+    It 'throws when saving to invalid path' {
+        $workbook = New-OfficeExcel
+        { Save-OfficeExcel -Workbook $workbook -FilePath (Join-Path $TestDrive 'missing.xlsx') } | Should -Throw
+    }
+
+    It 'throws when loading from invalid path' {
+        { Get-OfficeExcel -FilePath (Join-Path $TestDrive 'missing.xlsx') } | Should -Throw
     }
 }

--- a/Tests/ExportOfficeExcel.Tests.ps1
+++ b/Tests/ExportOfficeExcel.Tests.ps1
@@ -1,8 +1,14 @@
 Describe 'Export-OfficeExcel cmdlet' {
     It 'creates an Excel file with a worksheet and table' {
         $path = Join-Path $TestDrive 'test.xlsx'
+        New-Item -Path $path -ItemType File | Out-Null
         $data = 1..3 | ForEach-Object { [PSCustomObject]@{ Value = $_ } }
         $data | Export-OfficeExcel -FilePath $path -WorksheetName 'Data'
         Test-Path $path | Should -BeTrue
+    }
+
+    It 'throws for invalid path' {
+        $data = 1..3 | ForEach-Object { [PSCustomObject]@{ Value = $_ } }
+        { $data | Export-OfficeExcel -FilePath (Join-Path $TestDrive 'missing.xlsx') } | Should -Throw
     }
 }

--- a/Tests/ImportOfficeExcel.Tests.ps1
+++ b/Tests/ImportOfficeExcel.Tests.ps1
@@ -1,6 +1,7 @@
 Describe 'Import-OfficeExcel cmdlet' {
     It 'imports specified worksheet data' {
         $path = Join-Path $TestDrive 'import.xlsx'
+        New-Item -Path $path -ItemType File | Out-Null
         $workbook = New-OfficeExcel
         $sheet1 = New-OfficeExcelWorkSheet -Workbook $workbook -WorksheetName 'Data' -Option Replace
         New-OfficeExcelValue -Worksheet $sheet1 -Row 1 -Column 1 -Value 'Name'
@@ -12,5 +13,9 @@ Describe 'Import-OfficeExcel cmdlet' {
         $rows = Import-OfficeExcel -FilePath $path -WorkSheetName 'Data'
         $rows[0].Name | Should -Be 'Jane'
         $rows[0].Age | Should -Be 31
+    }
+
+    It 'throws for invalid path' {
+        { Import-OfficeExcel -FilePath (Join-Path $TestDrive 'missing.xlsx') } | Should -Throw
     }
 }


### PR DESCRIPTION
## Summary
- add ValidateScript-based path checks to Excel cmdlets
- cover invalid path scenarios in Pester tests

## Testing
- `dotnet build`
- `pwsh -NoLogo -File ./PSWriteOffice.Tests.ps1` *(fails: The required module 'PSSharedGoods' is not loaded. The term 'Invoke-Pester' is not recognized as a name of a cmdlet, function, script file, or executable program)*
- `pwsh -NoLogo -Command "Register-PSRepository -Default; Install-Module -Name Pester -Force -SkipPublisherCheck -Scope CurrentUser"` *(fails: No match was found for the specified search criteria and module name 'Pester')*

------
https://chatgpt.com/codex/tasks/task_e_6890d6f1ee34832e9421d056e8efb961