### PR TITLE
Add typed and DataTable import options for Excel

### DIFF
--- a/Examples/Excel/Import/Example-ImportDataTable.ps1
+++ b/Examples/Excel/Import/Example-ImportDataTable.ps1
@@ -1,0 +1,13 @@
+Import-Module ../../PSWriteOffice.psd1 -Force
+
+$path = "$PSScriptRoot/DataTable.xlsx"
+$workbook = New-OfficeExcel
+$sheet = New-OfficeExcelWorkSheet -Workbook $workbook -WorksheetName 'Data' -Option Replace
+New-OfficeExcelValue -Worksheet $sheet -Row 1 -Column 1 -Value 'Name'
+New-OfficeExcelValue -Worksheet $sheet -Row 1 -Column 2 -Value 'Age'
+New-OfficeExcelValue -Worksheet $sheet -Row 2 -Column 1 -Value 'Jane'
+New-OfficeExcelValue -Worksheet $sheet -Row 2 -Column 2 -Value 31
+Save-OfficeExcel -Workbook $workbook -FilePath $path
+
+$table = Import-OfficeExcel -FilePath $path -AsDataTable
+$table | Format-Table

--- a/Examples/Excel/Import/Example-ImportTyped.ps1
+++ b/Examples/Excel/Import/Example-ImportTyped.ps1
@@ -1,0 +1,18 @@
+Import-Module ../../PSWriteOffice.psd1 -Force
+
+class Person {
+    [string]$Name
+    [int]$Age
+}
+
+$path = "$PSScriptRoot/Typed.xlsx"
+$workbook = New-OfficeExcel
+$sheet = New-OfficeExcelWorkSheet -Workbook $workbook -WorksheetName 'Data' -Option Replace
+New-OfficeExcelValue -Worksheet $sheet -Row 1 -Column 1 -Value 'Name'
+New-OfficeExcelValue -Worksheet $sheet -Row 1 -Column 2 -Value 'Age'
+New-OfficeExcelValue -Worksheet $sheet -Row 2 -Column 1 -Value 'John'
+New-OfficeExcelValue -Worksheet $sheet -Row 2 -Column 2 -Value 30
+Save-OfficeExcel -Workbook $workbook -FilePath $path
+
+$rows = Import-OfficeExcel -FilePath $path -Type ([Person])
+$rows | Format-Table

--- a/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.cs
@@ -1,5 +1,14 @@
+using System;
+using System.Collections.Generic;
+
 namespace PSWriteOffice.Services.Excel;
 
 public static partial class ExcelDocumentService
 {
+    public static object ConvertWorksheetData(IEnumerable<IDictionary<string, object?>> rows, Type? type, bool asDataTable)
+        => asDataTable
+            ? BuildDataTable(rows)
+            : type != null
+                ? MapRowsToType(rows, type)
+                : rows;
 }

--- a/Tests/ImportOfficeExcel.Tests.ps1
+++ b/Tests/ImportOfficeExcel.Tests.ps1
@@ -80,6 +80,43 @@ Describe 'Import-OfficeExcel cmdlet' {
         $rows[0].Column2 | Should -Be 30
     }
 
+    It 'imports data as specified type' {
+        class Person {
+            [string]$Name
+            [int]$Age
+        }
+
+        $path = Join-Path $TestDrive 'typed.xlsx'
+        New-Item -Path $path -ItemType File | Out-Null
+        $workbook = New-OfficeExcel
+        $sheet1 = New-OfficeExcelWorkSheet -Workbook $workbook -WorksheetName 'Data' -Option Replace
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 1 -Column 1 -Value 'Name'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 1 -Column 2 -Value 'Age'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 2 -Column 1 -Value 'John'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 2 -Column 2 -Value 30
+        Save-OfficeExcel -Workbook $workbook -FilePath $path
+        $rows = Import-OfficeExcel -FilePath $path -Type ([Person])
+        $rows[0].GetType().FullName | Should -Be ([Person]).FullName
+        $rows[0].Name | Should -Be 'John'
+        $rows[0].Age | Should -Be 30
+    }
+
+    It 'imports data as DataTable' {
+        $path = Join-Path $TestDrive 'datatable.xlsx'
+        New-Item -Path $path -ItemType File | Out-Null
+        $workbook = New-OfficeExcel
+        $sheet1 = New-OfficeExcelWorkSheet -Workbook $workbook -WorksheetName 'Data' -Option Replace
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 1 -Column 1 -Value 'Name'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 1 -Column 2 -Value 'Age'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 2 -Column 1 -Value 'Jane'
+        New-OfficeExcelValue -Worksheet $sheet1 -Row 2 -Column 2 -Value 31
+        Save-OfficeExcel -Workbook $workbook -FilePath $path
+        $table = Import-OfficeExcel -FilePath $path -AsDataTable
+        $table.GetType().FullName | Should -Be ([System.Data.DataTable]).FullName
+        $table.Rows.Count | Should -Be 1
+        $table.Rows[0].Name | Should -Be 'Jane'
+    }
+
     It 'throws for invalid path' {
         { Import-OfficeExcel -FilePath (Join-Path $TestDrive 'missing.xlsx') } | Should -Throw
     }


### PR DESCRIPTION
## Summary
- allow Import-OfficeExcel to output typed objects or DataTables via new `Type` parameter and `AsDataTable` switch
- add conversion helpers and public converter in `ExcelDocumentService`
- document and test typed and DataTable imports

## Testing
- `pwsh PSWriteOffice.Tests.ps1` *(fails: The required module 'PSSharedGoods' is not loaded)*

------
https://chatgpt.com/codex/tasks/task_e_68979afb505c832e99d185557d6bdc47