### PR TITLE
Add range and header options for Excel import

### DIFF
--- a/Examples/Excel/Import/Example-ImportHeaderOptions.ps1
+++ b/Examples/Excel/Import/Example-ImportHeaderOptions.ps1
@@ -1,0 +1,27 @@
+Import-Module ../../PSWriteOffice.psd1 -Force
+
+$pathHeader = "$PSScriptRoot/Header.xlsx"
+$workbook = New-OfficeExcel
+$sheet = New-OfficeExcelWorkSheet -Workbook $workbook -WorksheetName 'Data' -Option Replace
+New-OfficeExcelValue -Worksheet $sheet -Row 1 -Column 1 -Value 'Skip'
+New-OfficeExcelValue -Worksheet $sheet -Row 1 -Column 2 -Value 'Skip'
+New-OfficeExcelValue -Worksheet $sheet -Row 2 -Column 1 -Value 'FirstName'
+New-OfficeExcelValue -Worksheet $sheet -Row 2 -Column 2 -Value 'Age'
+New-OfficeExcelValue -Worksheet $sheet -Row 3 -Column 1 -Value 'John'
+New-OfficeExcelValue -Worksheet $sheet -Row 3 -Column 2 -Value 30
+Save-OfficeExcel -Workbook $workbook -FilePath $pathHeader
+
+$rowsWithHeader = Import-OfficeExcel -FilePath $pathHeader -StartRow 2 -EndRow 3 -HeaderRow 2
+$rowsWithHeader | Format-Table
+
+$pathNoHeader = "$PSScriptRoot/NoHeader.xlsx"
+$workbookNoHeader = New-OfficeExcel
+$sheetNoHeader = New-OfficeExcelWorkSheet -Workbook $workbookNoHeader -WorksheetName 'Data' -Option Replace
+New-OfficeExcelValue -Worksheet $sheetNoHeader -Row 1 -Column 1 -Value 'John'
+New-OfficeExcelValue -Worksheet $sheetNoHeader -Row 1 -Column 2 -Value 30
+New-OfficeExcelValue -Worksheet $sheetNoHeader -Row 2 -Column 1 -Value 'Jane'
+New-OfficeExcelValue -Worksheet $sheetNoHeader -Row 2 -Column 2 -Value 25
+Save-OfficeExcel -Workbook $workbookNoHeader -FilePath $pathNoHeader
+
+$rowsNoHeader = Import-OfficeExcel -FilePath $pathNoHeader -NoHeader -StartRow 1 -EndRow 2 -StartColumn 1 -EndColumn 2
+$rowsNoHeader | Format-Table

--- a/Examples/Excel/Import/Example-ImportRange.ps1
+++ b/Examples/Excel/Import/Example-ImportRange.ps1
@@ -1,0 +1,17 @@
+Import-Module ../../PSWriteOffice.psd1 -Force
+
+$path = "$PSScriptRoot/Range.xlsx"
+$workbook = New-OfficeExcel
+$sheet = New-OfficeExcelWorkSheet -Workbook $workbook -WorksheetName 'Data' -Option Replace
+New-OfficeExcelValue -Worksheet $sheet -Row 1 -Column 1 -Value 'Name'
+New-OfficeExcelValue -Worksheet $sheet -Row 1 -Column 2 -Value 'Age'
+New-OfficeExcelValue -Worksheet $sheet -Row 2 -Column 1 -Value 'John'
+New-OfficeExcelValue -Worksheet $sheet -Row 2 -Column 2 -Value 30
+New-OfficeExcelValue -Worksheet $sheet -Row 3 -Column 1 -Value 'Jane'
+New-OfficeExcelValue -Worksheet $sheet -Row 3 -Column 2 -Value 25
+New-OfficeExcelValue -Worksheet $sheet -Row 4 -Column 1 -Value 'Bob'
+New-OfficeExcelValue -Worksheet $sheet -Row 4 -Column 2 -Value 40
+Save-OfficeExcel -Workbook $workbook -FilePath $path
+
+$rows = Import-OfficeExcel -FilePath $path -StartRow 2 -EndRow 3 -StartColumn 1 -EndColumn 2
+$rows | Format-Table

--- a/Sources/PSWriteOffice/Cmdlets/Excel/ImportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ImportOfficeExcelCommand.cs
@@ -24,11 +24,29 @@ public class ImportOfficeExcelCommand : PSCmdlet
     [Parameter]
     public CultureInfo? Culture { get; set; }
 
