### PR TITLE
Add comment-based help and Word examples

### DIFF
--- a/Examples/Word/Close-OfficeWord.ps1
+++ b/Examples/Word/Close-OfficeWord.ps1
@@ -1,0 +1,6 @@
+Clear-Host
+Import-Module .\PSWriteOffice.psd1 -Force
+
+$path = "$PSScriptRoot\CloseDocument.docx"
+$doc = New-OfficeWord -FilePath $path
+Close-OfficeWord -Document $doc

--- a/Examples/Word/ConvertFrom-HTMLtoWord.ps1
+++ b/Examples/Word/ConvertFrom-HTMLtoWord.ps1
@@ -1,0 +1,6 @@
+Clear-Host
+Import-Module .\PSWriteOffice.psd1 -Force
+
+$path = "$PSScriptRoot\HtmlDocument.docx"
+$html = '<h1>Hello</h1><p>Generated from HTML</p>'
+ConvertFrom-HTMLtoWord -OutputFile $path -SourceHTML $html

--- a/Examples/Word/Get-OfficeWord.ps1
+++ b/Examples/Word/Get-OfficeWord.ps1
@@ -1,0 +1,10 @@
+Clear-Host
+Import-Module .\PSWriteOffice.psd1 -Force
+
+$path = "$PSScriptRoot\ExistingDocument.docx"
+$doc = New-OfficeWord -FilePath $path
+Save-OfficeWord -Document $doc
+Close-OfficeWord -Document $doc
+
+$loaded = Get-OfficeWord -FilePath $path
+Close-OfficeWord -Document $loaded

--- a/Examples/Word/New-OfficeWord.ps1
+++ b/Examples/Word/New-OfficeWord.ps1
@@ -1,0 +1,7 @@
+Clear-Host
+Import-Module .\PSWriteOffice.psd1 -Force
+
+$path = "$PSScriptRoot\NewDocument.docx"
+$document = New-OfficeWord -FilePath $path
+Save-OfficeWord -Document $document
+Close-OfficeWord -Document $document

--- a/Examples/Word/New-OfficeWordList.ps1
+++ b/Examples/Word/New-OfficeWordList.ps1
@@ -1,0 +1,11 @@
+Clear-Host
+Import-Module .\PSWriteOffice.psd1 -Force
+
+$path = "$PSScriptRoot\ListDocument.docx"
+$doc = New-OfficeWord -FilePath $path
+$list = New-OfficeWordList -Document $doc {
+    New-OfficeWordListItem -Text 'Item1'
+    New-OfficeWordListItem -Text 'Item2' -Level 1
+}
+Save-OfficeWord -Document $doc
+Close-OfficeWord -Document $doc

--- a/Examples/Word/New-OfficeWordListItem.ps1
+++ b/Examples/Word/New-OfficeWordListItem.ps1
@@ -1,0 +1,9 @@
+Clear-Host
+Import-Module .\PSWriteOffice.psd1 -Force
+
+$path = "$PSScriptRoot\ListItemDocument.docx"
+$doc = New-OfficeWord -FilePath $path
+$list = New-OfficeWordList -Document $doc
+New-OfficeWordListItem -List $list -Text 'First item'
+Save-OfficeWord -Document $doc
+Close-OfficeWord -Document $doc

--- a/Examples/Word/New-OfficeWordTable.ps1
+++ b/Examples/Word/New-OfficeWordTable.ps1
@@ -1,0 +1,12 @@
+Clear-Host
+Import-Module .\PSWriteOffice.psd1 -Force
+
+$path = "$PSScriptRoot\TableDocument.docx"
+$doc = New-OfficeWord -FilePath $path
+$data = @(
+    [PSCustomObject]@{ Name = 'A'; Value = 1 },
+    [PSCustomObject]@{ Name = 'B'; Value = 2 }
+)
+New-OfficeWordTable -Document $doc -DataTable $data
+Save-OfficeWord -Document $doc
+Close-OfficeWord -Document $doc

