### PR TITLE
Validate text array lengths in Word text cmdlet

### DIFF
--- a/Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordTextCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordTextCommand.cs
@@ -49,6 +49,24 @@ public class NewOfficeWordTextCommand : PSCmdlet
 
     protected override void ProcessRecord()
     {
+        var textLength = Text.Length;
+        if (Bold != null && Bold.Length != textLength)
+        {
+            throw new ArgumentException("Bold length must match Text length.", nameof(Bold));
+        }
+        if (Italic != null && Italic.Length != textLength)
+        {
+            throw new ArgumentException("Italic length must match Text length.", nameof(Italic));
+        }
+        if (Underline != null && Underline.Length != textLength)
+        {
+            throw new ArgumentException("Underline length must match Text length.", nameof(Underline));
+        }
+        if (Color != null && Color.Length != textLength)
+        {
+            throw new ArgumentException("Color length must match Text length.", nameof(Color));
+        }
+
         var paragraph = WordDocumentService.AddText(
             ParameterSetName == "Document" ? Document : null,
             ParameterSetName == "Paragraph" ? Paragraph : null,

--- a/Sources/PSWriteOffice/Services/Word/WordDocumentService.Text.cs
+++ b/Sources/PSWriteOffice/Services/Word/WordDocumentService.Text.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 
@@ -9,6 +10,23 @@ public static partial class WordDocumentService
         bool?[]? italic, UnderlineValues?[]? underline, string[]? color, JustificationValues? alignment,
         WordParagraphStyles? style)
     {
+        if (bold != null && bold.Length != text.Length)
+        {
+            throw new ArgumentException("bold length must match text length", nameof(bold));
+        }
+        if (italic != null && italic.Length != text.Length)
+        {
+            throw new ArgumentException("italic length must match text length", nameof(italic));
+        }
+        if (underline != null && underline.Length != text.Length)
+        {
+            throw new ArgumentException("underline length must match text length", nameof(underline));
+        }
+        if (color != null && color.Length != text.Length)
+        {
+            throw new ArgumentException("color length must match text length", nameof(color));
+        }
+
         var para = paragraph ?? document!.AddParagraph();
 
         for (var t = 0; t < text.Length; t++)

--- a/Tests/WordCmdlets.Tests.ps1
+++ b/Tests/WordCmdlets.Tests.ps1
@@ -21,6 +21,21 @@ Describe 'Word cmdlets' {
         Close-OfficeWord -Document $doc
     }
 
+    It 'throws when optional array length mismatches Text' {
+        $path = Join-Path $TestDrive 'mismatch.docx'
+        $doc = New-OfficeWord -FilePath $path
+        { New-OfficeWordText -Document $doc -Text @('one','two') -Bold @($true) } | Should -Throw
+        { New-OfficeWordText -Document $doc -Text @('one','two') -Color @('FF0000') } | Should -Throw
+        Close-OfficeWord -Document $doc
+    }
+
+    It 'throws in service when array length mismatches Text' {
+        $path = Join-Path $TestDrive 'mismatchService.docx'
+        $doc = New-OfficeWord -FilePath $path
+        { [PSWriteOffice.Services.Word.WordDocumentService]::AddText($doc, $null, @('a','b'), @($true), $null, $null, $null, $null, $null) } | Should -Throw
+        Close-OfficeWord -Document $doc
+    }
+
     It 'adds table' {
         $path = Join-Path $TestDrive 'table.docx'
         $doc = New-OfficeWord -FilePath $path


### PR DESCRIPTION
## Summary
- validate optional text property arrays in `New-OfficeWordText` before calling service
- add length checks to `WordDocumentService.AddText`
- add negative tests for mismatched text array lengths

## Testing
- `dotnet build Sources/PSWriteOffice/PSWriteOffice.csproj -c Release`
- `pwsh -NoLogo -File PSWriteOffice.Tests.ps1` *(fails: required modules PSSharedGoods, Pester, PSParseHTML not available)*

------
https://chatgpt.com/codex/tasks/task_e_689786f46124832eaba37bbf9e7a5499