### PR TITLE
Bump OfficeIMO package references

### DIFF
--- a/Sources/PSWriteOffice/PSWriteOffice.csproj
+++ b/Sources/PSWriteOffice/PSWriteOffice.csproj
@@ -67,12 +67,12 @@
         <ProjectReference Include="$(OfficeIMORoot)\OfficeIMO.Word.Html\OfficeIMO.Word.Html.csproj" />
     </ItemGroup>
     <ItemGroup Condition="!Exists('$(OfficeIMORoot)\OfficeIMO.Word\OfficeIMO.Word.csproj')">
-        <PackageReference Include="OfficeIMO.Word" Version="1.0.33" />
-        <PackageReference Include="OfficeIMO.Word.Markdown" Version="1.0.0" />
-        <PackageReference Include="OfficeIMO.Excel" Version="0.6.13" />
-        <PackageReference Include="OfficeIMO.PowerPoint" Version="1.0.8" />
-        <PackageReference Include="OfficeIMO.Markdown" Version="0.6.4" />
-        <PackageReference Include="OfficeIMO.CSV" Version="0.1.13" />
-        <PackageReference Include="OfficeIMO.Word.Html" Version="1.0.7" />
+        <PackageReference Include="OfficeIMO.Word" Version="1.0.41" />
+        <PackageReference Include="OfficeIMO.Word.Markdown" Version="1.0.15" />
+        <PackageReference Include="OfficeIMO.Excel" Version="0.6.21" />
+        <PackageReference Include="OfficeIMO.PowerPoint" Version="1.0.16" />
+        <PackageReference Include="OfficeIMO.Markdown" Version="0.6.8" />
+        <PackageReference Include="OfficeIMO.CSV" Version="0.1.21" />
+        <PackageReference Include="OfficeIMO.Word.Html" Version="1.0.15" />
     </ItemGroup>
 </Project>

