### PR TITLE
Fix invalid path Pester test for cross-platform compatibility

### DIFF
--- a/Tests/ExcelWorkbook.Tests.ps1
+++ b/Tests/ExcelWorkbook.Tests.ps1
@@ -12,7 +12,9 @@ Describe 'Excel workbook cmdlets' {
     It 'throws when saving to invalid path' {
         $workbook = New-OfficeExcel
         New-OfficeExcelWorkSheet -Workbook $workbook -WorksheetName 'Sheet1' | Out-Null
-        { Save-OfficeExcel -Workbook $workbook -FilePath 'C:\InvalidPath<>*|?"\missing.xlsx' -ErrorAction Stop } | Should -Throw
+        $invalidChar = [System.IO.Path]::GetInvalidFileNameChars() | Select-Object -First 1
+        $invalidPath = Join-Path $TestDrive "invalid$invalidChar.xlsx"
+        { Save-OfficeExcel -Workbook $workbook -FilePath $invalidPath -ErrorAction Stop } | Should -Throw
     }
 
     It 'throws when loading from invalid path' {


### PR DESCRIPTION
## Summary
- ensure invalid path test uses OS-agnostic invalid character so the cmdlet consistently throws on non-Windows

## Testing
- `pwsh -NoLogo -NoProfile -Command "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force; Register-PSRepository -Default -ErrorAction Stop; Set-PSRepository -Name PSGallery -InstallationPolicy Trusted; Install-Module Pester -Scope CurrentUser -Force; Invoke-Pester Tests/ExcelWorkbook.Tests.ps1"` *(failed: No match was found for the specified search criteria and module name 'Pester')*
- `pwsh -NoLogo -NoProfile -Command "./Build/Manage-PSWriteOffice.ps1"` *(failed: The term 'Invoke-ModuleBuild' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68985c6af664832e93e71d3422986a6a