--- a/Examples/Word/New-OfficeWordText.ps1
+++ b/Examples/Word/New-OfficeWordText.ps1
@@ -1,0 +1,8 @@
+Clear-Host
+Import-Module .\PSWriteOffice.psd1 -Force
+
+$path = "$PSScriptRoot\TextDocument.docx"
+$doc = New-OfficeWord -FilePath $path
+New-OfficeWordText -Document $doc -Text 'Hello from PSWriteOffice'
+Save-OfficeWord -Document $doc
+Close-OfficeWord -Document $doc

--- a/Examples/Word/Remove-OfficeWordFooter.ps1
+++ b/Examples/Word/Remove-OfficeWordFooter.ps1
@@ -1,0 +1,8 @@
+Clear-Host
+Import-Module .\PSWriteOffice.psd1 -Force
+
+$path = "$PSScriptRoot\RemoveFooter.docx"
+$doc = New-OfficeWord -FilePath $path
+Remove-OfficeWordFooter -Document $doc
+Save-OfficeWord -Document $doc
+Close-OfficeWord -Document $doc

--- a/Examples/Word/Remove-OfficeWordHeader.ps1
+++ b/Examples/Word/Remove-OfficeWordHeader.ps1
@@ -1,0 +1,8 @@
+Clear-Host
+Import-Module .\PSWriteOffice.psd1 -Force
+
+$path = "$PSScriptRoot\RemoveHeader.docx"
+$doc = New-OfficeWord -FilePath $path
+Remove-OfficeWordHeader -Document $doc
+Save-OfficeWord -Document $doc
+Close-OfficeWord -Document $doc

--- a/Examples/Word/Save-OfficeWord.ps1
+++ b/Examples/Word/Save-OfficeWord.ps1
@@ -1,0 +1,7 @@
+Clear-Host
+Import-Module .\PSWriteOffice.psd1 -Force
+
+$path = "$PSScriptRoot\SaveDocument.docx"
+$doc = New-OfficeWord -FilePath $path
+Save-OfficeWord -Document $doc
+Close-OfficeWord -Document $doc

--- a/Sources/PSWriteOffice/Cmdlets/Word/CloseOfficeWordCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/CloseOfficeWordCommand.cs
@@ -1,3 +1,14 @@
+/*
+.SYNOPSIS
+Closes a Word document.
+
+.DESCRIPTION
+Closes the specified Word document and releases associated resources.
+
+.EXAMPLE
+PS> .\Examples\Word\Close-OfficeWord.ps1
+Illustrates closing an open document.
+*/
 using System;
 using System.Management.Automation;
 using OfficeIMO.Word;

--- a/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromHTMLtoWordCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromHTMLtoWordCommand.cs
@@ -1,3 +1,14 @@
+/*
+.SYNOPSIS
+Converts HTML content into a Word document.
+
+.DESCRIPTION
+Creates a Word document from HTML content or an HTML file, with optional display after conversion.
+
+.EXAMPLE
+PS> .\Examples\Word\ConvertFrom-HTMLtoWord.ps1
+Converts an HTML snippet into a Word document.
+*/
 using System;
 using System.IO;
 using System.Management.Automation;

--- a/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordCommand.cs
@@ -1,3 +1,14 @@
+/*
+.SYNOPSIS
+Opens an existing Word document.
+
+.DESCRIPTION
+Loads a Word document from disk, optionally in read-only mode or with automatic saving.
+
+.EXAMPLE
+PS> .\Examples\Word\Get-OfficeWord.ps1
+Shows how to load a Word document from a file.
+*/
 using System;
 using System.IO;
 using System.Management.Automation;

--- a/Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordCommand.cs
@@ -1,3 +1,14 @@
+/*
+.SYNOPSIS
+Creates a new Word document.
+
+.DESCRIPTION
+Creates a new Word document at the specified file path. Optionally enables automatic saving when -AutoSave is used.
+
+.EXAMPLE
+PS> .\Examples\Word\New-OfficeWord.ps1
+Creates a new Word document and saves it to disk.
+*/
 using System;
 using System.Management.Automation;
 using PSWriteOffice.Services.Word;

