### PR TITLE
Add issue release docs and examples

### DIFF
--- a/Examples/Word/Example-WordCharts.ps1
+++ b/Examples/Word/Example-WordCharts.ps1
@@ -1,0 +1,27 @@
+Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
+
+$documents = Join-Path $PSScriptRoot '..\Documents'
+New-Item -Path $documents -ItemType Directory -Force | Out-Null
+
+$docPath = Join-Path $documents 'Word-Charts.docx'
+$doc = New-OfficeWord -Path $docPath
+
+try {
+    $doc.AddParagraph('Word charts are currently available through the underlying OfficeIMO document object.') | Out-Null
+    $doc.AddParagraph('Older samples that used PieChart() should now use AddChart().AddPie().') | Out-Null
+
+    $chart = $doc.AddChart('Regional Revenue Mix')
+    $chart.AddPie('North America', 125000).
+        AddPie('EMEA', 98000).
+        AddPie('APAC', 143000) | Out-Null
+    $chart.SetWidthToPageContent(0.70, 320) | Out-Null
+
+    Close-OfficeWord -Document $doc -Save
+    $doc = $null
+} finally {
+    if ($null -ne $doc) {
+        $doc.Dispose()
+    }
+}
+
+Write-Host "Document saved to $docPath"

--- a/Examples/Word/Example-WordLineBreaks.ps1
+++ b/Examples/Word/Example-WordLineBreaks.ps1
@@ -1,0 +1,22 @@
+Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
+
+$documents = Join-Path $PSScriptRoot '..\Documents'
+New-Item -Path $documents -ItemType Directory -Force | Out-Null
+
+$path = Join-Path $documents 'Example-WordLineBreaks.docx'
+$document = New-OfficeWord -Path $path
+
+# AddBreak() creates a same-paragraph line break similar to Shift+Enter in Word.
+$paragraph = $document.AddParagraph('Line 1 in the same paragraph')
+$null = $paragraph.AddBreak()
+$null = $paragraph.AddText('Line 2 after AddBreak()')
+$null = $paragraph.AddBreak()
+$null = $paragraph.AddText('Line 3 still in the same paragraph')
+
+# AddParagraph() creates a new paragraph, so an empty paragraph gives a visible blank line.
+$null = $document.AddParagraph()
+$null = $document.AddParagraph('This text comes after an empty paragraph break.')
+
+Save-OfficeWord -Document $document
+
+Write-Host "Document saved to $path"

--- a/Examples/Word/Example-WordLineBreaks.ps1
+++ b/Examples/Word/Example-WordLineBreaks.ps1
@@ -17,6 +17,6 @@ $null = $paragraph.AddText('Line 3 still in the same paragraph')
 $null = $document.AddParagraph()
 $null = $document.AddParagraph('This text comes after an empty paragraph break.')
 
-Save-OfficeWord -Document $document
+Close-OfficeWord -Document $document -Save
 
 Write-Host "Document saved to $path"

--- a/Examples/Word/Example-WordTableCalculatedColumns.ps1
+++ b/Examples/Word/Example-WordTableCalculatedColumns.ps1
@@ -1,0 +1,49 @@
+Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
+
+$documents = Join-Path $PSScriptRoot '..\Documents'
+New-Item -Path $documents -ItemType Directory -Force | Out-Null
+
+$services = @(
+    [PSCustomObject]@{
+        Name        = 'Directory API'
+        Status      = 'Healthy'
+        Owner       = 'Team Identity'
+        LastPatch   = [datetime]'2026-03-28'
+        NodeCount   = 4
+    }
+    [PSCustomObject]@{
+        Name        = 'Billing API'
+        Status      = 'Review'
+        Owner       = 'Team Finance'
+        LastPatch   = [datetime]'2026-03-14'
+        NodeCount   = 2
+    }
+)
+
+$tableData = $services | Select-Object Name, Status,
+@{
+    Name = 'Owner'
+    Expression = { $_.Owner }
+},
+@{
+    Name = 'LastPatch'
+    Expression = { $_.LastPatch.ToString('yyyy-MM-dd') }
+},
+@{
+    Name = 'NeedsAttention'
+    Expression = { if ($_.Status -eq 'Healthy') { 'No' } else { 'Yes' } }
+},
+@{
+    Name = 'ClusterSize'
+    Expression = { "$($_.NodeCount) nodes" }
+}
+
+$docPath = Join-Path $documents 'Word-CalculatedColumns.docx'
+
+New-OfficeWord -Path $docPath {
+    Add-OfficeWordParagraph -Text 'Calculated and projected columns'
+    Add-OfficeWordParagraph -Text 'Shape your objects before Add-OfficeWordTable when you want extra columns or friendlier labels.'
+    Add-OfficeWordTable -InputObject $tableData -Style 'GridTable1LightAccent1'
+} | Out-Null
+
+Write-Host "Document saved to $docPath"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2011-2026 Przemyslaw Klys, Evotec
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -27,6 +27,8 @@ If you want conversion and bridge workflows:
 - Word to Markdown: [Docs/ConvertTo-OfficeWordMarkdown.md](Docs/ConvertTo-OfficeWordMarkdown.md)
 - Markdown to Word: [Docs/ConvertFrom-OfficeWordMarkdown.md](Docs/ConvertFrom-OfficeWordMarkdown.md)
 - Word text replacement: [Docs/Update-OfficeWordText.md](Docs/Update-OfficeWordText.md)
+- Word chart example: [Examples/Word/Example-WordCharts.ps1](Examples/Word/Example-WordCharts.ps1)
+- Word table projection example: [Examples/Word/Example-WordTableCalculatedColumns.ps1](Examples/Word/Example-WordTableCalculatedColumns.ps1)
 - Excel navigation sheet: [Docs/Add-OfficeExcelTableOfContents.md](Docs/Add-OfficeExcelTableOfContents.md)
 - Excel chart finishing: [Docs/Set-OfficeExcelChartLegend.md](Docs/Set-OfficeExcelChartLegend.md), [Docs/Set-OfficeExcelChartDataLabels.md](Docs/Set-OfficeExcelChartDataLabels.md), [Docs/Set-OfficeExcelChartStyle.md](Docs/Set-OfficeExcelChartStyle.md)
 - Excel links and media: [Docs/Add-OfficeExcelImageFromUrl.md](Docs/Add-OfficeExcelImageFromUrl.md), [Docs/Set-OfficeExcelSmartHyperlink.md](Docs/Set-OfficeExcelSmartHyperlink.md), [Docs/Set-OfficeExcelHostHyperlink.md](Docs/Set-OfficeExcelHostHyperlink.md)
@@ -55,6 +57,9 @@ Word:
 - [Examples/Word/Example-WordBasic.ps1](Examples/Word/Example-WordBasic.ps1)
 - [Examples/Word/Example-WordAdvanced.ps1](Examples/Word/Example-WordAdvanced.ps1)
 - [Examples/Word/Example-WordReplaceText.ps1](Examples/Word/Example-WordReplaceText.ps1)
+- [Examples/Word/Example-WordCharts.ps1](Examples/Word/Example-WordCharts.ps1)
+- [Examples/Word/Example-WordLineBreaks.ps1](Examples/Word/Example-WordLineBreaks.ps1)
+- [Examples/Word/Example-WordTableCalculatedColumns.ps1](Examples/Word/Example-WordTableCalculatedColumns.ps1)
 - [Examples/Word/Example-WordMarkdownConvert.ps1](Examples/Word/Example-WordMarkdownConvert.ps1)
 
 Excel:

