### PR TITLE
Update PSWriteOffice OfficeIMO dependencies

### DIFF
--- a/Examples/Csv/Example-CsvAdvanced.ps1
+++ b/Examples/Csv/Example-CsvAdvanced.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Csv/Example-CsvBasic.ps1
+++ b/Examples/Csv/Example-CsvBasic.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Example-PlaceholderClasses.ps1
+++ b/Examples/Example-PlaceholderClasses.ps1
@@ -1,5 +1,9 @@
-Import-Module "$PSScriptRoot/../PSWriteOffice.psd1" -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    "$PSScriptRoot/../PSWriteOffice.psd1"
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 # Instantiate placeholder service and cmdlet
 $service = [PSWriteOffice.Services.Word.WordDocumentService]::new()
 $cmdlet = [PSWriteOffice.Cmdlets.Word.GetOfficeWordCommand]::new()

--- a/Examples/ExamplePowerPoint01-AddSlides.ps1
+++ b/Examples/ExamplePowerPoint01-AddSlides.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/ExamplePowerPoint02-Basic.ps1
+++ b/Examples/ExamplePowerPoint02-Basic.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/ExamplePowerPoint04-Text.ps1
+++ b/Examples/ExamplePowerPoint04-Text.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/ExamplePowerPoint05-Load.ps1
+++ b/Examples/ExamplePowerPoint05-Load.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/ExamplePowerPoint06-RemoveSlide.ps1
+++ b/Examples/ExamplePowerPoint06-RemoveSlide.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/ExamplePowerPoint07-WhatIf.ps1
+++ b/Examples/ExamplePowerPoint07-WhatIf.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/ExamplePowerPoint08-TablesAndShapes.ps1
+++ b/Examples/ExamplePowerPoint08-TablesAndShapes.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/ExamplePowerPoint09-Placeholders.ps1
+++ b/Examples/ExamplePowerPoint09-Placeholders.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/ExamplePowerPoint10-Dsl.ps1
+++ b/Examples/ExamplePowerPoint10-Dsl.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/ExamplePowerPoint11-InspectionDsl.ps1
+++ b/Examples/ExamplePowerPoint11-InspectionDsl.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/ExamplePowerPoint12-LayoutDsl.ps1
+++ b/Examples/ExamplePowerPoint12-LayoutDsl.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/ExamplePowerPoint13-LayoutPlaceholderAliases.ps1
+++ b/Examples/ExamplePowerPoint13-LayoutPlaceholderAliases.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Excel/Example-ExcelAdvanced.ps1
+++ b/Examples/Excel/Example-ExcelAdvanced.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Excel/Example-ExcelAliasDsl.ps1
+++ b/Examples/Excel/Example-ExcelAliasDsl.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Excel/Example-ExcelBasic.ps1
+++ b/Examples/Excel/Example-ExcelBasic.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Excel/Example-ExcelChartFormatting.ps1
+++ b/Examples/Excel/Example-ExcelChartFormatting.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Excel/Example-ExcelInternalLinks.ps1
+++ b/Examples/Excel/Example-ExcelInternalLinks.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Excel/Example-ExcelLinksAndImages.ps1
+++ b/Examples/Excel/Example-ExcelLinksAndImages.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Excel/Example-ExcelNavigationAndRanges.ps1
+++ b/Examples/Excel/Example-ExcelNavigationAndRanges.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Excel/Example-ExcelReadObjects.ps1
+++ b/Examples/Excel/Example-ExcelReadObjects.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Excel/Example-ExcelTablesAndRanges.ps1
+++ b/Examples/Excel/Example-ExcelTablesAndRanges.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Excel/Example-ExcelUrlLinks.ps1
+++ b/Examples/Excel/Example-ExcelUrlLinks.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Markdown/Example-MarkdownAdvanced.ps1
+++ b/Examples/Markdown/Example-MarkdownAdvanced.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Markdown/Example-MarkdownBasic.ps1
+++ b/Examples/Markdown/Example-MarkdownBasic.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $markdown = @(
     [PSCustomObject]@{ Name = 'Alpha'; Value = 1 }
     [PSCustomObject]@{ Name = 'Beta'; Value = 2 }

--- a/Examples/Markdown/Example-MarkdownDsl.ps1
+++ b/Examples/Markdown/Example-MarkdownDsl.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/PowerPoint/Example-PowerPointBackgroundsAndLayout.ps1
+++ b/Examples/PowerPoint/Example-PowerPointBackgroundsAndLayout.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/PowerPoint/Example-PowerPointCharts.ps1
+++ b/Examples/PowerPoint/Example-PowerPointCharts.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/PowerPoint/Example-PowerPointCopySlides.ps1
+++ b/Examples/PowerPoint/Example-PowerPointCopySlides.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/PowerPoint/Example-PowerPointSectionsAndImport.ps1
+++ b/Examples/PowerPoint/Example-PowerPointSectionsAndImport.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/PowerPoint/Example-PowerPointThemeAndLayout.ps1
+++ b/Examples/PowerPoint/Example-PowerPointThemeAndLayout.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/PowerPoint/Example-PowerPointTransitionsAndSizing.ps1
+++ b/Examples/PowerPoint/Example-PowerPointTransitionsAndSizing.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Word/Example-WordAdvanced.ps1
+++ b/Examples/Word/Example-WordAdvanced.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Word/Example-WordAliasDsl.ps1
+++ b/Examples/Word/Example-WordAliasDsl.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Word/Example-WordBasic.ps1
+++ b/Examples/Word/Example-WordBasic.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Word/Example-WordCharts.ps1
+++ b/Examples/Word/Example-WordCharts.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Word/Example-WordFind.ps1
+++ b/Examples/Word/Example-WordFind.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Word/Example-WordHtmlConvert.ps1
+++ b/Examples/Word/Example-WordHtmlConvert.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Word/Example-WordLineBreaks.ps1
+++ b/Examples/Word/Example-WordLineBreaks.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Word/Example-WordMarkdownConvert.ps1
+++ b/Examples/Word/Example-WordMarkdownConvert.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Word/Example-WordProtectionWatermark.ps1
+++ b/Examples/Word/Example-WordProtectionWatermark.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Word/Example-WordReadDocument.ps1
+++ b/Examples/Word/Example-WordReadDocument.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 $docPath = Join-Path $documents 'Word-AliasDsl.docx'
 if (-not (Test-Path $docPath)) {

--- a/Examples/Word/Example-WordReplaceText.ps1
+++ b/Examples/Word/Example-WordReplaceText.ps1
@@ -1,5 +1,9 @@
-Import-Module "$PSScriptRoot\..\..\PSWriteOffice.psd1" -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    "$PSScriptRoot\..\..\PSWriteOffice.psd1"
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $Path = Join-Path $PSScriptRoot 'Example-WordReplaceText.docx'
 
 New-OfficeWord -Path $Path {

--- a/Examples/Word/Example-WordTableCalculatedColumns.ps1
+++ b/Examples/Word/Example-WordTableCalculatedColumns.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/Examples/Word/Example-WordTableCells.ps1
+++ b/Examples/Word/Example-WordTableCells.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $path = Join-Path $PSScriptRoot 'Example-WordTableCells.docx'
 $imagePath = Join-Path $PSScriptRoot 'Example-WordTableCells.png'
 $fixturePath = Join-Path $PSScriptRoot 'Example-WordTableCells.fixture.png'

--- a/Examples/Word/Example-WordTableConditions.ps1
+++ b/Examples/Word/Example-WordTableConditions.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/PSWriteOffice.Tests.ps1
+++ b/PSWriteOffice.Tests.ps1
@@ -54,11 +54,23 @@ foreach ($Module in $PSDInformation.RequiredModules) {
 }
 Write-Color
 
+$previousDevelopmentFlag = $env:PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES
+$developmentOutputPath = Join-Path $ResolvedModulePath 'Sources/PSWriteOffice/bin/Debug'
+if (-not $previousDevelopmentFlag -and (Test-Path -LiteralPath $developmentOutputPath)) {
+    $env:PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES = 'true'
+}
+
 try {
     Import-Module $PrimaryModule.FullName -Force -Global -ErrorAction Stop
     Import-Module Pester -Force -ErrorAction Stop
 } catch {
     throw "Failed to import module $ModuleName"
+} finally {
+    if ($null -eq $previousDevelopmentFlag) {
+        Remove-Item env:PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES -ErrorAction SilentlyContinue
+    } else {
+        $env:PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES = $previousDevelopmentFlag
+    }
 }
 
 $env:PSWRITEOFFICE_MODULE_MANIFEST = $PrimaryModule.FullName

--- a/PSWriteOffice.psm1
+++ b/PSWriteOffice.psm1
@@ -1,6 +1,6 @@
 ﻿# to speed up development adding direct path to binaries, instead of the the Lib folder
 $DevelopmentPath = Join-Path $PSScriptRoot 'Sources\PSWriteOffice\bin\Debug'
-$Development = Test-Path $DevelopmentPath
+$Development = $env:PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES -eq 'true' -and (Test-Path $DevelopmentPath)
 $DevelopmentFolderCore = "net8.0"
 $DevelopmentFolderDefault = "net472"
 $BinaryModules = @(

--- a/Sources/PSWriteOffice/PSWriteOffice.csproj
+++ b/Sources/PSWriteOffice/PSWriteOffice.csproj
@@ -67,12 +67,12 @@
         <ProjectReference Include="$(OfficeIMORoot)\OfficeIMO.Word.Html\OfficeIMO.Word.Html.csproj" />
     </ItemGroup>
     <ItemGroup Condition="!Exists('$(OfficeIMORoot)\OfficeIMO.Word\OfficeIMO.Word.csproj')">
-        <PackageReference Include="OfficeIMO.Word" Version="1.0.41" />
-        <PackageReference Include="OfficeIMO.Word.Markdown" Version="1.0.15" />
-        <PackageReference Include="OfficeIMO.Excel" Version="0.6.21" />
-        <PackageReference Include="OfficeIMO.PowerPoint" Version="1.0.16" />
-        <PackageReference Include="OfficeIMO.Markdown" Version="0.6.8" />
-        <PackageReference Include="OfficeIMO.CSV" Version="0.1.21" />
-        <PackageReference Include="OfficeIMO.Word.Html" Version="1.0.15" />
+        <PackageReference Include="OfficeIMO.Word" Version="1.0.45" />
+        <PackageReference Include="OfficeIMO.Word.Markdown" Version="1.0.19" />
+        <PackageReference Include="OfficeIMO.Excel" Version="0.6.25" />
+        <PackageReference Include="OfficeIMO.PowerPoint" Version="1.0.20" />
+        <PackageReference Include="OfficeIMO.Markdown" Version="0.6.12" />
+        <PackageReference Include="OfficeIMO.CSV" Version="0.1.25" />
+        <PackageReference Include="OfficeIMO.Word.Html" Version="1.0.19" />
     </ItemGroup>
 </Project>

--- a/Tests/Csv.Tests.ps1
+++ b/Tests/Csv.Tests.ps1
@@ -4,7 +4,7 @@
     } else {
         Join-Path $PSScriptRoot '..\PSWriteOffice.psd1'
     }
-    Import-Module $ModuleManifest -Force -Global
+    Import-Module $ModuleManifest -Global -ErrorAction Stop
 }
 
 Describe 'CSV cmdlets' {

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -4,7 +4,7 @@
     } else {
         Join-Path $PSScriptRoot '..\PSWriteOffice.psd1'
     }
-    Import-Module $ModuleManifest -Force -Global
+    Import-Module $ModuleManifest -Global -ErrorAction Stop
 
     . (Join-Path $PSScriptRoot 'TestHelpers.ps1')
 }

--- a/Tests/Markdown.Tests.ps1
+++ b/Tests/Markdown.Tests.ps1
@@ -4,7 +4,7 @@
     } else {
         Join-Path $PSScriptRoot '..\PSWriteOffice.psd1'
     }
