### PR TITLE
Add formula, pivot, and chart support to Export-OfficeExcel

### DIFF
--- a/Examples/Excel/Export/Example-Chart.ps1
+++ b/Examples/Excel/Export/Example-Chart.ps1
@@ -1,0 +1,4 @@
+$data = 1..5 | ForEach-Object { [PSCustomObject]@{ Value = $_ } }
+$chart = @{ Title = 'Chart1'; Range = 'A1:B6' }
+$path = Join-Path $PSScriptRoot 'Chart.xlsx'
+$data | Export-OfficeExcel -FilePath $path -WorksheetName 'Data' -Charts $chart -Show

--- a/Examples/Excel/Export/Example-Formulas.ps1
+++ b/Examples/Excel/Export/Example-Formulas.ps1
@@ -1,0 +1,7 @@
+$data = @(
+    [PSCustomObject]@{ A = 1; B = 2 }
+    [PSCustomObject]@{ A = 3; B = 4 }
+)
+$formulas = @{ 'C2' = '=A2+B2'; 'C3' = '=A3+B3' }
+$path = Join-Path $PSScriptRoot 'Formulas.xlsx'
+$data | Export-OfficeExcel -FilePath $path -WorksheetName 'Data' -Formulas $formulas -Show

--- a/Examples/Excel/Export/Example-PivotTable.ps1
+++ b/Examples/Excel/Export/Example-PivotTable.ps1
@@ -1,0 +1,8 @@
+$data = @(
+    [PSCustomObject]@{ Category = 'A'; Value = 1 }
+    [PSCustomObject]@{ Category = 'A'; Value = 2 }
+    [PSCustomObject]@{ Category = 'B'; Value = 3 }
+)
+$pivot = @{ Name = 'Pivot1'; SourceRange = 'A1:B4'; TargetCell = 'D2'; RowFields = @('Category'); Values = @{ Value = 'Sum' } }
+$path = Join-Path $PSScriptRoot 'Pivot.xlsx'
+$data | Export-OfficeExcel -FilePath $path -WorksheetName 'Data' -PivotTables $pivot -Show

--- a/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.Chart.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.Chart.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using A = DocumentFormat.OpenXml.Drawing;
+using C = DocumentFormat.OpenXml.Drawing.Charts;
+
+namespace PSWriteOffice.Services.Excel;
+
+public static partial class ExcelDocumentService
+{
+    public static void AddChart(string filePath, string worksheetName, string chartTitle)
+    {
+        using var document = SpreadsheetDocument.Open(filePath, true);
+        var workbookPart = document.WorkbookPart;
+        if (workbookPart == null)
+        {
+            return;
+        }
+
+        var sheet = workbookPart.Workbook.Sheets?.Elements<Sheet>().FirstOrDefault(s => s.Name == worksheetName);
+        if (sheet == null)
+        {
+            return;
+        }
+
+        var worksheetPart = (WorksheetPart)workbookPart.GetPartById(sheet.Id!);
+        var drawingsPart = worksheetPart.DrawingsPart ?? worksheetPart.AddNewPart<DrawingsPart>();
+        if (!worksheetPart.Worksheet.Elements<Drawing>().Any())
+        {
+            worksheetPart.Worksheet.Append(new Drawing { Id = worksheetPart.GetIdOfPart(drawingsPart) });
+            worksheetPart.Worksheet.Save();
+        }
+
+        var chartPart = drawingsPart.AddNewPart<ChartPart>();
+        var chartSpace = new C.ChartSpace();
+        chartSpace.Append(new C.EditingLanguage { Val = "en-US" });
+        var chart = chartSpace.AppendChild(new C.Chart());
+
+        if (!string.IsNullOrEmpty(chartTitle))
+        {
+            var title = new C.Title
+            {
+                ChartText = new C.ChartText
+                {
+                    RichText = new C.RichText(new A.Paragraph(new A.Run(new A.Text(chartTitle))))
+                }
+            };
+            chart.AppendChild(title);
+        }
+
+        chart.AppendChild(new C.PlotArea(new C.Layout()));
+        chartPart.ChartSpace = chartSpace;
+        chartPart.ChartSpace.Save();
+    }
+}

--- a/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.Formula.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.Formula.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using ClosedXML.Excel;
+
+namespace PSWriteOffice.Services.Excel;
+
+public static partial class ExcelDocumentService
+{
+    public static void ApplyFormulas(IXLWorksheet worksheet, IDictionary<string, string> formulas)
+    {
+        foreach (var kvp in formulas)
+        {
+            worksheet.Cell(kvp.Key).FormulaA1 = kvp.Value;
+        }
+    }
+}

--- a/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.Pivot.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.Pivot.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using ClosedXML.Excel;
+
+namespace PSWriteOffice.Services.Excel;
+
+public static partial class ExcelDocumentService
+{
+    public static IXLPivotTable AddPivotTable(
+        IXLWorksheet worksheet,
+        string name,
+        string sourceRange,
+        string targetCell,
+        IEnumerable<string>? rowLabels,
+        IEnumerable<string>? columnLabels,
+        IDictionary<string, XLPivotSummary>? values)
+    {
+        var pivot = worksheet.PivotTables.Add(name, worksheet.Cell(targetCell), worksheet.Range(sourceRange));
+
+        if (rowLabels != null)
+        {
+            foreach (var label in rowLabels)
+            {
+                pivot.RowLabels.Add(label);
+            }
+        }
+
+        if (columnLabels != null)
+        {
+            foreach (var label in columnLabels)
+            {
+                pivot.ColumnLabels.Add(label);
+            }
+        }
+
+        if (values != null)
+        {
+            foreach (var kvp in values)
+            {
+                pivot.Values.Add(kvp.Key).SetSummaryFormula(kvp.Value);
+            }
+        }
+
+        return pivot;
+    }
+}


### PR DESCRIPTION
## Summary
- enable formula injection via `ApplyFormulas` and new `-Formulas` parameter
- add pivot table creation with `AddPivotTable` and `-PivotTables` parameter
- introduce basic chart support and `-Charts` parameter plus example scripts

## Testing
- `dotnet build Sources/PSWriteOffice/PSWriteOffice.csproj`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester Tests/ExportOfficeExcel.Tests.ps1"` *(fails: The term 'Invoke-Pester' is not recognized)*
- `pwsh -NoLogo -NoProfile -Command "Register-PSRepository -Default; Install-Module Pester -Force -Scope CurrentUser"` *(fails: No match was found for 'Pester')*

------
https://chatgpt.com/codex/tasks/task_e_6898c3cb8c10832ea76efedb76e989f5