### PR TITLE
Ensure Export-OfficeExcel includes all properties

### DIFF
--- a/Examples/ExportOfficeExcel/Example-AllProperties.ps1
+++ b/Examples/ExportOfficeExcel/Example-AllProperties.ps1
@@ -1,0 +1,9 @@
+Clear-Host
+Import-Module .\PSWriteOffice.psd1 -Force
+
+$path = Join-Path $PSScriptRoot 'AllProperties.xlsx'
+$data = @(
+    [PSCustomObject]@{ Name = 'Alice'; Age = 30 },
+    [PSCustomObject]@{ Name = 'Bob' }
+)
+$data | Export-OfficeExcel -FilePath $path -AllProperties -Show

--- a/Tests/ExportOfficeExcel.Tests.ps1
+++ b/Tests/ExportOfficeExcel.Tests.ps1
@@ -19,6 +19,20 @@ Describe 'Export-OfficeExcel cmdlet' {
         $rows[-1].Value | Should -Be 4
     }
 
+    It 'includes all properties when AllProperties is used' {
+        $path = Join-Path $TestDrive 'allprops.xlsx'
+        New-Item -Path $path -ItemType File | Out-Null
+        $data = @(
+            [PSCustomObject]@{ First = 1; Second = 'A' },
+            [PSCustomObject]@{ First = 2 }
+        )
+        $data | Export-OfficeExcel -FilePath $path -AllProperties
+        $rows = Import-OfficeExcel -FilePath $path
+        $rows[0].PSObject.Properties.Name | Should -Contain 'Second'
+        $rows[1].PSObject.Properties.Name | Should -Contain 'Second'
+        $rows[1].Second | Should -BeNullOrEmpty
+    }
+
     It 'throws for invalid path' {
         $data = 1..3 | ForEach-Object { [PSCustomObject]@{ Value = $_ } }
         { $data | Export-OfficeExcel -FilePath (Join-Path $TestDrive 'missing.xlsx') } | Should -Throw


### PR DESCRIPTION
## Summary
- honor `AllProperties` switch in Export-OfficeExcel to include missing properties across all rows
- add example demonstrating `AllProperties` usage
- cover `AllProperties` behavior with new Pester test

## Testing
- `dotnet build Sources/PSWriteOffice.sln`
- `pwsh -NoLogo -NoProfile -File ./PSWriteOffice.Tests.ps1` *(fails: required modules like PSSharedGoods/Pester unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68978718861c832eb6ae45a374f2ffce