-    Import-Module $ModuleManifest -Force -Global
+    Import-Module $ModuleManifest -Global -ErrorAction Stop
 }
 
 Describe 'Markdown cmdlets' {

--- a/Tests/PowerPoint.Tests.ps1
+++ b/Tests/PowerPoint.Tests.ps1
@@ -4,7 +4,7 @@ BeforeAll {
     } else {
         Join-Path $PSScriptRoot '..\PSWriteOffice.psd1'
     }
-    Import-Module $ModuleManifest -Force -Global
+    Import-Module $ModuleManifest -Global -ErrorAction Stop
 
     . (Join-Path $PSScriptRoot 'TestHelpers.ps1')
 }

--- a/Tests/WordDsl.Tests.ps1
+++ b/Tests/WordDsl.Tests.ps1
@@ -4,7 +4,7 @@ BeforeAll {
     } else {
         Join-Path $PSScriptRoot '..\PSWriteOffice.psd1'
     }
-    Import-Module $ModuleManifest -Force -Global
+    Import-Module $ModuleManifest -Global -ErrorAction Stop
 }
 
 Describe 'Word DSL surface' {

--- a/Tests/WordHtml.Tests.ps1
+++ b/Tests/WordHtml.Tests.ps1
@@ -4,7 +4,7 @@
     } else {
         Join-Path $PSScriptRoot '..\PSWriteOffice.psd1'
     }
