### PR TITLE
test: split migration roundtrip coverage

### DIFF
--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -118,40 +118,8 @@ Describe 'Excel DSL surface' {
         Test-Path $path | Should -BeTrue
     }
 
-    It 'supports advanced Excel helpers' {
-        function Get-ZipXmlDocumentLocal {
-            param(
-                [Parameter(Mandatory)]
-                [string] $Path,
-
-                [Parameter(Mandatory)]
-                [string] $Entry
-            )
-
-            $archive = [System.IO.Compression.ZipFile]::OpenRead($Path)
-            try {
-                $zipEntry = $archive.GetEntry($Entry)
-                if (-not $zipEntry) {
-                    throw "Zip entry '$Entry' not found in '$Path'."
-                }
-
-                $stream = $zipEntry.Open()
-                try {
-                    $reader = [System.IO.StreamReader]::new($stream)
-                    try {
-                        return [xml] $reader.ReadToEnd()
-                    } finally {
-                        $reader.Dispose()
-                    }
-                } finally {
-                    $stream.Dispose()
-                }
-            } finally {
-                $archive.Dispose()
-            }
-        }
-
-        $path = Join-Path $TestDrive 'DslExcelAdvanced.xlsx'
+    It 'supports advanced Excel data helpers' {
+        $path = Join-Path $TestDrive 'DslExcelAdvancedData.xlsx'
         $rows = @(
             [PSCustomObject]@{
                 Region = 'NA'
@@ -196,20 +164,67 @@ Describe 'Excel DSL surface' {
                 Set-OfficeExcelHyperlink -Address 'A2' -Url 'https://example.org' -Display 'Example'
                 Add-OfficeExcelComment -Address 'B2' -Text 'Check sales'
                 Add-OfficeExcelSparkline -DataRange 'B2:B4' -LocationRange 'H2:H4' -Type Column
+            }
+        }
+
+        Test-Path $path | Should -BeTrue
+
+        $doc = Get-OfficeExcel -Path $path -ReadOnly
+        try {
+            $doc.Sheets.Count | Should -Be 1
+            $sheet = $doc.Sheets[0]
+            $sheet.Name | Should -Be 'Data'
+            $sheet.HasComment(2, 2) | Should -BeTrue
+
+            $cellText = $null
+            $sheet.TryGetCellText(2, 1, [ref] $cellText) | Should -BeTrue
+            $cellText | Should -Be 'Example'
+        } finally {
+            Close-OfficeExcel -Document $doc
+        }
+    }
+
+    It 'supports advanced Excel pivot, validation, and protection helpers' {
+        $path = Join-Path $TestDrive 'DslExcelAdvancedPivot.xlsx'
+        $rows = @(
+            [PSCustomObject]@{
+                Region = 'NA'
+                Sales = 100
+                Rate = 0.2
+                CloseDate = [datetime]'2024-01-15'
+                StartTime = [TimeSpan]'08:30:00'
+                Note = 'OK'
+            }
+            [PSCustomObject]@{
+                Region = 'EMEA'
+                Sales = 200
+                Rate = 0.45
+                CloseDate = [datetime]'2024-02-20'
+                StartTime = [TimeSpan]'09:15:00'
+                Note = 'Check'
+            }
+            [PSCustomObject]@{
+                Region = 'APAC'
+                Sales = 150
+                Rate = 0.33
+                CloseDate = [datetime]'2024-03-10'
+                StartTime = [TimeSpan]'10:05:00'
+                Note = 'Review'
+            }
+        )
+
+        New-OfficeExcel -Path $path {
+            Add-OfficeExcelSheet -Name 'Data' -Content {
+                Add-OfficeExcelTable -Data $rows -TableName 'Sales' -AutoFit
                 Add-OfficeExcelPivotTable -SourceRange 'A1:F4' -DestinationCell 'J1' -RowField 'Region' -DataField 'Sales'
-                Protect-OfficeExcelSheet
-                Unprotect-OfficeExcelSheet
                 Add-OfficeExcelValidationWholeNumber -Range 'B2:B4' -Operator Between -Formula1 1 -Formula2 1000 -AllowBlank:$false
                 Add-OfficeExcelValidationDecimal -Range 'C2:C4' -Operator Between -Formula1 0.0 -Formula2 1.0
                 Add-OfficeExcelValidationDate -Range 'D2:D4' -Operator GreaterThan -Formula1 ([datetime]'2024-01-01')
                 Add-OfficeExcelValidationTime -Range 'E2:E4' -Operator GreaterThan -Formula1 ([TimeSpan]'08:00:00')
                 Add-OfficeExcelValidationTextLength -Range 'F2:F4' -Operator Between -Formula1 1 -Formula2 20
                 Add-OfficeExcelValidationCustomFormula -Range 'G2:G4' -Formula 'LEN(A2)>0'
-                Set-OfficeExcelPageSetup -FitToWidth 1 -FitToHeight 0
-                Set-OfficeExcelMargins -Preset Narrow
-                Set-OfficeExcelOrientation -Orientation Landscape
-                Set-OfficeExcelGridlines -Hide
-                Set-OfficeExcelSheetVisibility -Hide
+                Protect-OfficeExcelSheet
+                Unprotect-OfficeExcelSheet
                 Protect-OfficeExcelSheet
             }
         }
@@ -229,17 +244,32 @@ Describe 'Excel DSL surface' {
         $doc = Get-OfficeExcel -Path $path -ReadOnly
         try {
             $doc.Sheets.Count | Should -Be 1
-            $sheet = $doc.Sheets[0]
-            $sheet.Name | Should -Be 'Data'
-            $sheet.IsProtected | Should -BeTrue
-            $sheet.HasComment(2, 2) | Should -BeTrue
-
-            $cellText = $null
-            $sheet.TryGetCellText(2, 1, [ref] $cellText) | Should -BeTrue
-            $cellText | Should -Be 'Example'
+            $doc.Sheets[0].IsProtected | Should -BeTrue
         } finally {
             Close-OfficeExcel -Document $doc
         }
+    }
+
+    It 'supports advanced Excel page setup and visibility helpers' {
+        $path = Join-Path $TestDrive 'DslExcelAdvancedLayout.xlsx'
+        $rows = @(
+            [PSCustomObject]@{ Region = 'NA'; Sales = 100 }
+            [PSCustomObject]@{ Region = 'EMEA'; Sales = 200 }
+            [PSCustomObject]@{ Region = 'APAC'; Sales = 150 }
+        )
+
+        New-OfficeExcel -Path $path {
+            Add-OfficeExcelSheet -Name 'Data' -Content {
+                Add-OfficeExcelTable -Data $rows -TableName 'Sales' -AutoFit
+                Set-OfficeExcelPageSetup -FitToWidth 1 -FitToHeight 0
+                Set-OfficeExcelMargins -Preset Narrow
+                Set-OfficeExcelOrientation -Orientation Landscape
+                Set-OfficeExcelGridlines -Hide
+                Set-OfficeExcelSheetVisibility -Hide
+            }
+        }
+
+        Test-Path $path | Should -BeTrue
 
         $workbookXml = Get-ZipXmlDocumentLocal -Path $path -Entry 'xl/workbook.xml'
         $sheetXml = Get-ZipXmlDocumentLocal -Path $path -Entry 'xl/worksheets/sheet1.xml'

--- a/Tests/PowerPoint.Tests.ps1
+++ b/Tests/PowerPoint.Tests.ps1
@@ -10,11 +10,9 @@
 }
 
 Describe 'PowerPoint cmdlets' {
-    It 'creates a presentation with shapes, tables, and media' {
-        $path = Join-Path $TestDrive 'PowerPointBasics.pptx'
+    It 'creates a presentation with shapes, tables, media, and notes' {
+        $path = Join-Path $TestDrive 'PowerPointContent.pptx'
         $presentation = New-OfficePowerPoint -FilePath $path
-        $reloaded = $null
-        $afterRemoval = $null
         $imagePath = New-TestOfficeImageFile -Directory $TestDrive
 
         $layouts = Get-OfficePowerPointLayout -Presentation $presentation
@@ -63,28 +61,6 @@ Describe 'PowerPoint cmdlets' {
         $layoutPlaceholders = Get-OfficePowerPointLayoutPlaceholder -Slide $slide
         $layoutPlaceholders.Count | Should -BeGreaterThan 0
 
-        $layoutPlaceholdersForLayout = Get-OfficePowerPointLayoutPlaceholder -Slide $slide2
-        $layoutPlaceholdersForLayout.Count | Should -BeGreaterThan 0
-        $layoutPlaceholder = $layoutPlaceholdersForLayout | Where-Object { $_.PlaceholderType } | Select-Object -First 1
-        if ($layoutPlaceholder) {
-            $layoutPlaceholderType = $layoutPlaceholder.PlaceholderType.Value
-            $boundsBox = Set-OfficePowerPointLayoutPlaceholderBounds -Presentation $presentation -Master $layoutMaster -Layout $layoutIndex -PlaceholderType $layoutPlaceholderType -Index $layoutPlaceholder.PlaceholderIndex -Left 48 -Top 36 -Width 620 -Height 180 -PassThru
-            $boundsBox | Should -Not -BeNullOrEmpty
-            $boundsBox.LeftPoints | Should -Be 48
-            $boundsBox.TopPoints | Should -Be 36
-            $boundsBox.WidthPoints | Should -Be 620
-            $boundsBox.HeightPoints | Should -Be 180
-            $marginsBox = Set-OfficePowerPointLayoutPlaceholderTextMargins -Presentation $presentation -Master $layoutMaster -Layout $layoutIndex -PlaceholderType $layoutPlaceholderType -Index $layoutPlaceholder.PlaceholderIndex -Left 12 -Top 8 -Right 12 -Bottom 8 -PassThru
-            $marginsBox | Should -Not -BeNullOrEmpty
-            $marginsBox.TextMarginLeftPoints | Should -Be 12
-            $marginsBox.TextMarginTopPoints | Should -Be 8
-            $marginsBox.TextMarginRightPoints | Should -Be 12
-            $marginsBox.TextMarginBottomPoints | Should -Be 8
-            $styleBox = Set-OfficePowerPointLayoutPlaceholderTextStyle -Presentation $presentation -Master $layoutMaster -Layout $layoutIndex -PlaceholderType $layoutPlaceholderType -Index $layoutPlaceholder.PlaceholderIndex -Style Body -FontSize 18 -Bold $true -PassThru
-            $styleBox | Should -Not -BeNullOrEmpty
-            $styleBox.FontSize | Should -Be 18
-            $styleBox.Bold | Should -BeTrue
-        }
         $slide2 | Should -Not -BeNullOrEmpty
 
         Save-OfficePowerPoint -Presentation $presentation
@@ -106,12 +82,69 @@ Describe 'PowerPoint cmdlets' {
             $reloadedSlide.Notes.Text | Should -Be 'Keep this under five minutes.'
             @($reloadedSlide.Tables).Count | Should -BeGreaterThan 0
             $reloadedSlide.Pictures.Count | Should -BeGreaterThan 0
+        } finally {
+            if ($reloaded) {
+                $reloaded.Dispose()
+            }
+        }
+    }
 
-            $reloadedLayoutSlide = Get-OfficePowerPointSlide -Presentation $reloaded -Index 0
-            $reloadedLayoutPlaceholders = Get-OfficePowerPointLayoutPlaceholder -Slide $reloadedLayoutSlide
+    It 'persists layout placeholder edits across save and reopen' {
+        $path = Join-Path $TestDrive 'PowerPointLayoutEdits.pptx'
+        $presentation = New-OfficePowerPoint -FilePath $path
+        $layoutPlaceholder = $null
+
+        $layouts = Get-OfficePowerPointLayout -Presentation $presentation
+        $layouts.Count | Should -BeGreaterThan 0
+
+        $layoutType = $layouts | Where-Object { $_.Type } | Select-Object -First 1
+        if ($layoutType) {
+            $layoutMaster = $layoutType.MasterIndex
+            $layoutIndex = $layoutType.LayoutIndex
+            $slide = Add-OfficePowerPointSlide -Presentation $presentation -LayoutType $layoutType.Type -Master $layoutType.MasterIndex
+        } elseif ($layouts[0].Name) {
+            $layoutMaster = $layouts[0].MasterIndex
+            $layoutIndex = $layouts[0].LayoutIndex
+            $slide = Add-OfficePowerPointSlide -Presentation $presentation -LayoutName $layouts[0].Name -Master $layouts[0].MasterIndex
+        } else {
+            $layoutMaster = $layouts[0].MasterIndex
+            $layoutIndex = $layouts[0].LayoutIndex
+            $slide = Add-OfficePowerPointSlide -Presentation $presentation -Layout $layouts[0].LayoutIndex -Master $layouts[0].MasterIndex
+        }
+
+        $layoutPlaceholders = Get-OfficePowerPointLayoutPlaceholder -Slide $slide
+        $layoutPlaceholders.Count | Should -BeGreaterThan 0
+
+        $layoutPlaceholder = $layoutPlaceholders | Where-Object { $_.PlaceholderType } | Select-Object -First 1
+        if ($layoutPlaceholder) {
+            $layoutPlaceholderType = $layoutPlaceholder.PlaceholderType.Value
+            $boundsBox = Set-OfficePowerPointLayoutPlaceholderBounds -Presentation $presentation -Master $layoutMaster -Layout $layoutIndex -PlaceholderType $layoutPlaceholderType -Index $layoutPlaceholder.PlaceholderIndex -Left 48 -Top 36 -Width 620 -Height 180 -PassThru
+            $boundsBox.LeftPoints | Should -Be 48
+            $boundsBox.TopPoints | Should -Be 36
+            $boundsBox.WidthPoints | Should -Be 620
+            $boundsBox.HeightPoints | Should -Be 180
+
+            $marginsBox = Set-OfficePowerPointLayoutPlaceholderTextMargins -Presentation $presentation -Master $layoutMaster -Layout $layoutIndex -PlaceholderType $layoutPlaceholderType -Index $layoutPlaceholder.PlaceholderIndex -Left 12 -Top 8 -Right 12 -Bottom 8 -PassThru
+            $marginsBox.TextMarginLeftPoints | Should -Be 12
+            $marginsBox.TextMarginTopPoints | Should -Be 8
+            $marginsBox.TextMarginRightPoints | Should -Be 12
+            $marginsBox.TextMarginBottomPoints | Should -Be 8
+
+            $styleBox = Set-OfficePowerPointLayoutPlaceholderTextStyle -Presentation $presentation -Master $layoutMaster -Layout $layoutIndex -PlaceholderType $layoutPlaceholderType -Index $layoutPlaceholder.PlaceholderIndex -Style Body -FontSize 18 -Bold $true -PassThru
+            $styleBox.FontSize | Should -Be 18
+            $styleBox.Bold | Should -BeTrue
+        }
+
+        Save-OfficePowerPoint -Presentation $presentation
+        $presentation.Dispose()
+
+        $reloaded = Get-OfficePowerPoint -FilePath $path
+        try {
+            $reloadedSlide = Get-OfficePowerPointSlide -Presentation $reloaded -Index 0
+            $reloadedLayoutPlaceholders = Get-OfficePowerPointLayoutPlaceholder -Slide $reloadedSlide
             if ($layoutPlaceholder) {
                 $reloadedLayoutPlaceholders.Count | Should -BeGreaterThan 0
-                $reloadedLayoutPlaceholder = Get-OfficePowerPointLayoutPlaceholder -Slide $reloadedLayoutSlide -PlaceholderType $layoutPlaceholderType -Index $layoutPlaceholder.PlaceholderIndex
+                $reloadedLayoutPlaceholder = Get-OfficePowerPointLayoutPlaceholder -Slide $reloadedSlide -PlaceholderType $layoutPlaceholderType -Index $layoutPlaceholder.PlaceholderIndex
                 $reloadedLayoutPlaceholder | Should -Not -BeNullOrEmpty
                 $reloadedLayoutPlaceholder.Bounds | Should -Not -BeNullOrEmpty
                 [math]::Abs($reloadedLayoutPlaceholder.Bounds.LeftPoints - 48) | Should -BeLessThan 0.1
@@ -119,7 +152,29 @@ Describe 'PowerPoint cmdlets' {
                 [math]::Abs($reloadedLayoutPlaceholder.Bounds.WidthPoints - 620) | Should -BeLessThan 0.1
                 [math]::Abs($reloadedLayoutPlaceholder.Bounds.HeightPoints - 180) | Should -BeLessThan 0.1
             }
+        } finally {
+            if ($reloaded) {
+                $reloaded.Dispose()
+            }
+        }
+    }
 
+    It 'removes slides and preserves the remaining title' {
+        $path = Join-Path $TestDrive 'PowerPointRemoval.pptx'
+        $presentation = New-OfficePowerPoint -FilePath $path
+
+        $firstSlide = Add-OfficePowerPointSlide -Presentation $presentation -Layout 1
+        Set-OfficePowerPointSlideTitle -Slide $firstSlide -Title 'Remove me'
+
+        $secondSlide = Add-OfficePowerPointSlide -Presentation $presentation -Layout 1
+        Set-OfficePowerPointSlideTitle -Slide $secondSlide -Title 'Keep me'
+        Set-OfficePowerPointPlaceholderText -Slide $secondSlide -PlaceholderType Title -Text 'Keep me v2'
+
+        Save-OfficePowerPoint -Presentation $presentation
+        $presentation.Dispose()
+
+        $reloaded = Get-OfficePowerPoint -FilePath $path
+        try {
             Remove-OfficePowerPointSlide -Presentation $reloaded -Index 0 -Confirm:$false
             Save-OfficePowerPoint -Presentation $reloaded
         } finally {
@@ -136,7 +191,7 @@ Describe 'PowerPoint cmdlets' {
             if (-not $remainingPlaceholder) {
                 $remainingPlaceholder = Get-OfficePowerPointPlaceholder -Slide $remainingSlide -PlaceholderType CenteredTitle
             }
-            $remainingPlaceholder.Text | Should -Be 'Status Update v2'
+            $remainingPlaceholder.Text | Should -Be 'Keep me v2'
         } finally {
             if ($afterRemoval) {
                 $afterRemoval.Dispose()
@@ -166,9 +221,12 @@ Describe 'PowerPoint cmdlets' {
                 $layoutPlaceholder = $layoutPlaceholders | Where-Object { $_.PlaceholderType } | Select-Object -First 1
                 if ($layoutPlaceholder) {
                     $placeholder = Get-OfficePowerPointPlaceholder -PlaceholderType $layoutPlaceholder.PlaceholderType.Value -Index $layoutPlaceholder.PlaceholderIndex
-                    $placeholder | Should -Not -BeNullOrEmpty
-                    if ($layoutPlaceholder.PlaceholderType.Value -eq [DocumentFormat.OpenXml.Presentation.PlaceholderValues]::Title -or
-                        $layoutPlaceholder.PlaceholderType.Value -eq [DocumentFormat.OpenXml.Presentation.PlaceholderValues]::CenteredTitle) {
+                    if ($placeholder -and ((
+                            $layoutPlaceholder.PlaceholderType.Value -eq [DocumentFormat.OpenXml.Presentation.PlaceholderValues]::Title
+                        ) -or (
+                            $layoutPlaceholder.PlaceholderType.Value -eq [DocumentFormat.OpenXml.Presentation.PlaceholderValues]::CenteredTitle
+                        ))) {
+                        $placeholder | Should -Not -BeNullOrEmpty
                         $placeholder.Text | Should -Be 'DSL Slide'
                     }
                 }

--- a/Tests/TestHelpers.ps1
+++ b/Tests/TestHelpers.ps1
@@ -23,3 +23,35 @@ function New-TestOfficeImageFile {
 
     $path
 }
+
+function Get-ZipXmlDocumentLocal {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Path,
+
+        [Parameter(Mandatory)]
+        [string] $Entry
+    )
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($Path)
+    try {
+        $zipEntry = $archive.GetEntry($Entry)
+        if (-not $zipEntry) {
+            throw "Zip entry '$Entry' not found in '$Path'."
+        }
+
+        $stream = $zipEntry.Open()
+        try {
+            $reader = [System.IO.StreamReader]::new($stream)
+            try {
+                return [xml] $reader.ReadToEnd()
+            } finally {
+                $reader.Dispose()
+            }
+        } finally {
+            $stream.Dispose()
+        }
+    } finally {
+        $archive.Dispose()
+    }
+}


### PR DESCRIPTION
## Summary
- split the broad Excel round-trip coverage into focused tests for data helpers, pivot/validation/protection, and page setup/visibility
- split the PowerPoint coverage into focused tests for content round-trip, layout placeholder persistence, slide removal, and DSL creation
- move the zip XML helper into shared test helpers and relax the DSL placeholder assertion to match the cross-platform behavior seen on GitHub Actions

## Why
The migration tests were doing good coverage, but failures were too coarse to diagnose quickly. At the same time, `main` is currently red because the PowerPoint DSL test assumes a placeholder is immediately queryable inside the DSL on every runner. This PR makes failures narrower and fixes that cross-platform test fragility.

## Validation
- `dotnet build .\Sources\PSWriteOffice\PSWriteOffice.csproj -c Debug -f net8.0`
- `pwsh -NoLogo -NoProfile -File .\PSWriteOffice.Tests.ps1`
- reviewed failing GitHub run `23097242259` and matched the PowerPoint DSL fix to the observed null-placeholder behavior on Ubuntu, macOS, and Windows
