### PR TITLE
Add append option to Export-OfficeExcel cmdlet

### DIFF
--- a/Tests/ExportOfficeExcel.Tests.ps1
+++ b/Tests/ExportOfficeExcel.Tests.ps1
@@ -7,6 +7,18 @@ Describe 'Export-OfficeExcel cmdlet' {
         Test-Path $path | Should -BeTrue
     }
 
+    It 'appends to an existing table when Append is used' {
+        $path = Join-Path $TestDrive 'append.xlsx'
+        New-Item -Path $path -ItemType File | Out-Null
+        $first = 1..2 | ForEach-Object { [PSCustomObject]@{ Value = $_ } }
+        $first | Export-OfficeExcel -FilePath $path -WorksheetName 'Data'
+        $second = 3..4 | ForEach-Object { [PSCustomObject]@{ Value = $_ } }
+        $second | Export-OfficeExcel -FilePath $path -WorksheetName 'Data' -Append
+        $rows = Import-OfficeExcel -FilePath $path -WorkSheetName 'Data'
+        $rows.Count | Should -Be 4
+        $rows[-1].Value | Should -Be 4
+    }
+
     It 'throws for invalid path' {
         $data = 1..3 | ForEach-Object { [PSCustomObject]@{ Value = $_ } }
         { $data | Export-OfficeExcel -FilePath (Join-Path $TestDrive 'missing.xlsx') } | Should -Throw


### PR DESCRIPTION
## Summary
- allow Export-OfficeExcel to append to existing worksheet tables
- add tests for appending data

## Testing
- `dotnet build Sources/PSWriteOffice/PSWriteOffice.csproj`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path Tests/ExportOfficeExcel.Tests.ps1"` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896355d1b6c832e916aa533f480bd86