-    Import-Module $ModuleManifest -Force -Global
+    Import-Module $ModuleManifest -Global -ErrorAction Stop
 }
 
 Describe 'Word HTML conversions' {

--- a/Tests/WordMarkdown.Tests.ps1
+++ b/Tests/WordMarkdown.Tests.ps1
@@ -4,7 +4,7 @@ BeforeAll {
     } else {
         Join-Path $PSScriptRoot '..\PSWriteOffice.psd1'
     }
-    Import-Module $ModuleManifest -Force -Global
+    Import-Module $ModuleManifest -Global -ErrorAction Stop
 }
 
 Describe 'Word Markdown conversions' {

--- a/Tests/WordReader.Tests.ps1
+++ b/Tests/WordReader.Tests.ps1
@@ -4,7 +4,7 @@
     } else {
         Join-Path $PSScriptRoot '..\PSWriteOffice.psd1'
     }
-    Import-Module $ModuleManifest -Force -Global
+    Import-Module $ModuleManifest -Global -ErrorAction Stop
 
     . (Join-Path $PSScriptRoot 'TestHelpers.ps1')
 }

--- a/WebsiteArtifacts/apidocs/powershell/examples/Csv/Example-CsvAdvanced.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Csv/Example-CsvAdvanced.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Csv/Example-CsvBasic.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Csv/Example-CsvBasic.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Example-PlaceholderClasses.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Example-PlaceholderClasses.ps1
@@ -1,5 +1,9 @@
-Import-Module "$PSScriptRoot/../PSWriteOffice.psd1" -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    "$PSScriptRoot/../PSWriteOffice.psd1"
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 # Instantiate placeholder service and cmdlet
 $service = [PSWriteOffice.Services.Word.WordDocumentService]::new()
 $cmdlet = [PSWriteOffice.Cmdlets.Word.GetOfficeWordCommand]::new()

