### PR TITLE
Add culture-aware Excel import

### DIFF
--- a/Sources/PSWriteOffice/Cmdlets/Excel/ImportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ImportOfficeExcelCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
@@ -20,11 +21,14 @@ public class ImportOfficeExcelCommand : PSCmdlet
     [Parameter]
     public string[]? WorkSheetName { get; set; }
 
+    [Parameter]
+    public CultureInfo? Culture { get; set; }
+
     protected override void ProcessRecord()
     {
         try
         {
-            var data = ExcelDocumentService.ImportWorkbook(FilePath, WorkSheetName);
+            var data = ExcelDocumentService.ImportWorkbook(FilePath, WorkSheetName, Culture);
             if (WorkSheetName != null && WorkSheetName.Length == 1 && data.TryGetValue(WorkSheetName[0], out var single))
             {
                 WriteObject(single, true);

--- a/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.Workbook.Import.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.Workbook.Import.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using ClosedXML.Excel;
 
@@ -7,6 +8,9 @@ namespace PSWriteOffice.Services.Excel;
 public static partial class ExcelDocumentService
 {
     public static IDictionary<string, IList<IDictionary<string, object?>>> ImportWorkbook(string filePath, IEnumerable<string>? worksheetNames = null)
+        => ImportWorkbook(filePath, worksheetNames, null);
+
+    public static IDictionary<string, IList<IDictionary<string, object?>>> ImportWorkbook(string filePath, IEnumerable<string>? worksheetNames, CultureInfo? culture)
     {
         using var workbook = LoadWorkbook(filePath);
         var result = new Dictionary<string, IList<IDictionary<string, object?>>>();
@@ -18,7 +22,7 @@ public static partial class ExcelDocumentService
                 continue;
             }
 
-            var rows = GetWorksheetData(worksheet).ToList();
+            var rows = GetWorksheetData(worksheet, culture).ToList();
             result[worksheet.Name] = rows;
         }
 

--- a/Tests/ImportOfficeExcel.Tests.ps1
+++ b/Tests/ImportOfficeExcel.Tests.ps1
@@ -15,6 +15,19 @@ Describe 'Import-OfficeExcel cmdlet' {
         $rows[0].Age | Should -Be 31
     }
 
+    It 'imports data using specified culture' {
+        $path = Join-Path $TestDrive 'culture.xlsx'
+        New-Item -Path $path -ItemType File | Out-Null
+        $workbook = New-OfficeExcel
+        $sheet1 = New-OfficeExcelWorkSheet -Workbook $workbook -WorksheetName 'Data' -Option Replace
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 1 -Column 1 -Value 'Number'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 2 -Column 1 -Value '1,23'
+        Save-OfficeExcel -Workbook $workbook -FilePath $path
+        $culture = [System.Globalization.CultureInfo]'pl-PL'
+        $rows = Import-OfficeExcel -FilePath $path -Culture $culture
+        $rows[0].Number | Should -Be 1.23
+    }
+
     It 'throws for invalid path' {
         { Import-OfficeExcel -FilePath (Join-Path $TestDrive 'missing.xlsx') } | Should -Throw
     }


### PR DESCRIPTION
## Summary
- add Culture parameter to Import-OfficeExcel cmdlet
- honor CultureInfo when importing workbook data
- test Import-OfficeExcel with culture-specific number formatting

## Testing
- `dotnet build Sources/PSWriteOffice/PSWriteOffice.csproj`
- `pwsh PSWriteOffice.Tests.ps1` *(fails: required module 'PSSharedGoods' is not loaded; Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_689635632d40832e82047b6b2155f997