--- a/PSWriteOffice.psd1
+++ b/PSWriteOffice.psd1
@@ -13,7 +13,7 @@
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{
-            LicenseUri                 = 'https://github.com/EvotecIT/PSWriteOffice/blob/main/LICENSE'
+            LicenseUri                 = 'https://github.com/EvotecIT/PSWriteOffice/blob/master/License'
             ProjectUri                 = 'https://github.com/EvotecIT/PSWriteOffice'
             Tags                       = @('officeimo', 'word', 'excel', 'powerpoint', 'markdown', 'csv', 'docx', 'xlsx', 'pptx', 'openxml', 'windows', 'linux', 'macos')
             RequireLicenseAcceptance   = $false

--- a/PSWriteOffice.psd1
+++ b/PSWriteOffice.psd1
@@ -13,7 +13,7 @@
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{
-            LicenseUri                 = 'https://github.com/EvotecIT/PSWriteOffice/blob/master/License'
+            LicenseUri                 = 'https://github.com/EvotecIT/PSWriteOffice/blob/main/LICENSE'
             ProjectUri                 = 'https://github.com/EvotecIT/PSWriteOffice'
             Tags                       = @('officeimo', 'word', 'excel', 'powerpoint', 'markdown', 'csv', 'docx', 'xlsx', 'pptx', 'openxml', 'windows', 'linux', 'macos')
             RequireLicenseAcceptance   = $false

--- a/README.MD
+++ b/README.MD
@@ -180,6 +180,28 @@ Update-OfficeWordText -Document $doc -OldValue 'FY24' -NewValue 'FY25'
 Close-OfficeWord -Document $doc -Save
 ```
 
+### Word charts with the current API
+
+```powershell
+$doc = New-OfficeWord -Path .\Report.docx
+$chart = $doc.AddChart('Revenue Mix')
+$chart.AddPie('North America', 125000).
+    AddPie('EMEA', 98000).
+    AddPie('APAC', 143000) | Out-Null
+Close-OfficeWord -Document $doc -Save
+```
+
+### Word tables with extra columns
+
+```powershell
+$tableData = $data | Select-Object Region, Revenue,
+@{ Name = 'RevenueBand'; Expression = { if ($_.Revenue -gt 100000) { 'High' } else { 'Standard' } } }
+
+New-OfficeWord -Path .\Report.docx {
+    Add-OfficeWordTable -InputObject $tableData -Style 'GridTable1LightAccent1'
+}
+```
+
 ### PowerPoint inspection
 
 ```powershell
@@ -244,6 +266,9 @@ Recommended examples:
 
 - [Examples/Word/Example-WordBasic.ps1](Examples/Word/Example-WordBasic.ps1)
 - [Examples/Word/Example-WordReplaceText.ps1](Examples/Word/Example-WordReplaceText.ps1)
+- [Examples/Word/Example-WordCharts.ps1](Examples/Word/Example-WordCharts.ps1)
+- [Examples/Word/Example-WordLineBreaks.ps1](Examples/Word/Example-WordLineBreaks.ps1)
+- [Examples/Word/Example-WordTableCalculatedColumns.ps1](Examples/Word/Example-WordTableCalculatedColumns.ps1)
 - [Examples/Word/Example-WordMarkdownConvert.ps1](Examples/Word/Example-WordMarkdownConvert.ps1)
 - [Examples/Excel/Example-ExcelBasic.ps1](Examples/Excel/Example-ExcelBasic.ps1)
 - [Examples/Excel/Example-ExcelAdvanced.ps1](Examples/Excel/Example-ExcelAdvanced.ps1)

--- a/Roadmap/Invoke-IssueReleaseSmokeTests.ps1
+++ b/Roadmap/Invoke-IssueReleaseSmokeTests.ps1
@@ -1,0 +1,202 @@
+param(
+    [string] $ModuleRoot = (Split-Path -Parent $PSScriptRoot),
+    [switch] $SkipBuild,
+    [switch] $SkipPester,
+    [switch] $SkipExamples,
+    [switch] $FailOnMissingArtifacts
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Step {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Message
+    )
+
+    Write-Host "==> $Message" -ForegroundColor Cyan
+}
+
+function New-CheckResult {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Name,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Passed', 'Skipped', 'Failed')]
+        [string] $Status,
+
+        [string] $Details = ''
+    )
+
+    [PSCustomObject]@{
+        Name    = $Name
+        Status  = $Status
+        Details = $Details
+    }
+}
+
+function Invoke-ExampleCheck {
+    param(
+        [Parameter(Mandatory)]
+        [string] $ScriptPath,
+
+        [Parameter(Mandatory)]
+        [string[]] $Outputs,
+
+        [switch] $MissingIsFailure
+    )
+
+    if (-not (Test-Path -Path $ScriptPath)) {
+        if ($MissingIsFailure) {
+            return New-CheckResult -Name (Split-Path -Leaf $ScriptPath) -Status Failed -Details "Example not found: $ScriptPath"
+        }
+
+        return New-CheckResult -Name (Split-Path -Leaf $ScriptPath) -Status Skipped -Details "Example not found on this branch: $ScriptPath"
+    }
+
+    foreach ($output in $Outputs) {
+        if (Test-Path -Path $output) {
+            Remove-Item -LiteralPath $output -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    try {
+        & $ScriptPath | Out-Null
+
+        $missingOutputs = foreach ($output in $Outputs) {
+            if (-not (Test-Path -Path $output)) {
+                $output
+            }
+        }
+
+        if ($missingOutputs) {
+            return New-CheckResult -Name (Split-Path -Leaf $ScriptPath) -Status Failed -Details ("Missing outputs: " + ($missingOutputs -join ', '))
+        }
+
+        return New-CheckResult -Name (Split-Path -Leaf $ScriptPath) -Status Passed -Details 'Example executed and expected outputs were created.'
+    } catch {
+        return New-CheckResult -Name (Split-Path -Leaf $ScriptPath) -Status Failed -Details $_.Exception.Message
+    } finally {
+        foreach ($output in $Outputs) {
+            if (Test-Path -Path $output) {
+                Remove-Item -LiteralPath $output -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}
+
+$resolvedRoot = (Resolve-Path -Path $ModuleRoot).Path
+$manifestPath = Join-Path $resolvedRoot 'PSWriteOffice.psd1'
+if (-not (Test-Path -Path $manifestPath)) {
+    throw "Unable to find PSWriteOffice.psd1 in '$resolvedRoot'."
+}
+
+$releaseArtifactChecks = @(
+    'Sources/PSWriteOffice/Cmdlets/Word/UpdateOfficeWordTextCommand.cs'
+    'Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCellCommand.cs'
+    'Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordChartCommand.cs'
+)
+$missingReleaseArtifacts = @(
+    foreach ($artifact in $releaseArtifactChecks) {
+        $artifactPath = Join-Path $resolvedRoot $artifact
+        if (-not (Test-Path -Path $artifactPath)) {
+            $artifact
+        }
+    }
+)
+
+$results = [System.Collections.Generic.List[object]]::new()
+
+Push-Location $resolvedRoot
+try {
+    if (-not $SkipBuild) {
+        Write-Step 'Building PSWriteOffice solution'
+        try {
+            dotnet build 'Sources/PSWriteOffice.sln'
+            $results.Add((New-CheckResult -Name 'dotnet build Sources/PSWriteOffice.sln' -Status Passed))
+        } catch {
+            $results.Add((New-CheckResult -Name 'dotnet build Sources/PSWriteOffice.sln' -Status Failed -Details $_.Exception.Message))
+        }
+    } else {
+        $results.Add((New-CheckResult -Name 'dotnet build Sources/PSWriteOffice.sln' -Status Skipped -Details 'Skipped by caller.'))
+    }
+
+    if (-not $SkipPester) {
+        if ($missingReleaseArtifacts.Count -gt 0 -and -not $FailOnMissingArtifacts) {
+            $results.Add((New-CheckResult -Name 'Word release-candidate Pester tests' -Status Skipped -Details ("Run on the merged release branch. Missing artifacts: " + ($missingReleaseArtifacts -join ', '))))
+        } else {
+            Write-Step 'Running Word release-candidate Pester tests'
+            $testFiles = @(
+                'Tests/WordDsl.Tests.ps1',
+                'Tests/WordReader.Tests.ps1'
+            )
+
+            foreach ($testFile in $testFiles) {
+                if (-not (Test-Path -Path $testFile)) {
+                    $status = if ($FailOnMissingArtifacts) { 'Failed' } else { 'Skipped' }
+                    $details = if ($FailOnMissingArtifacts) { "Missing test file: $testFile" } else { "Missing test file on this branch: $testFile" }
+                    $results.Add((New-CheckResult -Name $testFile -Status $status -Details $details))
+                    continue
+                }
+
+                try {
+                    Invoke-Pester $testFile -Output Detailed | Out-Null
+                    $results.Add((New-CheckResult -Name $testFile -Status Passed))
+                } catch {
+                    $results.Add((New-CheckResult -Name $testFile -Status Failed -Details $_.Exception.Message))
+                }
+            }
+        }
+    } else {
+        $results.Add((New-CheckResult -Name 'Word Pester tests' -Status Skipped -Details 'Skipped by caller.'))
+    }
+
+    if (-not $SkipExamples) {
+        Write-Step 'Running release examples'
+        $exampleChecks = @(
+            @{
+                ScriptPath = Join-Path $resolvedRoot 'Examples/Word/Example-WordLineBreaks.ps1'
+                Outputs    = @((Join-Path $resolvedRoot 'Examples/Documents/Example-WordLineBreaks.docx'))
+            }
+            @{
+                ScriptPath = Join-Path $resolvedRoot 'Examples/Word/Example-WordCharts.ps1'
+                Outputs    = @((Join-Path $resolvedRoot 'Examples/Documents/Word-Charts.docx'))
+            }
+            @{
+                ScriptPath = Join-Path $resolvedRoot 'Examples/Word/Example-WordTableCalculatedColumns.ps1'
+                Outputs    = @((Join-Path $resolvedRoot 'Examples/Documents/Word-CalculatedColumns.docx'))
+            }
+            @{
+                ScriptPath = Join-Path $resolvedRoot 'Examples/Word/Example-WordTableCells.ps1'
+                Outputs    = @(
+                    (Join-Path $resolvedRoot 'Examples/Word/Example-WordTableCells.docx')
+                    (Join-Path $resolvedRoot 'Examples/Word/Example-WordTableCells.png')
+                )
+            }
+            @{
+                ScriptPath = Join-Path $resolvedRoot 'Examples/Word/Example-WordReplaceText.ps1'
+                Outputs    = @((Join-Path $resolvedRoot 'Examples/Word/Example-WordReplaceText.docx'))
+            }
+        )
+
+        foreach ($exampleCheck in $exampleChecks) {
+            $result = Invoke-ExampleCheck -ScriptPath $exampleCheck.ScriptPath -Outputs $exampleCheck.Outputs -MissingIsFailure:$FailOnMissingArtifacts
+            $results.Add($result)
+        }
+    } else {
+        $results.Add((New-CheckResult -Name 'Release examples' -Status Skipped -Details 'Skipped by caller.'))
+    }
+} finally {
+    Pop-Location
+}
+
+Write-Host ''
+Write-Host 'Release smoke test summary:' -ForegroundColor Yellow
+$results | Format-Table -AutoSize | Out-Host
+
+$failed = @($results | Where-Object Status -eq 'Failed')
+if ($failed.Count -gt 0) {
+    throw ("Release smoke checks failed: " + (($failed | ForEach-Object Name) -join ', '))
+}

--- a/Roadmap/Invoke-IssueReleaseSmokeTests.ps1
+++ b/Roadmap/Invoke-IssueReleaseSmokeTests.ps1
@@ -140,6 +140,8 @@ try {
     if (-not $SkipPester) {
         if ($missingReleaseArtifacts.Count -gt 0 -and -not $FailOnMissingArtifacts) {
             $results.Add((New-CheckResult -Name 'Word release-candidate Pester tests' -Status Skipped -Details ("Run on the merged release branch. Missing artifacts: " + ($missingReleaseArtifacts -join ', '))))
+        } elseif ($missingReleaseArtifacts.Count -gt 0) {
+            $results.Add((New-CheckResult -Name 'Release artifacts' -Status Failed -Details ("Missing required release artifacts: " + ($missingReleaseArtifacts -join ', '))))
         } else {
             Write-Step 'Running Word release-candidate Pester tests'
             $testFiles = @(

--- a/Roadmap/Invoke-IssueReleaseSmokeTests.ps1
+++ b/Roadmap/Invoke-IssueReleaseSmokeTests.ps1
@@ -37,6 +37,16 @@ function New-CheckResult {
     }
 }
 
+function Get-NativeCommandErrorMessage {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Command
+    )
+
+    $exitCode = if ($null -ne $global:LASTEXITCODE) { $global:LASTEXITCODE } else { -1 }
+    return "'$Command' exited with code $exitCode."
+}
+
 function Invoke-ExampleCheck {
     param(
         [Parameter(Mandatory)]
@@ -115,7 +125,11 @@ try {
         Write-Step 'Building PSWriteOffice solution'
         try {
             dotnet build 'Sources/PSWriteOffice.sln'
-            $results.Add((New-CheckResult -Name 'dotnet build Sources/PSWriteOffice.sln' -Status Passed))
+            if ($LASTEXITCODE -ne 0) {
+                $results.Add((New-CheckResult -Name 'dotnet build Sources/PSWriteOffice.sln' -Status Failed -Details (Get-NativeCommandErrorMessage -Command 'dotnet build Sources/PSWriteOffice.sln')))
+            } else {
+                $results.Add((New-CheckResult -Name 'dotnet build Sources/PSWriteOffice.sln' -Status Passed))
+            }
         } catch {
             $results.Add((New-CheckResult -Name 'dotnet build Sources/PSWriteOffice.sln' -Status Failed -Details $_.Exception.Message))
         }
@@ -142,8 +156,14 @@ try {
                 }
 
                 try {
-                    Invoke-Pester $testFile -Output Detailed | Out-Null
-                    $results.Add((New-CheckResult -Name $testFile -Status Passed))
+                    $pesterResult = Invoke-Pester $testFile -Output Detailed -PassThru
+                    if ($null -eq $pesterResult) {
+                        $results.Add((New-CheckResult -Name $testFile -Status Failed -Details 'Invoke-Pester returned no result object.'))
+                    } elseif ($pesterResult.FailedCount -gt 0) {
+                        $results.Add((New-CheckResult -Name $testFile -Status Failed -Details ("Failed tests: " + $pesterResult.FailedCount)))
+                    } else {
+                        $results.Add((New-CheckResult -Name $testFile -Status Passed))
+                    }
                 } catch {
                     $results.Add((New-CheckResult -Name $testFile -Status Failed -Details $_.Exception.Message))
                 }

--- a/Roadmap/Invoke-IssueReleaseSmokeTests.ps1
+++ b/Roadmap/Invoke-IssueReleaseSmokeTests.ps1
@@ -138,10 +138,11 @@ try {
     }
 
     if (-not $SkipPester) {
+        $missingArtifactDetails = "Missing required release artifacts: " + ($missingReleaseArtifacts -join ', ')
         if ($missingReleaseArtifacts.Count -gt 0 -and -not $FailOnMissingArtifacts) {
             $results.Add((New-CheckResult -Name 'Word release-candidate Pester tests' -Status Skipped -Details ("Run on the merged release branch. Missing artifacts: " + ($missingReleaseArtifacts -join ', '))))
         } elseif ($missingReleaseArtifacts.Count -gt 0) {
-            $results.Add((New-CheckResult -Name 'Release artifacts' -Status Failed -Details ("Missing required release artifacts: " + ($missingReleaseArtifacts -join ', '))))
+            $results.Add((New-CheckResult -Name 'Release artifacts' -Status Failed -Details $missingArtifactDetails))
         } else {
             Write-Step 'Running Word release-candidate Pester tests'
             $testFiles = @(

--- a/Roadmap/Issue-Close-Templates.md
+++ b/Roadmap/Issue-Close-Templates.md
@@ -1,0 +1,88 @@
+# PSWriteOffice Issue Close Templates
+
+These are release-safe response drafts for use only after the relevant version is published.
+
+## Rules
+
+- Confirm the release version first.
+- Link to the released module or release notes.
+- Do not say an issue is fixed if the change only exists in source or an unreleased branch.
+- Keep replies short and concrete.
+
+## Template: Docs / Example
+
+`This is included in the released PSWriteOffice <version>. We added an example covering this scenario here: <link>. Closing this out, but if you still hit a gap on the released build, please reopen with a minimal sample.`
+
+## Template: New Cmdlet / Wrapper
+
+`This is available in the released PSWriteOffice <version>. The supported command path is <cmdlet/example>. Closing this issue based on the released implementation.`
+
+## Template: OfficeIMO-dependent fix
+
+`This is included in the released PSWriteOffice <version>, which consumes the OfficeIMO build containing the related fix. The released path is <cmdlet/example>. Closing this out, but please reopen if you can still reproduce it on the published version.`
+
+## Issue-specific drafts
+
+### `#1` Search and Replace Text
+
+`This is available in the released PSWriteOffice <version> through Update-OfficeWordText (alias Replace-OfficeWordText). Closing this issue based on the released implementation.`
+
+### `#3` Add Chart/Picture into Word Table Cell
+
+`This is supported in the released PSWriteOffice <version>. You can author pictures, lists, and nested tables directly inside table cells, and charts can be anchored to a paragraph created inside a table cell. Closing this out based on the released implementation and examples.`
+
+### `#4` Add table to table cell
+
+`This is supported in the released PSWriteOffice <version>. Nested Word tables can now be created inside table cells from the PowerShell DSL.`
+
+### `#5` Add Line Breaks
+
+`This is covered in the released PSWriteOffice <version> examples. We added a line-break example showing both paragraph breaks and same-paragraph breaks.`
+
+### `#7` No Charts :(
+
+`This is supported in the released PSWriteOffice <version> through Add-OfficeWordChart / WordChart. Closing this issue based on the released chart cmdlet surface.`
+
+### `#8` -Transpose parameter
+
+`This is available in the released PSWriteOffice <version>. Add-OfficeWordTable now supports transpose output.`
+
+### `#10` Set font name
+
+`This behavior is addressed in the released build we ship with PSWriteOffice <version>. Closing this out based on the released font handling behavior.`
+
+### `#12` Underline spaces/tabs
+
+`This is addressed in the released PSWriteOffice <version>, which consumes the related OfficeIMO fix for underline/tab round-tripping. Closing this issue based on the released package combination.`
+
+### `#13` Header / Footer Support
+
+`This is supported in the released PSWriteOffice <version>. Header and footer cmdlets are now part of the module.`
+
+### `#14` Bulleted list within table cell
+
+`This is supported in the released PSWriteOffice <version>. Lists can now be authored inside Word table cells from the DSL.`
+
+### `#15` Null array error when exporting to word
+
+`We added regression coverage around this path and could not reproduce document corruption on the released PSWriteOffice <version>. Closing this based on the released behavior, but please reopen with a minimal reproducer if you still see it on the published build.`
+
+### `#18` Close-OfficeWord without object
+
+`This is improved in the released PSWriteOffice <version>. Close-OfficeWord now has better tracked cleanup ergonomics for the current document flow.`
+
+### `#19` PieChart method
+
+`This is covered in the released PSWriteOffice <version> by the current Add-OfficeWordChart / WordChart path and updated examples for pie charts.`
+
+### `#20` Add some extra columns!?
+
+`This is covered in the released PSWriteOffice <version> examples by projecting object properties and calculated columns before calling Add-OfficeWordTable.`
+
+### `#21` License
+
+`This is addressed in the released PSWriteOffice <version>. The repository now includes a LICENSE file and the module metadata points to it correctly.`
+
+### `#26` TableLayout AutoFit behavior
+
+`This is available in the released PSWriteOffice <version>. Add-OfficeWordTable now exposes the expanded layout options for Word table autofit behavior.`

--- a/Roadmap/Issue-Release-Backlog.md
+++ b/Roadmap/Issue-Release-Backlog.md
@@ -1,0 +1,168 @@
+# PSWriteOffice Issue Release Backlog
+
+This document maps the current open GitHub issues to the work needed in `PSWriteOffice` and `OfficeIMO`.
+
+Related documents:
+
+- `Roadmap/Issue-Release-Execution.md`
+- `Roadmap/Issue-Close-Templates.md`
+
+It is intentionally release-safe:
+
+- Do not close any GitHub issue until the first released version containing the fix is published.
+- In PRs and commits, use `Refs #<issue>` instead of `Fixes`, `Closes`, or `Resolves`.
+- Treat "docs/examples only" issues as closable only after the improved guidance is released.
+
+## Working branches and worktrees
+
+| Repo | Worktree | Branch | Purpose |
+| --- | --- | --- | --- |
+| `PSWriteOffice` | `C:\Support\GitHub\_wt\pswriteoffice-word-issue-surface` | `codex/pswriteoffice-word-issue-surface` | Functional cmdlet work for Word issue surface |
+| `PSWriteOffice` | `C:\Support\GitHub\_wt\pswriteoffice-word-table-cells` | `codex/pswriteoffice-word-table-cells` | Table-cell composition work for Word |
+| `PSWriteOffice` | `C:\Support\GitHub\_wt\pswriteoffice-word-charts` | `codex/pswriteoffice-word-charts` | First-class Word chart cmdlet surface |
+| `PSWriteOffice` | `C:\Support\GitHub\_wt\pswriteoffice-issue-docs` | `codex/pswriteoffice-issue-docs` | Issue docs, examples, release notes, repo hygiene |
+| `OfficeIMO` | `C:\Support\GitHub\_wt\officeimo-word-issue-validation` | `codex/officeimo-word-issue-validation` | Validation tests and upstream fixes only when proven necessary |
+| `OfficeIMO` | `C:\Support\GitHub\_wt\officeimo-word-underline-tabs` | `codex/officeimo-word-underline-tabs` | PR-sized upstream fix for underline + tab round-tripping |
+| `OfficeIMO` | `C:\Support\GitHub\_wt\officeimo-word-table-content-aggregates` | `codex/officeimo-word-table-content-aggregates` | PR-sized upstream fix for body table image/chart document aggregates |
+
+## Issue triage summary
+
+### Close after release if no further regressions are found
+
+- `#10` Set font name
+  Current `OfficeIMO` tests show `FontFamily` also drives HighAnsi/EastAsia/ComplexScript as expected.
+- `#13` Header / Footer Support
+  `PSWriteOffice` now has first-class header/footer cmdlets and docs.
+
+### Close after release once released docs/examples ship
+
+- `#5` Add Line Breaks
+  Modern example now exists for paragraph breaks and same-paragraph breaks.
+- `#19` PieChart method
+  Updated example exists, and a dedicated Word chart cmdlet now backs it up.
+- `#20` Add some extra columns!?
+  Example now shows object projection/property-driven table columns.
+- `#21` License
+  `LICENSE` file and manifest `LicenseUri` cleanup are in place on the docs branch.
+
+### Implemented and verify again at release cut
+
+- `#1` Search and Replace Text
+  `Update-OfficeWordText` / `Replace-OfficeWordText` now wrap `OfficeIMO.Word.WordDocument.FindAndReplace`.
+- `#3` Add Chart/Picture into Word Table Cell
+  Table-cell DSL now supports paragraphs, images, lists, and nested tables.
+  Charts can now be anchored to a paragraph created inside a table cell by using `Add-OfficeWordChart -Paragraph $cell.AddParagraph()`.
+  Reader note: a dedicated `OfficeIMO` branch now fixes the top-level `WordDocument.Images` / `WordDocument.Charts` aggregates for body table content.
+- `#4` Add table to table cell
+  Nested tables are now exposed from the PowerShell DSL.
+- `#7` No Charts :(
+  `Add-OfficeWordChart` / `WordChart` now provide a PowerShell-first chart path.
+- `#8` -Transpose parameter
+  `Add-OfficeWordTable` now has transpose support.
+- `#14` Bulleted list within table cell?
+  Lists inside table cells are now covered by the table-cell DSL.
+- `#18` Close-OfficeWord unable to close an open worddoc without a valid WordDoc object being passed.
+  Document tracking plus current/all cleanup ergonomics are implemented.
+- `#26` TableLayout AutoFit behavior, no AutoFitContent or AutoFitWindow?
+  Table layout modes now map cleanly to the upstream options.
+
+### Validate first in OfficeIMO, then close only after released package uptake
+
+- `#12` Underline spaces/tabs
+  Focused regression test exists and a PR-sized `OfficeIMO` fix is ready on its own worktree.
+- `#15` Null array error when exporting to word
+  `OfficeIMO` validation and PSWriteOffice-level regression coverage both suggest this is no longer an active corruption bug.
+  Keep it open until the released package includes that coverage and we do one final smoke test.
+
+## Planned delivery by branch
+
+### `codex/pswriteoffice-word-issue-surface`
+
+- `#1` Replace cmdlet
+- `#8` Transpose support
+- `#18` Close-OfficeWord ergonomics
+- `#26` Expanded table layout modes
+
+Implemented and verified on this branch:
+
+- `dotnet build Sources\PSWriteOffice.sln` passed
+- `Invoke-Pester Tests\WordDsl.Tests.ps1 -Output Detailed` passed with replacement, transpose, close-tracking, and null-row regression coverage
+
+### `codex/pswriteoffice-word-table-cells`
+
+- `#3` Images/charts in table cells
+- `#4` Nested tables
+- `#14` Lists in table cells
+- Supporting DSL/host plumbing as needed
+
+Implemented and verified on this branch:
+
+- `WordTableCell` cmdlet and cell-aware host plumbing
+- Paragraphs, lists, images, and nested tables inside cells
+- `Invoke-Pester Tests\WordDsl.Tests.ps1 -Output Detailed` passed with cell-composition coverage
+
+Still open on this branch:
+
+- Merge or consume the upstream aggregate fix if we want the document-level readers to include body table images/charts in the released package
+
+### `codex/pswriteoffice-issue-docs`
+
+- `#5` Line-break examples
+- `#7` Word chart examples/guidance
+- `#19` Pie-chart migration guidance
+- `#20` Extra-column table guidance
+- `#21` License file and manifest cleanup
+- Release notes issue matrix for post-release closure
+
+Implemented on this branch so far:
+
+- `#5` `Examples/Word/Example-WordLineBreaks.ps1`
+- `#19` `Examples/Word/Example-WordCharts.ps1`
+- `#20` `Examples/Word/Example-WordTableCalculatedColumns.ps1`
+- `#21` `LICENSE` and manifest `LicenseUri` cleanup
+- Release-safe issue matrix and close-order guidance
+
+### `codex/pswriteoffice-word-charts`
+
+- `#7` First-class `Add-OfficeWordChart` / `WordChart`
+- `#19` Chart migration path backed by a real cmdlet
+- `#3` Supported chart-in-cell path through `-Paragraph` anchored to a table-cell paragraph
+- `Invoke-Pester Tests\WordDsl.Tests.ps1 -Output Detailed` passed with direct, DSL, and table-cell chart coverage
+
+### `codex/officeimo-word-issue-validation`
+
+- `#12` Regression test coverage
+- `#15` Repro/validation coverage
+- Upstream fixes only if tests prove they are still broken
+
+Implemented on this branch so far:
+
+- `#12` targeted underline/tab regression coverage
+- `#15` null-entry table export validation coverage
+
+### `codex/officeimo-word-underline-tabs`
+
+- `#12` PR-sized upstream fix isolated to `WordParagraph` plus the focused test
+- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~OfficeIMO.Tests.Word.Test_UnderlinedTextWithTabs_UsesTabCharactersAndPreservesDocument"` passed
+
+### `codex/officeimo-word-table-content-aggregates`
+
+- Optional upstream polish for `#3` reader ergonomics
+- Makes `WordDocument.Images`, `WordDocument.Charts`, `ParagraphsImages`, and `ParagraphsCharts` include body table content after reload
+- Keeps header/footer aggregate behavior unchanged
+- `dotnet test OfficeIMO.Tests\OfficeIMO.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~OfficeIMO.Tests.Word.Test_CreatingWordDocumentWithImagesInTable|FullyQualifiedName~OfficeIMO.Tests.Word.Test_ChartsInTableCells_AppearInDocumentAggregatesAfterReload"` passed
+
+## Release gate for issue closure
+
+Only close an issue when all of the following are true:
+
+1. The code or documentation change is merged.
+2. The containing version is released publicly.
+3. The release notes mention the relevant behavior change.
+4. We can answer the original issue with a short, concrete example or command path.
+
+## Suggested post-release close order
+
+1. Close the clearly shipped issues first: `#10`, `#13`, docs-only items, and any finished cmdlet wrappers.
+2. Close `OfficeIMO`-dependent issues only after the released `PSWriteOffice` build consumes the validated upstream package.
+3. Keep any issue open if the fix exists only in source, example code, or unreleased package versions.

--- a/Roadmap/Issue-Release-Execution.md
+++ b/Roadmap/Issue-Release-Execution.md
@@ -1,0 +1,86 @@
+# PSWriteOffice Issue Release Execution
+
+This document turns the issue backlog into a practical release sequence.
+
+## Guardrails
+
+- Keep `PSWriteOffice` and `OfficeIMO` PRs separate.
+- Keep each PR scoped to its dedicated worktree branch.
+- Do not use `Fixes`, `Closes`, or `Resolves` in commits or PR descriptions.
+- Do not close any issue until the released package is publicly available.
+
+## Recommended PR order
+
+1. `OfficeIMO` `codex/officeimo-word-underline-tabs`
+   Scope: `#12`
+   Why first: it is a real upstream bugfix with focused coverage and no dependency on PSWriteOffice.
+2. `OfficeIMO` `codex/officeimo-word-table-content-aggregates`
+   Scope: reader ergonomics for `#3`
+   Why second: it is optional polish, but if we want the better document-level aggregates in the first release, PSWriteOffice needs to consume this package.
+3. `PSWriteOffice` `codex/pswriteoffice-word-issue-surface`
+   Scope: `#1`, `#8`, `#18`, `#26`, plus the PSWriteOffice-level `#15` regression.
+4. `PSWriteOffice` `codex/pswriteoffice-word-table-cells`
+   Scope: `#3`, `#4`, `#14`
+   Note: this branch is already strong on paragraphs, images, lists, and nested tables in cells.
+5. `PSWriteOffice` `codex/pswriteoffice-word-charts`
+   Scope: `#7`, `#19`, plus chart-in-cell guidance for `#3`
+   Note: if the table-cell and chart branches are merged independently, keep the final integration smoke test explicit because both touch Word authoring flows.
+6. `PSWriteOffice` `codex/pswriteoffice-issue-docs`
+   Scope: `#5`, `#20`, `#21`, release notes, issue matrix, and post-release close guidance.
+
+## Merge dependencies
+
+- `codex/officeimo-word-underline-tabs` is independent.
+- `codex/officeimo-word-table-content-aggregates` is independent from the underline fix.
+- `codex/pswriteoffice-word-issue-surface` is independent from the table-cell and chart branches.
+- `codex/pswriteoffice-word-table-cells` is independent from the chart cmdlet branch for pictures, lists, and nested tables.
+- `codex/pswriteoffice-word-charts` provides the supported chart path, including chart-in-cell through `-Paragraph`.
+- If we want the best reader experience for table-cell images/charts, consume the `OfficeIMO` aggregate-fix package before the PSWriteOffice release cut.
+
+## Release-candidate smoke tests
+
+Run these after merge and before publishing:
+
+1. `PSWriteOffice` Word DSL tests on the release branch.
+2. A manual example run for:
+   `Example-WordLineBreaks.ps1`
+   `Example-WordTableCells.ps1`
+   `Example-WordCharts.ps1`
+   `Example-WordTableCalculatedColumns.ps1`
+3. One end-to-end smoke test for:
+   replace text
+   transpose table output
+   close current/all document tracking
+   list/image/nested table in a cell
+   chart anchored to a paragraph inside a table cell
+4. If the OfficeIMO aggregate fix is included, verify `Get-OfficeWord` read-back sees body table images/charts through document-level collections.
+
+Practical runner:
+
+- `pwsh -File .\Roadmap\Invoke-IssueReleaseSmokeTests.ps1 -FailOnMissingArtifacts`
+
+## Release note checklist
+
+- Mention Word search/replace support.
+- Mention transpose support for Word tables.
+- Mention expanded Word table layout options.
+- Mention improved `Close-OfficeWord` cleanup behavior.
+- Mention table-cell authoring support for paragraphs, lists, images, nested tables, and chart anchoring.
+- Mention first-class Word chart cmdlet support.
+- Mention docs/examples for line breaks, calculated table columns, and chart migration.
+- Mention any consumed `OfficeIMO` fixes, especially underline tabs and body table aggregate readers.
+
+## Post-release close order
+
+1. Close `#10` and `#13`.
+2. Close docs/example issues: `#5`, `#19`, `#20`, `#21`.
+3. Close direct PSWriteOffice wrapper issues: `#1`, `#7`, `#8`, `#18`, `#26`.
+4. Close table-cell issues: `#3`, `#4`, `#14`.
+5. Close upstream-dependent issues only after confirming the released PSWriteOffice version consumes the right OfficeIMO package:
+   `#12`
+   `#15`
+
+## If we want to defer one thing
+
+The safest deferrable polish is `codex/officeimo-word-table-content-aggregates`.
+The feature paths for authoring already work, and this branch only improves document-level read-back ergonomics for body table images and charts.

--- a/WebsiteArtifacts/apidocs/powershell/command-metadata.json
+++ b/WebsiteArtifacts/apidocs/powershell/command-metadata.json
@@ -1,6 +1,6 @@
 {
   "moduleName": "PSWriteOffice",
-  "generatedAt": "2026-04-04T06:56:42.9675461+00:00",
+  "generatedAt": "2026-04-04T07:11:41.7672038+00:00",
   "commands": [
     {
       "name": "Add-OfficeExcelAutoFilter",
@@ -8,7 +8,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelAutoFilterCommand.cs",
       "sourceLine": 27,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelAutoFilterCommand.cs#L27"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelAutoFilterCommand.cs#L27"
     },
     {
       "name": "Add-OfficeExcelChart",
@@ -16,7 +16,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelChartCommand.cs",
       "sourceLine": 23,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelChartCommand.cs#L23"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelChartCommand.cs#L23"
     },
     {
       "name": "Add-OfficeExcelComment",
@@ -24,7 +24,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelCommentCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelCommentCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelCommentCommand.cs#L17"
     },
     {
       "name": "Add-OfficeExcelConditionalColorScale",
@@ -32,7 +32,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalColorScaleCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalColorScaleCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalColorScaleCommand.cs#L17"
     },
     {
       "name": "Add-OfficeExcelConditionalDataBar",
@@ -40,7 +40,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalDataBarCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalDataBarCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalDataBarCommand.cs#L17"
     },
     {
       "name": "Add-OfficeExcelConditionalIconSet",
@@ -48,7 +48,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalIconSetCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalIconSetCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalIconSetCommand.cs#L19"
     },
     {
       "name": "Add-OfficeExcelConditionalRule",
@@ -56,7 +56,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalRuleCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalRuleCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalRuleCommand.cs#L18"
     },
     {
       "name": "Add-OfficeExcelImage",
@@ -64,7 +64,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelImageCommand.cs",
       "sourceLine": 24,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelImageCommand.cs#L24"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelImageCommand.cs#L24"
     },
     {
       "name": "Add-OfficeExcelImageFromUrl",
@@ -72,7 +72,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelImageFromUrlCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelImageFromUrlCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelImageFromUrlCommand.cs#L18"
     },
     {
       "name": "Add-OfficeExcelPivotTable",
@@ -80,7 +80,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelPivotTableCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelPivotTableCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelPivotTableCommand.cs#L19"
     },
     {
       "name": "Add-OfficeExcelSheet",
@@ -88,7 +88,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelSheetCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelSheetCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelSheetCommand.cs#L17"
     },
     {
       "name": "Add-OfficeExcelSparkline",
@@ -96,7 +96,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelSparklineCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelSparklineCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelSparklineCommand.cs#L19"
     },
     {
       "name": "Add-OfficeExcelTable",
@@ -104,7 +104,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableCommand.cs#L21"
     },
     {
       "name": "Add-OfficeExcelTableOfContents",
@@ -112,7 +112,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableOfContentsCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableOfContentsCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableOfContentsCommand.cs#L19"
     },
     {
       "name": "Add-OfficeExcelValidationCustomFormula",
@@ -120,7 +120,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationCustomFormulaCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationCustomFormulaCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationCustomFormulaCommand.cs#L16"
     },
     {
       "name": "Add-OfficeExcelValidationDate",
@@ -128,7 +128,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationDateCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationDateCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationDateCommand.cs#L19"
     },
     {
       "name": "Add-OfficeExcelValidationDecimal",
@@ -136,7 +136,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationDecimalCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationDecimalCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationDecimalCommand.cs#L18"
     },
     {
       "name": "Add-OfficeExcelValidationList",
@@ -144,7 +144,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationListCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationListCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationListCommand.cs#L18"
     },
     {
       "name": "Add-OfficeExcelValidationTextLength",
@@ -152,7 +152,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationTextLengthCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationTextLengthCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationTextLengthCommand.cs#L18"
     },
     {
       "name": "Add-OfficeExcelValidationTime",
@@ -160,7 +160,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationTimeCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationTimeCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationTimeCommand.cs#L19"
     },
     {
       "name": "Add-OfficeExcelValidationWholeNumber",
@@ -168,7 +168,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationWholeNumberCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationWholeNumberCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationWholeNumberCommand.cs#L18"
     },
     {
       "name": "Add-OfficeMarkdownCallout",
@@ -176,7 +176,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownCalloutCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownCalloutCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownCalloutCommand.cs#L17"
     },
     {
       "name": "Add-OfficeMarkdownCode",
@@ -184,7 +184,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownCodeCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownCodeCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownCodeCommand.cs#L17"
     },
     {
       "name": "Add-OfficeMarkdownDefinitionList",
@@ -192,7 +192,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownDefinitionListCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownDefinitionListCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownDefinitionListCommand.cs#L19"
     },
     {
       "name": "Add-OfficeMarkdownDetails",
@@ -200,7 +200,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownDetailsCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownDetailsCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownDetailsCommand.cs#L17"
     },
     {
       "name": "Add-OfficeMarkdownFrontMatter",
@@ -208,7 +208,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownFrontMatterCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownFrontMatterCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownFrontMatterCommand.cs#L21"
     },
     {
       "name": "Add-OfficeMarkdownHeading",
@@ -216,7 +216,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownHeadingCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownHeadingCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownHeadingCommand.cs#L18"
     },
     {
       "name": "Add-OfficeMarkdownHorizontalRule",
@@ -224,7 +224,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownHorizontalRuleCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownHorizontalRuleCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownHorizontalRuleCommand.cs#L17"
     },
     {
       "name": "Add-OfficeMarkdownImage",
@@ -232,7 +232,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownImageCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownImageCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownImageCommand.cs#L17"
     },
     {
       "name": "Add-OfficeMarkdownList",
@@ -240,7 +240,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownListCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownListCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownListCommand.cs#L20"
     },
     {
       "name": "Add-OfficeMarkdownParagraph",
@@ -248,7 +248,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownParagraphCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownParagraphCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownParagraphCommand.cs#L17"
     },
     {
       "name": "Add-OfficeMarkdownQuote",
@@ -256,7 +256,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownQuoteCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownQuoteCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownQuoteCommand.cs#L17"
     },
     {
       "name": "Add-OfficeMarkdownTable",
@@ -264,7 +264,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableCommand.cs",
       "sourceLine": 28,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableCommand.cs#L28"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableCommand.cs#L28"
     },
     {
       "name": "Add-OfficeMarkdownTableOfContents",
@@ -272,7 +272,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableOfContentsCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableOfContentsCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableOfContentsCommand.cs#L18"
     },
     {
       "name": "Add-OfficeMarkdownTaskList",
@@ -280,7 +280,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTaskListCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTaskListCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTaskListCommand.cs#L20"
     },
     {
       "name": "Add-OfficePowerPointBullets",
@@ -288,7 +288,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointBulletsCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointBulletsCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointBulletsCommand.cs#L21"
     },
     {
       "name": "Add-OfficePowerPointChart",
@@ -296,7 +296,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointChartCommand.cs",
       "sourceLine": 44,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointChartCommand.cs#L44"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointChartCommand.cs#L44"
     },
     {
       "name": "Add-OfficePowerPointImage",
@@ -304,7 +304,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointImageCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointImageCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointImageCommand.cs#L19"
     },
     {
       "name": "Add-OfficePowerPointSection",
@@ -312,7 +312,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointSectionCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointSectionCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointSectionCommand.cs#L19"
     },
     {
       "name": "Add-OfficePowerPointShape",
@@ -320,7 +320,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointShapeCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointShapeCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointShapeCommand.cs#L21"
     },
     {
       "name": "Add-OfficePowerPointSlide",
@@ -328,7 +328,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointSlideCommand.cs",
       "sourceLine": 25,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointSlideCommand.cs#L25"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointSlideCommand.cs#L25"
     },
     {
       "name": "Add-OfficePowerPointTable",
@@ -336,7 +336,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTableCommand.cs",
       "sourceLine": 24,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTableCommand.cs#L24"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTableCommand.cs#L24"
     },
     {
       "name": "Add-OfficePowerPointTextBox",
@@ -344,7 +344,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTextBoxCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTextBoxCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTextBoxCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordBookmark",
@@ -352,7 +352,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordBookmarkCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordBookmarkCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordBookmarkCommand.cs#L16"
     },
     {
       "name": "Add-OfficeWordCheckBox",
@@ -360,7 +360,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordCheckBoxCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordCheckBoxCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordCheckBoxCommand.cs#L17"
     },
     {
       "name": "Add-OfficeWordComboBox",
@@ -368,7 +368,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordComboBoxCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordComboBoxCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordComboBoxCommand.cs#L20"
     },
     {
       "name": "Add-OfficeWordContentControl",
@@ -376,7 +376,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordContentControlCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordContentControlCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordContentControlCommand.cs#L17"
     },
     {
       "name": "Add-OfficeWordDatePicker",
@@ -384,7 +384,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordDatePickerCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordDatePickerCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordDatePickerCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordDropDownList",
@@ -392,7 +392,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordDropDownListCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordDropDownListCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordDropDownListCommand.cs#L20"
     },
     {
       "name": "Add-OfficeWordField",
@@ -400,7 +400,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordFieldCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordFieldCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordFieldCommand.cs#L19"
     },
     {
       "name": "Add-OfficeWordFooter",
@@ -408,7 +408,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordFooterCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordFooterCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordFooterCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordHeader",
@@ -416,7 +416,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordHeaderCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordHeaderCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordHeaderCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordHyperlink",
@@ -424,7 +424,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordHyperlinkCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordHyperlinkCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordHyperlinkCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordImage",
@@ -432,7 +432,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordImageCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordImageCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordImageCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordList",
@@ -440,7 +440,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordListCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordListCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordListCommand.cs#L17"
     },
     {
       "name": "Add-OfficeWordListItem",
@@ -448,7 +448,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordListItemCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordListItemCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordListItemCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordPageNumber",
@@ -456,7 +456,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordPageNumberCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordPageNumberCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordPageNumberCommand.cs#L19"
     },
     {
       "name": "Add-OfficeWordParagraph",
@@ -464,7 +464,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordParagraphCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordParagraphCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordParagraphCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordPictureControl",
@@ -472,7 +472,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordPictureControlCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordPictureControlCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordPictureControlCommand.cs#L17"
     },
     {
       "name": "Add-OfficeWordRepeatingSection",
@@ -480,7 +480,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordRepeatingSectionCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordRepeatingSectionCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordRepeatingSectionCommand.cs#L17"
     },
     {
       "name": "Add-OfficeWordSection",
@@ -488,7 +488,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordSectionCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordSectionCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordSectionCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordTable",
@@ -496,7 +496,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCommand.cs",
       "sourceLine": 24,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCommand.cs#L24"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCommand.cs#L24"
     },
     {
       "name": "Add-OfficeWordTableCell",
@@ -504,7 +504,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCellCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCellCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCellCommand.cs#L19"
     },
     {
       "name": "Add-OfficeWordTableCondition",
@@ -512,7 +512,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableConditionCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableConditionCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableConditionCommand.cs#L19"
     },
     {
       "name": "Add-OfficeWordTableOfContent",
@@ -520,7 +520,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableOfContentCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableOfContentCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableOfContentCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordText",
@@ -528,7 +528,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTextCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTextCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTextCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordWatermark",
@@ -536,7 +536,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordWatermarkCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordWatermarkCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordWatermarkCommand.cs#L18"
     },
     {
       "name": "Clear-OfficeExcelAutoFilter",
@@ -544,7 +544,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/ClearOfficeExcelAutoFilterCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/ClearOfficeExcelAutoFilterCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/ClearOfficeExcelAutoFilterCommand.cs#L16"
     },
     {
       "name": "Close-OfficeExcel",
@@ -552,7 +552,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/CloseOfficeExcelCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/CloseOfficeExcelCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/CloseOfficeExcelCommand.cs#L16"
     },
     {
       "name": "Close-OfficeWord",
@@ -560,7 +560,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/CloseOfficeWordCommand.cs",
       "sourceLine": 28,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/CloseOfficeWordCommand.cs#L28"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/CloseOfficeWordCommand.cs#L28"
     },
     {
       "name": "ConvertFrom-OfficeWordHtml",
@@ -570,7 +570,7 @@
       ],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordHtmlCommand.cs",
       "sourceLine": 26,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordHtmlCommand.cs#L26"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordHtmlCommand.cs#L26"
     },
     {
       "name": "ConvertFrom-OfficeWordMarkdown",
@@ -580,7 +580,7 @@
       ],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordMarkdownCommand.cs",
       "sourceLine": 29,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordMarkdownCommand.cs#L29"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordMarkdownCommand.cs#L29"
     },
     {
       "name": "ConvertTo-OfficeCsv",
@@ -588,7 +588,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Csv/ConvertToOfficeCsvCommand.cs",
       "sourceLine": 38,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Csv/ConvertToOfficeCsvCommand.cs#L38"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Csv/ConvertToOfficeCsvCommand.cs#L38"
     },
     {
       "name": "ConvertTo-OfficeMarkdown",
@@ -596,7 +596,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/ConvertToOfficeMarkdownCommand.cs",
       "sourceLine": 33,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/ConvertToOfficeMarkdownCommand.cs#L33"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/ConvertToOfficeMarkdownCommand.cs#L33"
     },
     {
       "name": "ConvertTo-OfficeMarkdownHtml",
@@ -606,7 +606,7 @@
       ],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/ConvertToOfficeMarkdownHtmlCommand.cs",
       "sourceLine": 25,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/ConvertToOfficeMarkdownHtmlCommand.cs#L25"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/ConvertToOfficeMarkdownHtmlCommand.cs#L25"
     },
     {
       "name": "ConvertTo-OfficeWordHtml",
@@ -616,7 +616,7 @@
       ],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/ConvertToOfficeWordHtmlCommand.cs",
       "sourceLine": 27,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/ConvertToOfficeWordHtmlCommand.cs#L27"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/ConvertToOfficeWordHtmlCommand.cs#L27"
     },
     {
       "name": "ConvertTo-OfficeWordMarkdown",
@@ -626,7 +626,7 @@
       ],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/ConvertToOfficeWordMarkdownCommand.cs",
       "sourceLine": 27,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/ConvertToOfficeWordMarkdownCommand.cs#L27"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/ConvertToOfficeWordMarkdownCommand.cs#L27"
     },
     {
       "name": "Copy-OfficePowerPointSlide",
@@ -634,7 +634,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/CopyOfficePowerPointSlideCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/CopyOfficePowerPointSlideCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/CopyOfficePowerPointSlideCommand.cs#L18"
     },
     {
       "name": "Find-OfficeWord",
@@ -642,7 +642,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/FindOfficeWordCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/FindOfficeWordCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/FindOfficeWordCommand.cs#L21"
     },
     {
       "name": "Get-OfficeCsv",
@@ -650,7 +650,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Csv/GetOfficeCsvCommand.cs",
       "sourceLine": 31,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Csv/GetOfficeCsvCommand.cs#L31"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Csv/GetOfficeCsvCommand.cs#L31"
     },
     {
       "name": "Get-OfficeCsvData",
@@ -658,7 +658,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Csv/GetOfficeCsvDataCommand.cs",
       "sourceLine": 32,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Csv/GetOfficeCsvDataCommand.cs#L32"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Csv/GetOfficeCsvDataCommand.cs#L32"
     },
     {
       "name": "Get-OfficeExcel",
@@ -666,7 +666,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelCommand.cs#L17"
     },
     {
       "name": "Get-OfficeExcelData",
@@ -674,7 +674,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelDataCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelDataCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelDataCommand.cs#L19"
     },
     {
       "name": "Get-OfficeExcelNamedRange",
@@ -682,7 +682,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelNamedRangeCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelNamedRangeCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelNamedRangeCommand.cs#L19"
     },
     {
       "name": "Get-OfficeExcelPivotTable",
@@ -690,7 +690,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelPivotTableCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelPivotTableCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelPivotTableCommand.cs#L21"
     },
     {
       "name": "Get-OfficeExcelRange",
@@ -698,7 +698,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelRangeCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelRangeCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelRangeCommand.cs#L20"
     },
     {
       "name": "Get-OfficeExcelTable",
@@ -706,7 +706,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelTableCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelTableCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelTableCommand.cs#L18"
     },
     {
       "name": "Get-OfficeExcelUsedRange",
@@ -714,7 +714,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelUsedRangeCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelUsedRangeCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelUsedRangeCommand.cs#L19"
     },
     {
       "name": "Get-OfficeMarkdown",
@@ -722,7 +722,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/GetOfficeMarkdownCommand.cs",
       "sourceLine": 23,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/GetOfficeMarkdownCommand.cs#L23"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/GetOfficeMarkdownCommand.cs#L23"
     },
     {
       "name": "Get-OfficePowerPoint",
@@ -730,7 +730,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointCommand.cs#L18"
     },
     {
       "name": "Get-OfficePowerPointLayout",
@@ -738,7 +738,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutCommand.cs",
       "sourceLine": 23,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutCommand.cs#L23"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutCommand.cs#L23"
     },
     {
       "name": "Get-OfficePowerPointLayoutBox",
@@ -746,7 +746,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutBoxCommand.cs",
       "sourceLine": 25,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutBoxCommand.cs#L25"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutBoxCommand.cs#L25"
     },
     {
       "name": "Get-OfficePowerPointLayoutPlaceholder",
@@ -754,7 +754,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutPlaceholderCommand.cs",
       "sourceLine": 26,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutPlaceholderCommand.cs#L26"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutPlaceholderCommand.cs#L26"
     },
     {
       "name": "Get-OfficePowerPointNotes",
@@ -762,7 +762,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointNotesCommand.cs",
       "sourceLine": 24,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointNotesCommand.cs#L24"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointNotesCommand.cs#L24"
     },
     {
       "name": "Get-OfficePowerPointPlaceholder",
@@ -770,7 +770,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointPlaceholderCommand.cs",
       "sourceLine": 25,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointPlaceholderCommand.cs#L25"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointPlaceholderCommand.cs#L25"
     },
     {
       "name": "Get-OfficePowerPointSection",
@@ -778,7 +778,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSectionCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSectionCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSectionCommand.cs#L18"
     },
     {
       "name": "Get-OfficePowerPointShape",
@@ -786,7 +786,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointShapeCommand.cs",
       "sourceLine": 26,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointShapeCommand.cs#L26"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointShapeCommand.cs#L26"
     },
     {
       "name": "Get-OfficePowerPointSlide",
@@ -794,7 +794,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSlideCommand.cs",
       "sourceLine": 23,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSlideCommand.cs#L23"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSlideCommand.cs#L23"
     },
     {
       "name": "Get-OfficePowerPointSlideSummary",
@@ -802,7 +802,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSlideSummaryCommand.cs",
       "sourceLine": 24,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSlideSummaryCommand.cs#L24"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSlideSummaryCommand.cs#L24"
     },
     {
       "name": "Get-OfficePowerPointTheme",
@@ -810,7 +810,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointThemeCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointThemeCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointThemeCommand.cs#L18"
     },
     {
       "name": "Get-OfficeWord",
@@ -818,7 +818,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordCommand.cs#L17"
     },
     {
       "name": "Get-OfficeWordBookmark",
@@ -826,7 +826,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordBookmarkCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordBookmarkCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordBookmarkCommand.cs#L20"
     },
     {
       "name": "Get-OfficeWordCheckBox",
@@ -834,7 +834,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordCheckBoxCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordCheckBoxCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordCheckBoxCommand.cs#L21"
     },
     {
       "name": "Get-OfficeWordComboBox",
@@ -842,7 +842,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordComboBoxCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordComboBoxCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordComboBoxCommand.cs#L21"
     },
     {
       "name": "Get-OfficeWordContentControl",
@@ -850,7 +850,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordContentControlCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordContentControlCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordContentControlCommand.cs#L21"
     },
     {
       "name": "Get-OfficeWordDatePicker",
@@ -858,7 +858,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDatePickerCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDatePickerCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDatePickerCommand.cs#L21"
     },
     {
       "name": "Get-OfficeWordDocumentProperty",
@@ -866,7 +866,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDocumentPropertyCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDocumentPropertyCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDocumentPropertyCommand.cs#L20"
     },
     {
       "name": "Get-OfficeWordDropDownList",
@@ -874,7 +874,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDropDownListCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDropDownListCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDropDownListCommand.cs#L21"
     },
     {
       "name": "Get-OfficeWordField",
@@ -882,7 +882,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordFieldCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordFieldCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordFieldCommand.cs#L21"
     },
     {
       "name": "Get-OfficeWordHyperlink",
@@ -890,7 +890,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordHyperlinkCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordHyperlinkCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordHyperlinkCommand.cs#L19"
     },
     {
       "name": "Get-OfficeWordParagraph",
@@ -898,7 +898,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordParagraphCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordParagraphCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordParagraphCommand.cs#L19"
     },
     {
       "name": "Get-OfficeWordPictureControl",
@@ -906,7 +906,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordPictureControlCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordPictureControlCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordPictureControlCommand.cs#L21"
     },
     {
       "name": "Get-OfficeWordRepeatingSection",
@@ -914,7 +914,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordRepeatingSectionCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordRepeatingSectionCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordRepeatingSectionCommand.cs#L21"
     },
     {
       "name": "Get-OfficeWordRun",
@@ -922,7 +922,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordRunCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordRunCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordRunCommand.cs#L19"
     },
     {
       "name": "Get-OfficeWordSection",
@@ -930,7 +930,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordSectionCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordSectionCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordSectionCommand.cs#L20"
     },
     {
       "name": "Get-OfficeWordTable",
@@ -938,7 +938,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordTableCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordTableCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordTableCommand.cs#L19"
     },
     {
       "name": "Get-OfficeWordTableOfContent",
@@ -946,7 +946,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordTableOfContentCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordTableOfContentCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordTableOfContentCommand.cs#L19"
     },
     {
       "name": "Import-OfficePowerPointSlide",
@@ -954,7 +954,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/ImportOfficePowerPointSlideCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/ImportOfficePowerPointSlideCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/ImportOfficePowerPointSlideCommand.cs#L19"
     },
     {
       "name": "Invoke-OfficeExcelAutoFit",
@@ -962,7 +962,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/InvokeOfficeExcelAutoFitCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/InvokeOfficeExcelAutoFitCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/InvokeOfficeExcelAutoFitCommand.cs#L19"
     },
     {
       "name": "Invoke-OfficeExcelSort",
@@ -970,7 +970,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/InvokeOfficeExcelSortCommand.cs",
       "sourceLine": 25,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/InvokeOfficeExcelSortCommand.cs#L25"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/InvokeOfficeExcelSortCommand.cs#L25"
     },
     {
       "name": "Invoke-OfficeWordMailMerge",
@@ -978,7 +978,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/InvokeOfficeWordMailMergeCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/InvokeOfficeWordMailMergeCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/InvokeOfficeWordMailMergeCommand.cs#L21"
     },
     {
       "name": "New-OfficeExcel",
@@ -986,7 +986,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/NewOfficeExcelCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/NewOfficeExcelCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/NewOfficeExcelCommand.cs#L18"
     },
     {
       "name": "New-OfficeMarkdown",
@@ -994,7 +994,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/NewOfficeMarkdownCommand.cs",
       "sourceLine": 31,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Markdown/NewOfficeMarkdownCommand.cs#L31"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Markdown/NewOfficeMarkdownCommand.cs#L31"
     },
     {
       "name": "New-OfficePowerPoint",
@@ -1002,7 +1002,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/NewOfficePowerPointCommand.cs",
       "sourceLine": 24,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/NewOfficePowerPointCommand.cs#L24"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/NewOfficePowerPointCommand.cs#L24"
     },
     {
       "name": "New-OfficeWord",
@@ -1010,7 +1010,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordCommand.cs#L17"
     },
     {
       "name": "Protect-OfficeExcelSheet",
@@ -1018,7 +1018,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/ProtectOfficeExcelSheetCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/ProtectOfficeExcelSheetCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/ProtectOfficeExcelSheetCommand.cs#L16"
     },
     {
       "name": "Protect-OfficeWordDocument",
@@ -1026,7 +1026,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/ProtectOfficeWordDocumentCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/ProtectOfficeWordDocumentCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/ProtectOfficeWordDocumentCommand.cs#L18"
     },
     {
       "name": "Remove-OfficeExcelComment",
@@ -1034,7 +1034,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/RemoveOfficeExcelCommentCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/RemoveOfficeExcelCommentCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/RemoveOfficeExcelCommentCommand.cs#L16"
     },
     {
       "name": "Remove-OfficePowerPointSlide",
@@ -1042,7 +1042,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/RemoveOfficePowerPointSlideCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/RemoveOfficePowerPointSlideCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/RemoveOfficePowerPointSlideCommand.cs#L16"
     },
     {
       "name": "Remove-OfficeWordTableOfContent",
@@ -1050,7 +1050,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/RemoveOfficeWordTableOfContentCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/RemoveOfficeWordTableOfContentCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/RemoveOfficeWordTableOfContentCommand.cs#L16"
     },
     {
       "name": "Rename-OfficePowerPointSection",
@@ -1058,7 +1058,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/RenameOfficePowerPointSectionCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/RenameOfficePowerPointSectionCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/RenameOfficePowerPointSectionCommand.cs#L18"
     },
     {
       "name": "Save-OfficeExcel",
@@ -1066,7 +1066,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SaveOfficeExcelCommand.cs",
       "sourceLine": 15,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SaveOfficeExcelCommand.cs#L15"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SaveOfficeExcelCommand.cs#L15"
     },
     {
       "name": "Save-OfficePowerPoint",
@@ -1074,7 +1074,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SaveOfficePowerPointCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SaveOfficePowerPointCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/SaveOfficePowerPointCommand.cs#L17"
     },
     {
       "name": "Save-OfficeWord",
@@ -1082,7 +1082,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/SaveOfficeWordCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/SaveOfficeWordCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/SaveOfficeWordCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelCell",
@@ -1090,7 +1090,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelCellCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelCellCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelCellCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelChartDataLabels",
@@ -1098,7 +1098,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartDataLabelsCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartDataLabelsCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartDataLabelsCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelChartLegend",
@@ -1106,7 +1106,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartLegendCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartLegendCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartLegendCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelChartStyle",
@@ -1114,7 +1114,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartStyleCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartStyleCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartStyleCommand.cs#L16"
     },
     {
       "name": "Set-OfficeExcelColumn",
@@ -1122,7 +1122,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelColumnCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelColumnCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelColumnCommand.cs#L18"
     },
     {
       "name": "Set-OfficeExcelFormula",
@@ -1130,7 +1130,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelFormulaCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelFormulaCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelFormulaCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelFreeze",
@@ -1138,7 +1138,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelFreezeCommand.cs",
       "sourceLine": 22,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelFreezeCommand.cs#L22"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelFreezeCommand.cs#L22"
     },
     {
       "name": "Set-OfficeExcelGridlines",
@@ -1146,7 +1146,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelGridlinesCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelGridlinesCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelGridlinesCommand.cs#L16"
     },
     {
       "name": "Set-OfficeExcelHeaderFooter",
@@ -1154,7 +1154,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHeaderFooterCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHeaderFooterCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHeaderFooterCommand.cs#L19"
     },
     {
       "name": "Set-OfficeExcelHostHyperlink",
@@ -1162,7 +1162,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHostHyperlinkCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHostHyperlinkCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHostHyperlinkCommand.cs#L16"
     },
     {
       "name": "Set-OfficeExcelHyperlink",
@@ -1170,7 +1170,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHyperlinkCommand.cs",
       "sourceLine": 23,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHyperlinkCommand.cs#L23"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHyperlinkCommand.cs#L23"
     },
     {
       "name": "Set-OfficeExcelInternalLinks",
@@ -1178,7 +1178,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelInternalLinksCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelInternalLinksCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelInternalLinksCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelInternalLinksByHeader",
@@ -1186,7 +1186,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelInternalLinksByHeaderCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelInternalLinksByHeaderCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelInternalLinksByHeaderCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelMargins",
@@ -1194,7 +1194,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelMarginsCommand.cs",
       "sourceLine": 22,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelMarginsCommand.cs#L22"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelMarginsCommand.cs#L22"
     },
     {
       "name": "Set-OfficeExcelNamedRange",
@@ -1202,7 +1202,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelNamedRangeCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelNamedRangeCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelNamedRangeCommand.cs#L18"
     },
     {
       "name": "Set-OfficeExcelOrientation",
@@ -1210,7 +1210,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelOrientationCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelOrientationCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelOrientationCommand.cs#L16"
     },
     {
       "name": "Set-OfficeExcelPageSetup",
@@ -1218,7 +1218,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelPageSetupCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelPageSetupCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelPageSetupCommand.cs#L16"
     },
     {
       "name": "Set-OfficeExcelRow",
@@ -1226,7 +1226,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelRowCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelRowCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelRowCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelSheetVisibility",
@@ -1234,7 +1234,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelSheetVisibilityCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelSheetVisibilityCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelSheetVisibilityCommand.cs#L16"
     },
     {
       "name": "Set-OfficeExcelSmartHyperlink",
@@ -1242,7 +1242,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelSmartHyperlinkCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelSmartHyperlinkCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelSmartHyperlinkCommand.cs#L16"
     },
     {
       "name": "Set-OfficeExcelUrlLinks",
@@ -1250,7 +1250,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelUrlLinksCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelUrlLinksCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelUrlLinksCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelUrlLinksByHeader",
@@ -1258,7 +1258,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelUrlLinksByHeaderCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelUrlLinksByHeaderCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelUrlLinksByHeaderCommand.cs#L18"
     },
     {
       "name": "Set-OfficePowerPointBackground",
@@ -1266,7 +1266,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointBackgroundCommand.cs",
       "sourceLine": 23,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointBackgroundCommand.cs#L23"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointBackgroundCommand.cs#L23"
     },
     {
       "name": "Set-OfficePowerPointLayoutPlaceholderBounds",
@@ -1274,7 +1274,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderBoundsCommand.cs",
       "sourceLine": 29,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderBoundsCommand.cs#L29"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderBoundsCommand.cs#L29"
     },
     {
       "name": "Set-OfficePowerPointLayoutPlaceholderTextMargins",
@@ -1282,7 +1282,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderTextMarginsCommand.cs",
       "sourceLine": 29,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderTextMarginsCommand.cs#L29"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderTextMarginsCommand.cs#L29"
     },
     {
       "name": "Set-OfficePowerPointLayoutPlaceholderTextStyle",
@@ -1290,7 +1290,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderTextStyleCommand.cs",
       "sourceLine": 30,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderTextStyleCommand.cs#L30"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderTextStyleCommand.cs#L30"
     },
     {
       "name": "Set-OfficePowerPointNotes",
@@ -1298,7 +1298,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointNotesCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointNotesCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointNotesCommand.cs#L18"
     },
     {
       "name": "Set-OfficePowerPointPlaceholderText",
@@ -1306,7 +1306,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointPlaceholderTextCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointPlaceholderTextCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointPlaceholderTextCommand.cs#L20"
     },
     {
       "name": "Set-OfficePowerPointSlideLayout",
@@ -1314,7 +1314,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideLayoutCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideLayoutCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideLayoutCommand.cs#L19"
     },
     {
       "name": "Set-OfficePowerPointSlideSize",
@@ -1322,7 +1322,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideSizeCommand.cs",
       "sourceLine": 25,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideSizeCommand.cs#L25"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideSizeCommand.cs#L25"
     },
     {
       "name": "Set-OfficePowerPointSlideTitle",
@@ -1330,7 +1330,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideTitleCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideTitleCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideTitleCommand.cs#L19"
     },
     {
       "name": "Set-OfficePowerPointSlideTransition",
@@ -1338,7 +1338,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideTransitionCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideTransitionCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideTransitionCommand.cs#L19"
     },
     {
       "name": "Set-OfficePowerPointThemeColor",
@@ -1346,7 +1346,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeColorCommand.cs",
       "sourceLine": 27,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeColorCommand.cs#L27"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeColorCommand.cs#L27"
     },
     {
       "name": "Set-OfficePowerPointThemeFonts",
@@ -1354,7 +1354,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeFontsCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeFontsCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeFontsCommand.cs#L18"
     },
     {
       "name": "Set-OfficePowerPointThemeName",
@@ -1362,7 +1362,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeNameCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeNameCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeNameCommand.cs#L18"
     },
     {
       "name": "Set-OfficeWordBackground",
@@ -1370,7 +1370,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordBackgroundCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordBackgroundCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordBackgroundCommand.cs#L18"
     },
     {
       "name": "Set-OfficeWordDocumentProperty",
@@ -1378,7 +1378,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordDocumentPropertyCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordDocumentPropertyCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordDocumentPropertyCommand.cs#L17"
     },
     {
       "name": "Set-OfficeWordTableOfContent",
@@ -1386,7 +1386,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordTableOfContentCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordTableOfContentCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordTableOfContentCommand.cs#L17"
     },
     {
       "name": "Unprotect-OfficeExcelSheet",
@@ -1394,7 +1394,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/UnprotectOfficeExcelSheetCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Excel/UnprotectOfficeExcelSheetCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Excel/UnprotectOfficeExcelSheetCommand.cs#L16"
     },
     {
       "name": "Update-OfficePowerPointText",
@@ -1404,7 +1404,7 @@
       ],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/UpdateOfficePowerPointTextCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/PowerPoint/UpdateOfficePowerPointTextCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/PowerPoint/UpdateOfficePowerPointTextCommand.cs#L19"
     },
     {
       "name": "Update-OfficeWordFields",
@@ -1412,7 +1412,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/UpdateOfficeWordFieldsCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/UpdateOfficeWordFieldsCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/UpdateOfficeWordFieldsCommand.cs#L17"
     },
     {
       "name": "Update-OfficeWordTableOfContent",
@@ -1420,7 +1420,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/UpdateOfficeWordTableOfContentCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/UpdateOfficeWordTableOfContentCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/UpdateOfficeWordTableOfContentCommand.cs#L17"
     },
     {
       "name": "Update-OfficeWordText",
@@ -1430,7 +1430,7 @@
       ],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/UpdateOfficeWordTextCommand.cs",
       "sourceLine": 25,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/30d554cf538493fada9b60ccda9ab90d8f228d7b/Sources/PSWriteOffice/Cmdlets/Word/UpdateOfficeWordTextCommand.cs#L25"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5/Sources/PSWriteOffice/Cmdlets/Word/UpdateOfficeWordTextCommand.cs#L25"
     }
   ]
 }

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordCharts.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordCharts.ps1
@@ -1,0 +1,27 @@
+Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
+
+$documents = Join-Path $PSScriptRoot '..\Documents'
+New-Item -Path $documents -ItemType Directory -Force | Out-Null
+
+$docPath = Join-Path $documents 'Word-Charts.docx'
+$doc = New-OfficeWord -Path $docPath
+
+try {
+    $doc.AddParagraph('Word charts are currently available through the underlying OfficeIMO document object.') | Out-Null
+    $doc.AddParagraph('Older samples that used PieChart() should now use AddChart().AddPie().') | Out-Null
+
+    $chart = $doc.AddChart('Regional Revenue Mix')
+    $chart.AddPie('North America', 125000).
+        AddPie('EMEA', 98000).
+        AddPie('APAC', 143000) | Out-Null
+    $chart.SetWidthToPageContent(0.70, 320) | Out-Null
+
+    Close-OfficeWord -Document $doc -Save
+    $doc = $null
+} finally {
+    if ($null -ne $doc) {
+        $doc.Dispose()
+    }
+}
+
+Write-Host "Document saved to $docPath"

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordLineBreaks.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordLineBreaks.ps1
@@ -1,0 +1,22 @@
+Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
+
+$documents = Join-Path $PSScriptRoot '..\Documents'
+New-Item -Path $documents -ItemType Directory -Force | Out-Null
+
+$path = Join-Path $documents 'Example-WordLineBreaks.docx'
+$document = New-OfficeWord -Path $path
+
+# AddBreak() creates a same-paragraph line break similar to Shift+Enter in Word.
+$paragraph = $document.AddParagraph('Line 1 in the same paragraph')
+$null = $paragraph.AddBreak()
+$null = $paragraph.AddText('Line 2 after AddBreak()')
+$null = $paragraph.AddBreak()
+$null = $paragraph.AddText('Line 3 still in the same paragraph')
+
+# AddParagraph() creates a new paragraph, so an empty paragraph gives a visible blank line.
+$null = $document.AddParagraph()
+$null = $document.AddParagraph('This text comes after an empty paragraph break.')
+
+Close-OfficeWord -Document $document -Save
+
+Write-Host "Document saved to $path"

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordTableCalculatedColumns.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordTableCalculatedColumns.ps1
@@ -1,0 +1,49 @@
+Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
+
+$documents = Join-Path $PSScriptRoot '..\Documents'
+New-Item -Path $documents -ItemType Directory -Force | Out-Null
+
+$services = @(
+    [PSCustomObject]@{
+        Name        = 'Directory API'
+        Status      = 'Healthy'
+        Owner       = 'Team Identity'
+        LastPatch   = [datetime]'2026-03-28'
+        NodeCount   = 4
+    }
+    [PSCustomObject]@{
+        Name        = 'Billing API'
+        Status      = 'Review'
+        Owner       = 'Team Finance'
+        LastPatch   = [datetime]'2026-03-14'
+        NodeCount   = 2
+    }
+)
+
+$tableData = $services | Select-Object Name, Status,
+@{
+    Name = 'Owner'
+    Expression = { $_.Owner }
+},
+@{
+    Name = 'LastPatch'
+    Expression = { $_.LastPatch.ToString('yyyy-MM-dd') }
+},
+@{
+    Name = 'NeedsAttention'
+    Expression = { if ($_.Status -eq 'Healthy') { 'No' } else { 'Yes' } }
+},
+@{
+    Name = 'ClusterSize'
+    Expression = { "$($_.NodeCount) nodes" }
+}
+
+$docPath = Join-Path $documents 'Word-CalculatedColumns.docx'
+
+New-OfficeWord -Path $docPath {
+    Add-OfficeWordParagraph -Text 'Calculated and projected columns'
+    Add-OfficeWordParagraph -Text 'Shape your objects before Add-OfficeWordTable when you want extra columns or friendlier labels.'
+    Add-OfficeWordTable -InputObject $tableData -Style 'GridTable1LightAccent1'
+} | Out-Null
+
+Write-Host "Document saved to $docPath"

--- a/WebsiteArtifacts/project-manifest.json
+++ b/WebsiteArtifacts/project-manifest.json
@@ -7,8 +7,8 @@
   "status": "active",
   "listed": false,
   "version": "0.3.0",
-  "generatedAt": "2026-04-04T06:56:43.0329965+00:00",
-  "commit": "30d554cf538493fada9b60ccda9ab90d8f228d7b",
+  "generatedAt": "2026-04-04T07:11:41.8389655+00:00",
+  "commit": "6c5bfd3047e4e53d36d1ba49ddae688cd3e256e5",
   "links": {
     "source": "https://github.com/EvotecIT/PSWriteOffice"
   },


### PR DESCRIPTION
## What changed
- add release-safe issue tracking documents and close templates
- add a branch-aware release smoke runner for issue coverage verification
- add missing Word examples for line breaks, charts, and calculated table columns
- add a real `LICENSE` file and align module metadata

## Why
This gives us the release tooling and documentation needed to ship PSWriteOffice confidently, map work back to the open issues, and postpone issue closure until the release is actually published.

## Validation
- `dotnet build Sources/PSWriteOffice.sln`
- `./Roadmap/Invoke-IssueReleaseSmokeTests.ps1`

## Notes
- Refs #5
- Refs #19
- Refs #20
- Refs #21
- No issue-closing keywords yet because release is still pending.