--- a/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint01-AddSlides.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint01-AddSlides.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint02-Basic.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint02-Basic.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint04-Text.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint04-Text.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint05-Load.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint05-Load.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint06-RemoveSlide.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint06-RemoveSlide.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint07-WhatIf.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint07-WhatIf.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint08-TablesAndShapes.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint08-TablesAndShapes.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint09-Placeholders.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint09-Placeholders.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint10-Dsl.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint10-Dsl.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint11-InspectionDsl.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint11-InspectionDsl.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint12-LayoutDsl.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint12-LayoutDsl.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint13-LayoutPlaceholderAliases.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/ExamplePowerPoint13-LayoutPlaceholderAliases.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot 'Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelAdvanced.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelAdvanced.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelAliasDsl.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelAliasDsl.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelBasic.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelBasic.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelChartFormatting.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelChartFormatting.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelInternalLinks.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelInternalLinks.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelLinksAndImages.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelLinksAndImages.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelNavigationAndRanges.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelNavigationAndRanges.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelReadObjects.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelReadObjects.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelTablesAndRanges.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelTablesAndRanges.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelUrlLinks.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Excel/Example-ExcelUrlLinks.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Markdown/Example-MarkdownAdvanced.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Markdown/Example-MarkdownAdvanced.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Markdown/Example-MarkdownBasic.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Markdown/Example-MarkdownBasic.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $markdown = @(
     [PSCustomObject]@{ Name = 'Alpha'; Value = 1 }
     [PSCustomObject]@{ Name = 'Beta'; Value = 2 }

