### PR TITLE
Stop mutating PR branches during PowerShell CI

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -47,6 +47,7 @@ jobs:
         shell: pwsh
 
       - name: Commit refreshed PSD1
+        if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}


### PR DESCRIPTION
## Summary
- stop the PSD1 refresh step from auto-committing on pull_request runs
- keep PR workflows generating refreshed manifest artifacts for downstream test jobs
- avoid invalidating PR checks by moving the branch head mid-run

## Testing
- python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/test-powershell.yml').read_text(encoding='utf-8')); print('YAML OK')"