--- a/Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordListCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordListCommand.cs
@@ -1,3 +1,14 @@
+/*
+.SYNOPSIS
+Adds a list to a Word document.
+
+.DESCRIPTION
+Creates a list in a Word document and optionally populates it with list items.
+
+.EXAMPLE
+PS> .\Examples\Word\New-OfficeWordList.ps1
+Illustrates creating a list with list items.
+*/
 using System;
 using System.Management.Automation;
 using OfficeIMO.Word;

--- a/Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordListItemCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordListItemCommand.cs
@@ -1,3 +1,14 @@
+/*
+.SYNOPSIS
+Creates a list item for a Word list.
+
+.DESCRIPTION
+Adds a list item to an existing list or returns data representing a list item.
+
+.EXAMPLE
+PS> .\Examples\Word\New-OfficeWordListItem.ps1
+Shows how to add an item to a list.
+*/
 using System;
 using System.Collections.Specialized;
 using System.Management.Automation;

--- a/Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordTableCommand.cs
@@ -1,3 +1,14 @@
+/*
+.SYNOPSIS
+Adds a table to a Word document.
+
+.DESCRIPTION
+Creates a table in a Word document from an array of objects with optional style and layout.
+
+.EXAMPLE
+PS> .\Examples\Word\New-OfficeWordTable.ps1
+Shows how to insert a table into a document.
+*/
 using System;
 using System.Management.Automation;
 using OfficeIMO.Word;

--- a/Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordTextCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordTextCommand.cs
@@ -1,3 +1,14 @@
+/*
+.SYNOPSIS
+Adds text to a Word document or paragraph.
+
+.DESCRIPTION
+Appends text to a Word document or paragraph with optional formatting and alignment.
+
+.EXAMPLE
+PS> .\Examples\Word\New-OfficeWordText.ps1
+Demonstrates adding formatted text to a document.
+*/
 using System;
 using System.Management.Automation;
 using DocumentFormat.OpenXml.Wordprocessing;

--- a/Sources/PSWriteOffice/Cmdlets/Word/RemoveOfficeWordFooterCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/RemoveOfficeWordFooterCommand.cs
@@ -1,3 +1,14 @@
+/*
+.SYNOPSIS
+Removes footers from a Word document.
+
+.DESCRIPTION
+Deletes all footers from the provided Word document.
+
+.EXAMPLE
+PS> .\Examples\Word\Remove-OfficeWordFooter.ps1
+Demonstrates removing footers from a document.
+*/
 using System;
 using System.Management.Automation;
 using OfficeIMO.Word;

--- a/Sources/PSWriteOffice/Cmdlets/Word/RemoveOfficeWordHeaderCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/RemoveOfficeWordHeaderCommand.cs
@@ -1,3 +1,14 @@
+/*
+.SYNOPSIS
+Removes headers from a Word document.
+
+.DESCRIPTION
+Deletes all headers from the provided Word document.
+
+.EXAMPLE
+PS> .\Examples\Word\Remove-OfficeWordHeader.ps1
+Demonstrates removing headers from a document.
+*/
 using System;
 using System.Management.Automation;
 using OfficeIMO.Word;

--- a/Sources/PSWriteOffice/Cmdlets/Word/SaveOfficeWordCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/SaveOfficeWordCommand.cs
@@ -1,3 +1,14 @@
+/*
+.SYNOPSIS
+Saves a Word document.
+
+.DESCRIPTION
+Saves the Word document to its current or a new file path and can optionally display the file.
+
+.EXAMPLE
+PS> .\Examples\Word\Save-OfficeWord.ps1
+Shows how to save a document to disk.
+*/
 using System;
 using System.Management.Automation;
 using OfficeIMO.Word;


### PR DESCRIPTION
## Summary
- document Word cmdlets with comment-based help referencing new examples
- add sample scripts under `Examples/Word` for each Word cmdlet

## Testing
- `dotnet build Sources/PSWriteOffice.sln`
- `pwsh -NoLogo -NoProfile -Command "Register-PSRepository -Default; Install-Module Pester -Force -Scope CurrentUser; Invoke-Pester -Path Tests"` *(failed: Install-Package: No match was found for the specified search criteria and module name 'Pester'.)*

------
https://chatgpt.com/codex/tasks/task_e_68963533870c832e8dd4d4ff0d501498