### PR TITLE
Add FilePath alias to Save-OfficeWord

### DIFF
--- a/Docs/Save-OfficeWord.md
+++ b/Docs/Save-OfficeWord.md
@@ -66,7 +66,7 @@ Optional save-as path.
 ```yaml
 Type: String
 Parameter Sets: __AllParameterSets
-Aliases: None
+Aliases: FilePath
 Possible values: 
 
 Required: False

--- a/Sources/PSWriteOffice/Cmdlets/Word/SaveOfficeWordCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/SaveOfficeWordCommand.cs
@@ -22,6 +22,7 @@ public sealed class SaveOfficeWordCommand : PSCmdlet
 
     /// <summary>Optional save-as path.</summary>
     [Parameter]
+    [Alias("FilePath")]
     public string? Path { get; set; }
 
     /// <summary>Open the document after saving.</summary>


### PR DESCRIPTION
## Summary
- add `FilePath` as an alias for `Save-OfficeWord -Path`
- refresh the generated command documentation for `Save-OfficeWord`

## Context
Issue #76 used `Save-OfficeWord -FilePath`, while the current command only exposed `-Path`. This restores the compatibility alias without adding document conversion logic to PSWriteOffice. The actual DOTX to DOCX save fix is handled in OfficeIMO.

Related: #76
Depends on: EvotecIT/OfficeIMO#1782

## Validation
- dotnet build C:\Support\GitHub\PSWriteOffice\Sources\PSWriteOffice\PSWriteOffice.csproj -c Release -f net8.0 --no-restore
