### PR TITLE
Enable WhatIf support for PowerPoint save

### DIFF
--- a/Examples/ExamplePowerPoint07-WhatIf.ps1
+++ b/Examples/ExamplePowerPoint07-WhatIf.ps1
@@ -1,0 +1,6 @@
+Clear-Host
+# Demonstrates using WhatIf when saving a presentation
+$path = "$PSScriptRoot\Documents\WhatIfExample.pptx"
+$presentation = New-OfficePowerPoint -FilePath $path
+Add-OfficePowerPointSlide -Presentation $presentation -Layout 1 | Out-Null
+Save-OfficePowerPoint -Presentation $presentation -WhatIf

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/SaveOfficePowerPointCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SaveOfficePowerPointCommand.cs
@@ -5,10 +5,11 @@ using PSWriteOffice.Services.PowerPoint;
 
 namespace PSWriteOffice.Cmdlets.PowerPoint;
 
-[Cmdlet(VerbsData.Save, "OfficePowerPoint")]
+[Cmdlet(VerbsData.Save, "OfficePowerPoint", SupportsShouldProcess = true)]
 public class SaveOfficePowerPointCommand : PSCmdlet
 {
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
+    [ValidateNotNull]
     public Presentation Presentation { get; set; } = null!;
 
     [Parameter]
@@ -24,7 +25,10 @@ public class SaveOfficePowerPointCommand : PSCmdlet
 
         try
         {
-            PowerPointDocumentService.SavePresentation(Presentation, Show.IsPresent);
+            if (ShouldProcess("PowerPoint presentation", "Save"))
+            {
+                PowerPointDocumentService.SavePresentation(Presentation, Show.IsPresent);
+            }
         }
         catch (Exception ex)
         {

--- a/Tests/PowerPointCmdlets.Tests.ps1
+++ b/Tests/PowerPointCmdlets.Tests.ps1
@@ -12,6 +12,13 @@ Describe 'PowerPoint cmdlets' {
         Test-Path $path | Should -BeTrue
     }
 
+    It 'supports WhatIf when saving presentation' {
+        $path = Join-Path $TestDrive 'whatif.pptx'
+        $pres = New-OfficePowerPoint -FilePath $path
+        Save-OfficePowerPoint -Presentation $pres -WhatIf
+        Test-Path $path | Should -BeFalse
+    }
+
     It 'adds slide to presentation' {
         $path = Join-Path $TestDrive 'addslide.pptx'
         $pres = New-OfficePowerPoint -FilePath $path


### PR DESCRIPTION
## Summary
- add ValidateNotNull to Presentation parameter and enable ShouldProcess for Save-OfficePowerPoint
- guard PowerPointDocumentService.SavePresentation with ShouldProcess
- cover Save-OfficePowerPoint -WhatIf in tests and add example

## Testing
- `dotnet build Sources/PSWriteOffice.sln`
- `pwsh -NoLogo -NoProfile -File PSWriteOffice.Tests.ps1` *(fails: The required module 'PSWriteColor' is not loaded; The term 'Invoke-Pester' is not recognized)*
- `pwsh -NoLogo -NoProfile -Command 'Import-Module ./PSWriteOffice.psm1; $path = Join-Path (Get-Location) "whatif_manual.pptx"; $pres = New-OfficePowerPoint -FilePath $path; Save-OfficePowerPoint -Presentation $pres -WhatIf; Test-Path $path'`


------
https://chatgpt.com/codex/tasks/task_e_6896353d4868832eb0e8be491345d346