--- a/WebsiteArtifacts/apidocs/powershell/command-metadata.json
+++ b/WebsiteArtifacts/apidocs/powershell/command-metadata.json
@@ -1,6 +1,6 @@
 {
   "moduleName": "PSWriteOffice",
-  "generatedAt": "2026-04-03T22:18:15.9888644+00:00",
+  "generatedAt": "2026-04-04T06:36:10.6682453+00:00",
   "commands": [
     {
       "name": "Add-OfficeExcelAutoFilter",
@@ -8,7 +8,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelAutoFilterCommand.cs",
       "sourceLine": 27,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelAutoFilterCommand.cs#L27"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelAutoFilterCommand.cs#L27"
     },
     {
       "name": "Add-OfficeExcelChart",
@@ -16,7 +16,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelChartCommand.cs",
       "sourceLine": 23,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelChartCommand.cs#L23"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelChartCommand.cs#L23"
     },
     {
       "name": "Add-OfficeExcelComment",
@@ -24,7 +24,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelCommentCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelCommentCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelCommentCommand.cs#L17"
     },
     {
       "name": "Add-OfficeExcelConditionalColorScale",
@@ -32,7 +32,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalColorScaleCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalColorScaleCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalColorScaleCommand.cs#L17"
     },
     {
       "name": "Add-OfficeExcelConditionalDataBar",
@@ -40,7 +40,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalDataBarCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalDataBarCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalDataBarCommand.cs#L17"
     },
     {
       "name": "Add-OfficeExcelConditionalIconSet",
@@ -48,7 +48,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalIconSetCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalIconSetCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalIconSetCommand.cs#L19"
     },
     {
       "name": "Add-OfficeExcelConditionalRule",
@@ -56,7 +56,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalRuleCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalRuleCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelConditionalRuleCommand.cs#L18"
     },
     {
       "name": "Add-OfficeExcelImage",
@@ -64,7 +64,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelImageCommand.cs",
       "sourceLine": 24,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelImageCommand.cs#L24"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelImageCommand.cs#L24"
     },
     {
       "name": "Add-OfficeExcelImageFromUrl",
@@ -72,7 +72,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelImageFromUrlCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelImageFromUrlCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelImageFromUrlCommand.cs#L18"
     },
     {
       "name": "Add-OfficeExcelPivotTable",
@@ -80,7 +80,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelPivotTableCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelPivotTableCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelPivotTableCommand.cs#L19"
     },
     {
       "name": "Add-OfficeExcelSheet",
@@ -88,7 +88,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelSheetCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelSheetCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelSheetCommand.cs#L17"
     },
     {
       "name": "Add-OfficeExcelSparkline",
@@ -96,7 +96,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelSparklineCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelSparklineCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelSparklineCommand.cs#L19"
     },
     {
       "name": "Add-OfficeExcelTable",
@@ -104,7 +104,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableCommand.cs#L21"
     },
     {
       "name": "Add-OfficeExcelTableOfContents",
@@ -112,7 +112,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableOfContentsCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableOfContentsCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableOfContentsCommand.cs#L19"
     },
     {
       "name": "Add-OfficeExcelValidationCustomFormula",
@@ -120,7 +120,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationCustomFormulaCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationCustomFormulaCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationCustomFormulaCommand.cs#L16"
     },
     {
       "name": "Add-OfficeExcelValidationDate",
@@ -128,7 +128,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationDateCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationDateCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationDateCommand.cs#L19"
     },
     {
       "name": "Add-OfficeExcelValidationDecimal",
@@ -136,7 +136,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationDecimalCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationDecimalCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationDecimalCommand.cs#L18"
     },
     {
       "name": "Add-OfficeExcelValidationList",
@@ -144,7 +144,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationListCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationListCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationListCommand.cs#L18"
     },
     {
       "name": "Add-OfficeExcelValidationTextLength",
@@ -152,7 +152,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationTextLengthCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationTextLengthCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationTextLengthCommand.cs#L18"
     },
     {
       "name": "Add-OfficeExcelValidationTime",
@@ -160,7 +160,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationTimeCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationTimeCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationTimeCommand.cs#L19"
     },
     {
       "name": "Add-OfficeExcelValidationWholeNumber",
@@ -168,7 +168,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationWholeNumberCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationWholeNumberCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelValidationWholeNumberCommand.cs#L18"
     },
     {
       "name": "Add-OfficeMarkdownCallout",
@@ -176,7 +176,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownCalloutCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownCalloutCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownCalloutCommand.cs#L17"
     },
     {
       "name": "Add-OfficeMarkdownCode",
@@ -184,7 +184,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownCodeCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownCodeCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownCodeCommand.cs#L17"
     },
     {
       "name": "Add-OfficeMarkdownDefinitionList",
@@ -192,7 +192,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownDefinitionListCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownDefinitionListCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownDefinitionListCommand.cs#L19"
     },
     {
       "name": "Add-OfficeMarkdownDetails",
@@ -200,7 +200,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownDetailsCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownDetailsCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownDetailsCommand.cs#L17"
     },
     {
       "name": "Add-OfficeMarkdownFrontMatter",
@@ -208,7 +208,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownFrontMatterCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownFrontMatterCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownFrontMatterCommand.cs#L21"
     },
     {
       "name": "Add-OfficeMarkdownHeading",
@@ -216,7 +216,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownHeadingCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownHeadingCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownHeadingCommand.cs#L18"
     },
     {
       "name": "Add-OfficeMarkdownHorizontalRule",
@@ -224,7 +224,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownHorizontalRuleCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownHorizontalRuleCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownHorizontalRuleCommand.cs#L17"
     },
     {
       "name": "Add-OfficeMarkdownImage",
@@ -232,7 +232,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownImageCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownImageCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownImageCommand.cs#L17"
     },
     {
       "name": "Add-OfficeMarkdownList",
@@ -240,7 +240,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownListCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownListCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownListCommand.cs#L20"
     },
     {
       "name": "Add-OfficeMarkdownParagraph",
@@ -248,7 +248,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownParagraphCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownParagraphCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownParagraphCommand.cs#L17"
     },
     {
       "name": "Add-OfficeMarkdownQuote",
@@ -256,7 +256,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownQuoteCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownQuoteCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownQuoteCommand.cs#L17"
     },
     {
       "name": "Add-OfficeMarkdownTable",
@@ -264,7 +264,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableCommand.cs",
       "sourceLine": 28,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableCommand.cs#L28"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableCommand.cs#L28"
     },
     {
       "name": "Add-OfficeMarkdownTableOfContents",
@@ -272,7 +272,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableOfContentsCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableOfContentsCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableOfContentsCommand.cs#L18"
     },
     {
       "name": "Add-OfficeMarkdownTaskList",
@@ -280,7 +280,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTaskListCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTaskListCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTaskListCommand.cs#L20"
     },
     {
       "name": "Add-OfficePowerPointBullets",
@@ -288,7 +288,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointBulletsCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointBulletsCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointBulletsCommand.cs#L21"
     },
     {
       "name": "Add-OfficePowerPointChart",
@@ -296,7 +296,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointChartCommand.cs",
       "sourceLine": 44,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointChartCommand.cs#L44"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointChartCommand.cs#L44"
     },
     {
       "name": "Add-OfficePowerPointImage",
@@ -304,7 +304,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointImageCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointImageCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointImageCommand.cs#L19"
     },
     {
       "name": "Add-OfficePowerPointSection",
@@ -312,7 +312,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointSectionCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointSectionCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointSectionCommand.cs#L19"
     },
     {
       "name": "Add-OfficePowerPointShape",
@@ -320,7 +320,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointShapeCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointShapeCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointShapeCommand.cs#L21"
     },
     {
       "name": "Add-OfficePowerPointSlide",
@@ -328,7 +328,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointSlideCommand.cs",
       "sourceLine": 25,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointSlideCommand.cs#L25"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointSlideCommand.cs#L25"
     },
     {
       "name": "Add-OfficePowerPointTable",
@@ -336,7 +336,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTableCommand.cs",
       "sourceLine": 24,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTableCommand.cs#L24"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTableCommand.cs#L24"
     },
     {
       "name": "Add-OfficePowerPointTextBox",
@@ -344,7 +344,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTextBoxCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTextBoxCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTextBoxCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordBookmark",
@@ -352,7 +352,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordBookmarkCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordBookmarkCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordBookmarkCommand.cs#L16"
     },
     {
       "name": "Add-OfficeWordCheckBox",
@@ -360,7 +360,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordCheckBoxCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordCheckBoxCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordCheckBoxCommand.cs#L17"
     },
     {
       "name": "Add-OfficeWordComboBox",
@@ -368,7 +368,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordComboBoxCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordComboBoxCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordComboBoxCommand.cs#L20"
     },
     {
       "name": "Add-OfficeWordContentControl",
@@ -376,7 +376,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordContentControlCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordContentControlCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordContentControlCommand.cs#L17"
     },
     {
       "name": "Add-OfficeWordDatePicker",
@@ -384,7 +384,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordDatePickerCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordDatePickerCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordDatePickerCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordDropDownList",
@@ -392,7 +392,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordDropDownListCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordDropDownListCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordDropDownListCommand.cs#L20"
     },
     {
       "name": "Add-OfficeWordField",
@@ -400,7 +400,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordFieldCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordFieldCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordFieldCommand.cs#L19"
     },
     {
       "name": "Add-OfficeWordFooter",
@@ -408,7 +408,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordFooterCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordFooterCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordFooterCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordHeader",
@@ -416,7 +416,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordHeaderCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordHeaderCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordHeaderCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordHyperlink",
@@ -424,7 +424,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordHyperlinkCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordHyperlinkCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordHyperlinkCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordImage",
@@ -432,7 +432,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordImageCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordImageCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordImageCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordList",
@@ -440,7 +440,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordListCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordListCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordListCommand.cs#L17"
     },
     {
       "name": "Add-OfficeWordListItem",
@@ -448,7 +448,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordListItemCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordListItemCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordListItemCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordPageNumber",
@@ -456,7 +456,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordPageNumberCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordPageNumberCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordPageNumberCommand.cs#L19"
     },
     {
       "name": "Add-OfficeWordParagraph",
@@ -464,7 +464,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordParagraphCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordParagraphCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordParagraphCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordPictureControl",
@@ -472,7 +472,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordPictureControlCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordPictureControlCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordPictureControlCommand.cs#L17"
     },
     {
       "name": "Add-OfficeWordRepeatingSection",
@@ -480,7 +480,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordRepeatingSectionCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordRepeatingSectionCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordRepeatingSectionCommand.cs#L17"
     },
     {
       "name": "Add-OfficeWordSection",
@@ -488,7 +488,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordSectionCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordSectionCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordSectionCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordTable",
@@ -496,7 +496,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCommand.cs",
       "sourceLine": 24,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCommand.cs#L24"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCommand.cs#L24"
     },
     {
       "name": "Add-OfficeWordTableCell",
@@ -504,7 +504,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCellCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCellCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCellCommand.cs#L19"
     },
     {
       "name": "Add-OfficeWordTableCondition",
@@ -512,7 +512,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableConditionCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableConditionCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableConditionCommand.cs#L19"
     },
     {
       "name": "Add-OfficeWordTableOfContent",
@@ -520,7 +520,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableOfContentCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableOfContentCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableOfContentCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordText",
@@ -528,7 +528,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTextCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTextCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTextCommand.cs#L18"
     },
     {
       "name": "Add-OfficeWordWatermark",
@@ -536,7 +536,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordWatermarkCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordWatermarkCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordWatermarkCommand.cs#L18"
     },
     {
       "name": "Clear-OfficeExcelAutoFilter",
@@ -544,7 +544,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/ClearOfficeExcelAutoFilterCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/ClearOfficeExcelAutoFilterCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/ClearOfficeExcelAutoFilterCommand.cs#L16"
     },
     {
       "name": "Close-OfficeExcel",
@@ -552,7 +552,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/CloseOfficeExcelCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/CloseOfficeExcelCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/CloseOfficeExcelCommand.cs#L16"
     },
     {
       "name": "Close-OfficeWord",
@@ -560,7 +560,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/CloseOfficeWordCommand.cs",
       "sourceLine": 22,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/CloseOfficeWordCommand.cs#L22"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/CloseOfficeWordCommand.cs#L22"
     },
     {
       "name": "ConvertFrom-OfficeWordHtml",
@@ -570,7 +570,7 @@
       ],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordHtmlCommand.cs",
       "sourceLine": 26,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordHtmlCommand.cs#L26"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordHtmlCommand.cs#L26"
     },
     {
       "name": "ConvertFrom-OfficeWordMarkdown",
@@ -580,7 +580,7 @@
       ],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordMarkdownCommand.cs",
       "sourceLine": 29,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordMarkdownCommand.cs#L29"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordMarkdownCommand.cs#L29"
     },
     {
       "name": "ConvertTo-OfficeCsv",
@@ -588,7 +588,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Csv/ConvertToOfficeCsvCommand.cs",
       "sourceLine": 38,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Csv/ConvertToOfficeCsvCommand.cs#L38"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Csv/ConvertToOfficeCsvCommand.cs#L38"
     },
     {
       "name": "ConvertTo-OfficeMarkdown",
@@ -596,7 +596,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/ConvertToOfficeMarkdownCommand.cs",
       "sourceLine": 33,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/ConvertToOfficeMarkdownCommand.cs#L33"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/ConvertToOfficeMarkdownCommand.cs#L33"
     },
     {
       "name": "ConvertTo-OfficeMarkdownHtml",
@@ -606,7 +606,7 @@
       ],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/ConvertToOfficeMarkdownHtmlCommand.cs",
       "sourceLine": 25,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/ConvertToOfficeMarkdownHtmlCommand.cs#L25"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/ConvertToOfficeMarkdownHtmlCommand.cs#L25"
     },
     {
       "name": "ConvertTo-OfficeWordHtml",
@@ -616,7 +616,7 @@
       ],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/ConvertToOfficeWordHtmlCommand.cs",
       "sourceLine": 27,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/ConvertToOfficeWordHtmlCommand.cs#L27"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/ConvertToOfficeWordHtmlCommand.cs#L27"
     },
     {
       "name": "ConvertTo-OfficeWordMarkdown",
@@ -626,7 +626,7 @@
       ],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/ConvertToOfficeWordMarkdownCommand.cs",
       "sourceLine": 27,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/ConvertToOfficeWordMarkdownCommand.cs#L27"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/ConvertToOfficeWordMarkdownCommand.cs#L27"
     },
     {
       "name": "Copy-OfficePowerPointSlide",
@@ -634,7 +634,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/CopyOfficePowerPointSlideCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/CopyOfficePowerPointSlideCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/CopyOfficePowerPointSlideCommand.cs#L18"
     },
     {
       "name": "Find-OfficeWord",
@@ -642,7 +642,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/FindOfficeWordCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/FindOfficeWordCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/FindOfficeWordCommand.cs#L21"
     },
     {
       "name": "Get-OfficeCsv",
@@ -650,7 +650,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Csv/GetOfficeCsvCommand.cs",
       "sourceLine": 31,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Csv/GetOfficeCsvCommand.cs#L31"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Csv/GetOfficeCsvCommand.cs#L31"
     },
     {
       "name": "Get-OfficeCsvData",
@@ -658,7 +658,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Csv/GetOfficeCsvDataCommand.cs",
       "sourceLine": 32,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Csv/GetOfficeCsvDataCommand.cs#L32"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Csv/GetOfficeCsvDataCommand.cs#L32"
     },
     {
       "name": "Get-OfficeExcel",
@@ -666,7 +666,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelCommand.cs#L17"
     },
     {
       "name": "Get-OfficeExcelData",
@@ -674,7 +674,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelDataCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelDataCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelDataCommand.cs#L19"
     },
     {
       "name": "Get-OfficeExcelNamedRange",
@@ -682,7 +682,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelNamedRangeCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelNamedRangeCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelNamedRangeCommand.cs#L19"
     },
     {
       "name": "Get-OfficeExcelPivotTable",
@@ -690,7 +690,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelPivotTableCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelPivotTableCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelPivotTableCommand.cs#L21"
     },
     {
       "name": "Get-OfficeExcelRange",
@@ -698,7 +698,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelRangeCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelRangeCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelRangeCommand.cs#L20"
     },
     {
       "name": "Get-OfficeExcelTable",
@@ -706,7 +706,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelTableCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelTableCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelTableCommand.cs#L18"
     },
     {
       "name": "Get-OfficeExcelUsedRange",
@@ -714,7 +714,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelUsedRangeCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelUsedRangeCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelUsedRangeCommand.cs#L19"
     },
     {
       "name": "Get-OfficeMarkdown",
@@ -722,7 +722,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/GetOfficeMarkdownCommand.cs",
       "sourceLine": 23,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/GetOfficeMarkdownCommand.cs#L23"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/GetOfficeMarkdownCommand.cs#L23"
     },
     {
       "name": "Get-OfficePowerPoint",
@@ -730,7 +730,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointCommand.cs#L18"
     },
     {
       "name": "Get-OfficePowerPointLayout",
@@ -738,7 +738,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutCommand.cs",
       "sourceLine": 23,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutCommand.cs#L23"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutCommand.cs#L23"
     },
     {
       "name": "Get-OfficePowerPointLayoutBox",
@@ -746,7 +746,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutBoxCommand.cs",
       "sourceLine": 25,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutBoxCommand.cs#L25"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutBoxCommand.cs#L25"
     },
     {
       "name": "Get-OfficePowerPointLayoutPlaceholder",
@@ -754,7 +754,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutPlaceholderCommand.cs",
       "sourceLine": 26,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutPlaceholderCommand.cs#L26"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointLayoutPlaceholderCommand.cs#L26"
     },
     {
       "name": "Get-OfficePowerPointNotes",
@@ -762,7 +762,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointNotesCommand.cs",
       "sourceLine": 24,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointNotesCommand.cs#L24"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointNotesCommand.cs#L24"
     },
     {
       "name": "Get-OfficePowerPointPlaceholder",
@@ -770,7 +770,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointPlaceholderCommand.cs",
       "sourceLine": 25,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointPlaceholderCommand.cs#L25"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointPlaceholderCommand.cs#L25"
     },
     {
       "name": "Get-OfficePowerPointSection",
@@ -778,7 +778,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSectionCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSectionCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSectionCommand.cs#L18"
     },
     {
       "name": "Get-OfficePowerPointShape",
@@ -786,7 +786,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointShapeCommand.cs",
       "sourceLine": 26,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointShapeCommand.cs#L26"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointShapeCommand.cs#L26"
     },
     {
       "name": "Get-OfficePowerPointSlide",
@@ -794,7 +794,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSlideCommand.cs",
       "sourceLine": 23,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSlideCommand.cs#L23"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSlideCommand.cs#L23"
     },
     {
       "name": "Get-OfficePowerPointSlideSummary",
@@ -802,7 +802,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSlideSummaryCommand.cs",
       "sourceLine": 24,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSlideSummaryCommand.cs#L24"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointSlideSummaryCommand.cs#L24"
     },
     {
       "name": "Get-OfficePowerPointTheme",
@@ -810,7 +810,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointThemeCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointThemeCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointThemeCommand.cs#L18"
     },
     {
       "name": "Get-OfficeWord",
@@ -818,7 +818,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordCommand.cs#L17"
     },
     {
       "name": "Get-OfficeWordBookmark",
@@ -826,7 +826,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordBookmarkCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordBookmarkCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordBookmarkCommand.cs#L20"
     },
     {
       "name": "Get-OfficeWordCheckBox",
@@ -834,7 +834,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordCheckBoxCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordCheckBoxCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordCheckBoxCommand.cs#L21"
     },
     {
       "name": "Get-OfficeWordComboBox",
@@ -842,7 +842,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordComboBoxCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordComboBoxCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordComboBoxCommand.cs#L21"
     },
     {
       "name": "Get-OfficeWordContentControl",
@@ -850,7 +850,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordContentControlCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordContentControlCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordContentControlCommand.cs#L21"
     },
     {
       "name": "Get-OfficeWordDatePicker",
@@ -858,7 +858,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDatePickerCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDatePickerCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDatePickerCommand.cs#L21"
     },
     {
       "name": "Get-OfficeWordDocumentProperty",
@@ -866,7 +866,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDocumentPropertyCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDocumentPropertyCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDocumentPropertyCommand.cs#L20"
     },
     {
       "name": "Get-OfficeWordDropDownList",
@@ -874,7 +874,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDropDownListCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDropDownListCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordDropDownListCommand.cs#L21"
     },
     {
       "name": "Get-OfficeWordField",
@@ -882,7 +882,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordFieldCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordFieldCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordFieldCommand.cs#L21"
     },
     {
       "name": "Get-OfficeWordHyperlink",
@@ -890,7 +890,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordHyperlinkCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordHyperlinkCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordHyperlinkCommand.cs#L19"
     },
     {
       "name": "Get-OfficeWordParagraph",
@@ -898,7 +898,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordParagraphCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordParagraphCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordParagraphCommand.cs#L19"
     },
     {
       "name": "Get-OfficeWordPictureControl",
@@ -906,7 +906,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordPictureControlCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordPictureControlCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordPictureControlCommand.cs#L21"
     },
     {
       "name": "Get-OfficeWordRepeatingSection",
@@ -914,7 +914,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordRepeatingSectionCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordRepeatingSectionCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordRepeatingSectionCommand.cs#L21"
     },
     {
       "name": "Get-OfficeWordRun",
@@ -922,7 +922,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordRunCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordRunCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordRunCommand.cs#L19"
     },
     {
       "name": "Get-OfficeWordSection",
@@ -930,7 +930,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordSectionCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordSectionCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordSectionCommand.cs#L20"
     },
     {
       "name": "Get-OfficeWordTable",
@@ -938,7 +938,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordTableCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordTableCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordTableCommand.cs#L19"
     },
     {
       "name": "Get-OfficeWordTableOfContent",
@@ -946,7 +946,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordTableOfContentCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordTableOfContentCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/GetOfficeWordTableOfContentCommand.cs#L19"
     },
     {
       "name": "Import-OfficePowerPointSlide",
@@ -954,7 +954,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/ImportOfficePowerPointSlideCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/ImportOfficePowerPointSlideCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/ImportOfficePowerPointSlideCommand.cs#L19"
     },
     {
       "name": "Invoke-OfficeExcelAutoFit",
@@ -962,7 +962,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/InvokeOfficeExcelAutoFitCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/InvokeOfficeExcelAutoFitCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/InvokeOfficeExcelAutoFitCommand.cs#L19"
     },
     {
       "name": "Invoke-OfficeExcelSort",
@@ -970,7 +970,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/InvokeOfficeExcelSortCommand.cs",
       "sourceLine": 25,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/InvokeOfficeExcelSortCommand.cs#L25"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/InvokeOfficeExcelSortCommand.cs#L25"
     },
     {
       "name": "Invoke-OfficeWordMailMerge",
@@ -978,7 +978,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/InvokeOfficeWordMailMergeCommand.cs",
       "sourceLine": 21,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/InvokeOfficeWordMailMergeCommand.cs#L21"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/InvokeOfficeWordMailMergeCommand.cs#L21"
     },
     {
       "name": "New-OfficeExcel",
@@ -986,7 +986,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/NewOfficeExcelCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/NewOfficeExcelCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/NewOfficeExcelCommand.cs#L18"
     },
     {
       "name": "New-OfficeMarkdown",
@@ -994,7 +994,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Markdown/NewOfficeMarkdownCommand.cs",
       "sourceLine": 31,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Markdown/NewOfficeMarkdownCommand.cs#L31"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Markdown/NewOfficeMarkdownCommand.cs#L31"
     },
     {
       "name": "New-OfficePowerPoint",
@@ -1002,7 +1002,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/NewOfficePowerPointCommand.cs",
       "sourceLine": 24,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/NewOfficePowerPointCommand.cs#L24"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/NewOfficePowerPointCommand.cs#L24"
     },
     {
       "name": "New-OfficeWord",
@@ -1010,7 +1010,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/NewOfficeWordCommand.cs#L17"
     },
     {
       "name": "Protect-OfficeExcelSheet",
@@ -1018,7 +1018,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/ProtectOfficeExcelSheetCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/ProtectOfficeExcelSheetCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/ProtectOfficeExcelSheetCommand.cs#L16"
     },
     {
       "name": "Protect-OfficeWordDocument",
@@ -1026,7 +1026,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/ProtectOfficeWordDocumentCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/ProtectOfficeWordDocumentCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/ProtectOfficeWordDocumentCommand.cs#L18"
     },
     {
       "name": "Remove-OfficeExcelComment",
@@ -1034,7 +1034,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/RemoveOfficeExcelCommentCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/RemoveOfficeExcelCommentCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/RemoveOfficeExcelCommentCommand.cs#L16"
     },
     {
       "name": "Remove-OfficePowerPointSlide",
@@ -1042,7 +1042,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/RemoveOfficePowerPointSlideCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/RemoveOfficePowerPointSlideCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/RemoveOfficePowerPointSlideCommand.cs#L16"
     },
     {
       "name": "Remove-OfficeWordTableOfContent",
@@ -1050,7 +1050,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/RemoveOfficeWordTableOfContentCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/RemoveOfficeWordTableOfContentCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/RemoveOfficeWordTableOfContentCommand.cs#L16"
     },
     {
       "name": "Rename-OfficePowerPointSection",
@@ -1058,7 +1058,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/RenameOfficePowerPointSectionCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/RenameOfficePowerPointSectionCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/RenameOfficePowerPointSectionCommand.cs#L18"
     },
     {
       "name": "Save-OfficeExcel",
@@ -1066,7 +1066,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SaveOfficeExcelCommand.cs",
       "sourceLine": 15,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SaveOfficeExcelCommand.cs#L15"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SaveOfficeExcelCommand.cs#L15"
     },
     {
       "name": "Save-OfficePowerPoint",
@@ -1074,7 +1074,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SaveOfficePowerPointCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/SaveOfficePowerPointCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/SaveOfficePowerPointCommand.cs#L17"
     },
     {
       "name": "Save-OfficeWord",
@@ -1082,7 +1082,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/SaveOfficeWordCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/SaveOfficeWordCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/SaveOfficeWordCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelCell",
@@ -1090,7 +1090,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelCellCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelCellCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelCellCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelChartDataLabels",
@@ -1098,7 +1098,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartDataLabelsCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartDataLabelsCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartDataLabelsCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelChartLegend",
@@ -1106,7 +1106,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartLegendCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartLegendCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartLegendCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelChartStyle",
@@ -1114,7 +1114,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartStyleCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartStyleCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartStyleCommand.cs#L16"
     },
     {
       "name": "Set-OfficeExcelColumn",
@@ -1122,7 +1122,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelColumnCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelColumnCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelColumnCommand.cs#L18"
     },
     {
       "name": "Set-OfficeExcelFormula",
@@ -1130,7 +1130,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelFormulaCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelFormulaCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelFormulaCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelFreeze",
@@ -1138,7 +1138,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelFreezeCommand.cs",
       "sourceLine": 22,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelFreezeCommand.cs#L22"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelFreezeCommand.cs#L22"
     },
     {
       "name": "Set-OfficeExcelGridlines",
@@ -1146,7 +1146,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelGridlinesCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelGridlinesCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelGridlinesCommand.cs#L16"
     },
     {
       "name": "Set-OfficeExcelHeaderFooter",
@@ -1154,7 +1154,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHeaderFooterCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHeaderFooterCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHeaderFooterCommand.cs#L19"
     },
     {
       "name": "Set-OfficeExcelHostHyperlink",
@@ -1162,7 +1162,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHostHyperlinkCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHostHyperlinkCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHostHyperlinkCommand.cs#L16"
     },
     {
       "name": "Set-OfficeExcelHyperlink",
@@ -1170,7 +1170,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHyperlinkCommand.cs",
       "sourceLine": 23,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHyperlinkCommand.cs#L23"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelHyperlinkCommand.cs#L23"
     },
     {
       "name": "Set-OfficeExcelInternalLinks",
@@ -1178,7 +1178,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelInternalLinksCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelInternalLinksCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelInternalLinksCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelInternalLinksByHeader",
@@ -1186,7 +1186,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelInternalLinksByHeaderCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelInternalLinksByHeaderCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelInternalLinksByHeaderCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelMargins",
@@ -1194,7 +1194,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelMarginsCommand.cs",
       "sourceLine": 22,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelMarginsCommand.cs#L22"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelMarginsCommand.cs#L22"
     },
     {
       "name": "Set-OfficeExcelNamedRange",
@@ -1202,7 +1202,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelNamedRangeCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelNamedRangeCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelNamedRangeCommand.cs#L18"
     },
     {
       "name": "Set-OfficeExcelOrientation",
@@ -1210,7 +1210,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelOrientationCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelOrientationCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelOrientationCommand.cs#L16"
     },
     {
       "name": "Set-OfficeExcelPageSetup",
@@ -1218,7 +1218,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelPageSetupCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelPageSetupCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelPageSetupCommand.cs#L16"
     },
     {
       "name": "Set-OfficeExcelRow",
@@ -1226,7 +1226,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelRowCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelRowCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelRowCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelSheetVisibility",
@@ -1234,7 +1234,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelSheetVisibilityCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelSheetVisibilityCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelSheetVisibilityCommand.cs#L16"
     },
     {
       "name": "Set-OfficeExcelSmartHyperlink",
@@ -1242,7 +1242,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelSmartHyperlinkCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelSmartHyperlinkCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelSmartHyperlinkCommand.cs#L16"
     },
     {
       "name": "Set-OfficeExcelUrlLinks",
@@ -1250,7 +1250,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelUrlLinksCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelUrlLinksCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelUrlLinksCommand.cs#L17"
     },
     {
       "name": "Set-OfficeExcelUrlLinksByHeader",
@@ -1258,7 +1258,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelUrlLinksByHeaderCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelUrlLinksByHeaderCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelUrlLinksByHeaderCommand.cs#L18"
     },
     {
       "name": "Set-OfficePowerPointBackground",
@@ -1266,7 +1266,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointBackgroundCommand.cs",
       "sourceLine": 23,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointBackgroundCommand.cs#L23"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointBackgroundCommand.cs#L23"
     },
     {
       "name": "Set-OfficePowerPointLayoutPlaceholderBounds",
@@ -1274,7 +1274,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderBoundsCommand.cs",
       "sourceLine": 29,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderBoundsCommand.cs#L29"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderBoundsCommand.cs#L29"
     },
     {
       "name": "Set-OfficePowerPointLayoutPlaceholderTextMargins",
@@ -1282,7 +1282,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderTextMarginsCommand.cs",
       "sourceLine": 29,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderTextMarginsCommand.cs#L29"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderTextMarginsCommand.cs#L29"
     },
     {
       "name": "Set-OfficePowerPointLayoutPlaceholderTextStyle",
@@ -1290,7 +1290,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderTextStyleCommand.cs",
       "sourceLine": 30,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderTextStyleCommand.cs#L30"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointLayoutPlaceholderTextStyleCommand.cs#L30"
     },
     {
       "name": "Set-OfficePowerPointNotes",
@@ -1298,7 +1298,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointNotesCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointNotesCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointNotesCommand.cs#L18"
     },
     {
       "name": "Set-OfficePowerPointPlaceholderText",
@@ -1306,7 +1306,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointPlaceholderTextCommand.cs",
       "sourceLine": 20,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointPlaceholderTextCommand.cs#L20"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointPlaceholderTextCommand.cs#L20"
     },
     {
       "name": "Set-OfficePowerPointSlideLayout",
@@ -1314,7 +1314,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideLayoutCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideLayoutCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideLayoutCommand.cs#L19"
     },
     {
       "name": "Set-OfficePowerPointSlideSize",
@@ -1322,7 +1322,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideSizeCommand.cs",
       "sourceLine": 25,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideSizeCommand.cs#L25"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideSizeCommand.cs#L25"
     },
     {
       "name": "Set-OfficePowerPointSlideTitle",
@@ -1330,7 +1330,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideTitleCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideTitleCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideTitleCommand.cs#L19"
     },
     {
       "name": "Set-OfficePowerPointSlideTransition",
@@ -1338,7 +1338,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideTransitionCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideTransitionCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointSlideTransitionCommand.cs#L19"
     },
     {
       "name": "Set-OfficePowerPointThemeColor",
@@ -1346,7 +1346,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeColorCommand.cs",
       "sourceLine": 27,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeColorCommand.cs#L27"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeColorCommand.cs#L27"
     },
     {
       "name": "Set-OfficePowerPointThemeFonts",
@@ -1354,7 +1354,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeFontsCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeFontsCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeFontsCommand.cs#L18"
     },
     {
       "name": "Set-OfficePowerPointThemeName",
@@ -1362,7 +1362,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeNameCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeNameCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointThemeNameCommand.cs#L18"
     },
     {
       "name": "Set-OfficeWordBackground",
@@ -1370,7 +1370,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordBackgroundCommand.cs",
       "sourceLine": 18,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordBackgroundCommand.cs#L18"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordBackgroundCommand.cs#L18"
     },
     {
       "name": "Set-OfficeWordDocumentProperty",
@@ -1378,7 +1378,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordDocumentPropertyCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordDocumentPropertyCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordDocumentPropertyCommand.cs#L17"
     },
     {
       "name": "Set-OfficeWordTableOfContent",
@@ -1386,7 +1386,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordTableOfContentCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordTableOfContentCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/SetOfficeWordTableOfContentCommand.cs#L17"
     },
     {
       "name": "Unprotect-OfficeExcelSheet",
@@ -1394,7 +1394,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Excel/UnprotectOfficeExcelSheetCommand.cs",
       "sourceLine": 16,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Excel/UnprotectOfficeExcelSheetCommand.cs#L16"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Excel/UnprotectOfficeExcelSheetCommand.cs#L16"
     },
     {
       "name": "Update-OfficePowerPointText",
@@ -1404,7 +1404,7 @@
       ],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/PowerPoint/UpdateOfficePowerPointTextCommand.cs",
       "sourceLine": 19,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/PowerPoint/UpdateOfficePowerPointTextCommand.cs#L19"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/PowerPoint/UpdateOfficePowerPointTextCommand.cs#L19"
     },
     {
       "name": "Update-OfficeWordFields",
@@ -1412,7 +1412,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/UpdateOfficeWordFieldsCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/UpdateOfficeWordFieldsCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/UpdateOfficeWordFieldsCommand.cs#L17"
     },
     {
       "name": "Update-OfficeWordTableOfContent",
@@ -1420,7 +1420,7 @@
       "aliases": [],
       "sourcePath": "Sources/PSWriteOffice/Cmdlets/Word/UpdateOfficeWordTableOfContentCommand.cs",
       "sourceLine": 17,
-      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/1c80857e9034db437b9ea12188445979d97e16a9/Sources/PSWriteOffice/Cmdlets/Word/UpdateOfficeWordTableOfContentCommand.cs#L17"
+      "sourceUrl": "https://github.com/EvotecIT/PSWriteOffice/blob/b127e9a042422edc94e403861d17fadaeef505f4/Sources/PSWriteOffice/Cmdlets/Word/UpdateOfficeWordTableOfContentCommand.cs#L17"
     }
   ]
 }

--- a/WebsiteArtifacts/project-manifest.json
+++ b/WebsiteArtifacts/project-manifest.json
@@ -7,8 +7,8 @@
   "status": "active",
   "listed": false,
   "version": "0.3.0",
-  "generatedAt": "2026-04-03T22:18:16.1005548+00:00",
-  "commit": "1c80857e9034db437b9ea12188445979d97e16a9",
+  "generatedAt": "2026-04-04T06:36:10.7316670+00:00",
+  "commit": "b127e9a042422edc94e403861d17fadaeef505f4",
   "links": {
     "source": "https://github.com/EvotecIT/PSWriteOffice"
   },


### PR DESCRIPTION
## What changed
- bump PSWriteOffice fallback NuGet references to the latest published OfficeIMO packages
- align the package-mode dependency graph with the OfficeIMO release that just shipped

## Why
PSWriteOffice should consume the released OfficeIMO fixes even when building without a local OfficeIMO source checkout.

## Validation
- `dotnet build Sources/PSWriteOffice.sln /p:OfficeIMORoot=C:\Support\GitHub\_missing_officeimo`

## Notes
- Refs #12
- Supports the release integration path for the latest OfficeIMO publish
- No issue-closing keywords yet because release is still pending.