+    [Parameter]
+    public int? StartRow { get; set; }
+
+    [Parameter]
+    public int? EndRow { get; set; }
+
+    [Parameter]
+    public int? StartColumn { get; set; }
+
+    [Parameter]
+    public int? EndColumn { get; set; }
+
+    [Parameter]
+    public int? HeaderRow { get; set; }
+
+    [Parameter]
+    public SwitchParameter NoHeader { get; set; }
+
     protected override void ProcessRecord()
     {
         try
         {
-            var data = ExcelDocumentService.ImportWorkbook(FilePath, WorkSheetName, Culture);
+            var data = ExcelDocumentService.ImportWorkbook(FilePath, WorkSheetName, Culture, StartRow, EndRow, StartColumn, EndColumn, HeaderRow, NoHeader);
             if (WorkSheetName != null && WorkSheetName.Length == 1 && data.TryGetValue(WorkSheetName[0], out var single))
             {
                 WriteObject(single, true);

--- a/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.Workbook.Import.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.Workbook.Import.cs
@@ -8,9 +8,18 @@ namespace PSWriteOffice.Services.Excel;
 public static partial class ExcelDocumentService
 {
     public static IDictionary<string, IList<IDictionary<string, object?>>> ImportWorkbook(string filePath, IEnumerable<string>? worksheetNames = null)
-        => ImportWorkbook(filePath, worksheetNames, null);
+        => ImportWorkbook(filePath, worksheetNames, null, null, null, null, null, null, false);
 
-    public static IDictionary<string, IList<IDictionary<string, object?>>> ImportWorkbook(string filePath, IEnumerable<string>? worksheetNames, CultureInfo? culture)
+    public static IDictionary<string, IList<IDictionary<string, object?>>> ImportWorkbook(
+        string filePath,
+        IEnumerable<string>? worksheetNames,
+        CultureInfo? culture,
+        int? startRow,
+        int? endRow,
+        int? startColumn,
+        int? endColumn,
+        int? headerRow,
+        bool noHeader)
     {
         using var workbook = LoadWorkbook(filePath);
         var result = new Dictionary<string, IList<IDictionary<string, object?>>>();
@@ -22,7 +31,7 @@ public static partial class ExcelDocumentService
                 continue;
             }
 
-            var rows = GetWorksheetData(worksheet, culture).ToList();
+            var rows = GetWorksheetData(worksheet, startRow, endRow, startColumn, endColumn, headerRow, noHeader, culture).ToList();
             result[worksheet.Name] = rows;
         }
 

--- a/Tests/ImportOfficeExcel.Tests.ps1
+++ b/Tests/ImportOfficeExcel.Tests.ps1
@@ -28,6 +28,58 @@ Describe 'Import-OfficeExcel cmdlet' {
         $rows[0].Number | Should -Be 1.23
     }
 
+    It 'imports data within specified range' {
+        $path = Join-Path $TestDrive 'range.xlsx'
+        New-Item -Path $path -ItemType File | Out-Null
+        $workbook = New-OfficeExcel
+        $sheet1 = New-OfficeExcelWorkSheet -Workbook $workbook -WorksheetName 'Data' -Option Replace
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 1 -Column 1 -Value 'Name'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 1 -Column 2 -Value 'Age'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 2 -Column 1 -Value 'John'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 2 -Column 2 -Value 30
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 3 -Column 1 -Value 'Jane'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 3 -Column 2 -Value 25
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 4 -Column 1 -Value 'Bob'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 4 -Column 2 -Value 40
+        Save-OfficeExcel -Workbook $workbook -FilePath $path
+        $rows = Import-OfficeExcel -FilePath $path -StartRow 2 -EndRow 3 -StartColumn 1 -EndColumn 2
+        $rows.Count | Should -Be 2
+        $rows[0].Name | Should -Be 'John'
+        $rows[1].Name | Should -Be 'Jane'
+    }
+
+    It 'imports data using custom header row' {
+        $path = Join-Path $TestDrive 'headerrow.xlsx'
+        New-Item -Path $path -ItemType File | Out-Null
+        $workbook = New-OfficeExcel
+        $sheet1 = New-OfficeExcelWorkSheet -Workbook $workbook -WorksheetName 'Data' -Option Replace
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 1 -Column 1 -Value 'Skip'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 1 -Column 2 -Value 'Skip'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 2 -Column 1 -Value 'Name'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 2 -Column 2 -Value 'Age'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 3 -Column 1 -Value 'John'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 3 -Column 2 -Value 30
+        Save-OfficeExcel -Workbook $workbook -FilePath $path
+        $rows = Import-OfficeExcel -FilePath $path -StartRow 2 -EndRow 3 -HeaderRow 2
+        $rows[0].Name | Should -Be 'John'
+        $rows[0].Age | Should -Be 30
+    }
+
+    It 'imports data without header row' {
+        $path = Join-Path $TestDrive 'noheader.xlsx'
+        New-Item -Path $path -ItemType File | Out-Null
+        $workbook = New-OfficeExcel
+        $sheet1 = New-OfficeExcelWorkSheet -Workbook $workbook -WorksheetName 'Data' -Option Replace
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 1 -Column 1 -Value 'John'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 1 -Column 2 -Value 30
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 2 -Column 1 -Value 'Jane'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 2 -Column 2 -Value 25
+        Save-OfficeExcel -Workbook $workbook -FilePath $path
+        $rows = Import-OfficeExcel -FilePath $path -NoHeader -StartRow 1 -EndRow 2 -StartColumn 1 -EndColumn 2
+        $rows[0].Column1 | Should -Be 'John'
+        $rows[0].Column2 | Should -Be 30
+    }
+
     It 'throws for invalid path' {
         { Import-OfficeExcel -FilePath (Join-Path $TestDrive 'missing.xlsx') } | Should -Throw
     }


### PR DESCRIPTION
## Summary
- extend Import-OfficeExcel cmdlet with row/column range and header controls
- support range and header options in workbook and worksheet data services
- cover new import scenarios with Pester tests and examples

## Testing
- `dotnet build Sources/PSWriteOffice/PSWriteOffice.csproj`
- `pwsh -NoLogo -NoProfile -NonInteractive -File ./PSWriteOffice.Tests.ps1` *(fails: The required module 'PSSharedGoods' is not loaded; The term 'Invoke-Pester' is not recognized)*
- `pwsh -NoLogo -NoProfile -Command "Install-Module -Name Pester -Force -SkipPublisherCheck; Install-Module -Name PSSharedGoods -Force -SkipPublisherCheck"` *(fails: No match was found for the specified search criteria and module name 'Pester'; No match was found for 'PSSharedGoods')*


------
https://chatgpt.com/codex/tasks/task_e_6897921772a0832eaa53bdc38b93c00a