--- a/WebsiteArtifacts/apidocs/powershell/examples/Markdown/Example-MarkdownDsl.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Markdown/Example-MarkdownDsl.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/PowerPoint/Example-PowerPointBackgroundsAndLayout.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/PowerPoint/Example-PowerPointBackgroundsAndLayout.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/PowerPoint/Example-PowerPointCharts.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/PowerPoint/Example-PowerPointCharts.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/PowerPoint/Example-PowerPointCopySlides.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/PowerPoint/Example-PowerPointCopySlides.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/PowerPoint/Example-PowerPointSectionsAndImport.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/PowerPoint/Example-PowerPointSectionsAndImport.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/PowerPoint/Example-PowerPointThemeAndLayout.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/PowerPoint/Example-PowerPointThemeAndLayout.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/PowerPoint/Example-PowerPointTransitionsAndSizing.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/PowerPoint/Example-PowerPointTransitionsAndSizing.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordAdvanced.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordAdvanced.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordAliasDsl.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordAliasDsl.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordBasic.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordBasic.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordCharts.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordCharts.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordFind.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordFind.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordHtmlConvert.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordHtmlConvert.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordLineBreaks.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordLineBreaks.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordMarkdownConvert.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordMarkdownConvert.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordProtectionWatermark.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordProtectionWatermark.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordReadDocument.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordReadDocument.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 $docPath = Join-Path $documents 'Word-AliasDsl.docx'
 if (-not (Test-Path $docPath)) {

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordReplaceText.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordReplaceText.ps1
@@ -1,5 +1,9 @@
-Import-Module "$PSScriptRoot\..\..\PSWriteOffice.psd1" -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    "$PSScriptRoot\..\..\PSWriteOffice.psd1"
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $Path = Join-Path $PSScriptRoot 'Example-WordReplaceText.docx'
 
 New-OfficeWord -Path $Path {

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordTableCalculatedColumns.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordTableCalculatedColumns.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordTableCells.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordTableCells.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $path = Join-Path $PSScriptRoot 'Example-WordTableCells.docx'
 $imagePath = Join-Path $PSScriptRoot 'Example-WordTableCells.png'
 $fixturePath = Join-Path $PSScriptRoot 'Example-WordTableCells.fixture.png'

--- a/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordTableConditions.ps1
+++ b/WebsiteArtifacts/apidocs/powershell/examples/Word/Example-WordTableConditions.ps1
@@ -1,5 +1,9 @@
-Import-Module (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1') -Force
-
+$modulePath = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+    $env:PSWRITEOFFICE_MODULE_MANIFEST
+} else {
+    (Join-Path $PSScriptRoot '..\..\PSWriteOffice.psd1')
+}
+if (-not (Get-Module -Name PSWriteOffice)) { Import-Module $modulePath -ErrorAction Stop }
 $documents = Join-Path $PSScriptRoot '..\Documents'
 New-Item -Path $documents -ItemType Directory -Force | Out-Null
 


### PR DESCRIPTION
## Summary
- Bump PSWriteOffice package-mode OfficeIMO dependencies to the May 1 OfficeIMO release, including OfficeIMO.Word 1.0.45 with the DOTX save fix.
- Gate development binary loading behind PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES so packaged/import validation does not accidentally pick local Debug binaries.
- Make examples/tests import an explicit module manifest when provided, which helps validate packaged artifacts cleanly.

## Validation
- dotnet restore Sources\\PSWriteOffice\\PSWriteOffice.csproj /p:OfficeIMORoot=.missing-officeimo
- dotnet build Sources\\PSWriteOffice\\PSWriteOffice.csproj -c Release /p:OfficeIMORoot=.missing-officeimo --no-restore
- dotnet build .\\Sources\\PSWriteOffice.sln -c Debug /p:OfficeIMORoot=.missing-officeimo
- pwsh -NoLogo -NoProfile -File .\\PSWriteOffice.Tests.ps1 (59 passed)
- pwsh -NoLogo -NoProfile -File .\\Build\\Validate-PackagedArtefact.ps1 (imports passed in PowerShell 7 and Windows PowerShell; existing local binary-conflict advisories only)

Refs #76