### PR TITLE
fix(ci): use hosted pwsh on Linux and macOS

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -165,13 +165,6 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Install PowerShell
-        run: |
-          curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-          curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft.list
-          sudo apt-get update
-          sudo apt-get install -y powershell
-
       - name: Install PowerShell modules
         shell: pwsh
         run: |
@@ -206,9 +199,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
-
-      - name: Install PowerShell
-        run: brew install --cask powershell
 
       - name: Install PowerShell modules
         shell: pwsh


### PR DESCRIPTION
## Summary
- remove manual PowerShell installation from the Ubuntu and macOS jobs
- rely on the GitHub-hosted runner pwsh that the workflow already uses for module and test steps
- keep the change scoped to the cross-platform PowerShell workflow only

## Why
The current main workflow is failing on macOS with `key not found: "homebrew/core/powershell"`. These install steps are stale and block the actual module tests from running.

## Testing
- git diff --check
- observed main workflow failure in run 23096990477 on the macOS install step
