### PR TITLE
Update OfficeIMO dependencies

### DIFF
--- a/Build/Manage-PSWriteOffice.ps1
+++ b/Build/Manage-PSWriteOffice.ps1
@@ -16,7 +16,7 @@
         # ID used to uniquely identify this module
         GUID                   = 'd75a279d-30c2-4c2d-ae0d-12f1f3bf4d39'
         # Version number of this module.
-        ModuleVersion          = '0.X.0'
+        ModuleVersion          = '1.0.0'
         # Author of this module
         Author                 = 'Przemyslaw Klys'
         # Company or vendor of this module

--- a/PSWriteOffice.psd1
+++ b/PSWriteOffice.psd1
@@ -9,7 +9,7 @@
     DotNetFrameworkVersion = '4.7.2'
     FunctionsToExport      = @()
     GUID                   = 'd75a279d-30c2-4c2d-ae0d-12f1f3bf4d39'
-    ModuleVersion          = '0.3.0'
+    ModuleVersion          = '1.0.0'
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{

--- a/README.MD
+++ b/README.MD
@@ -235,67 +235,12 @@ Get-OfficePowerPointShape -Presentation $ppt -Index 0
 
 ## Documentation 📚
 
-Start here:
+Use the examples in this README for the first pass, then move to the generated command reference when you need exact parameters and pipeline behavior.
 
-- [OVERVIEW.md](OVERVIEW.md)
-- [Docs/Readme.md](Docs/Readme.md)
-
-Recommended docs:
-
-- [Docs/New-OfficeWord.md](Docs/New-OfficeWord.md)
-- [Docs/Update-OfficeWordText.md](Docs/Update-OfficeWordText.md)
-- [Docs/Add-OfficeWordChart.md](Docs/Add-OfficeWordChart.md)
-- [Docs/New-OfficeExcel.md](Docs/New-OfficeExcel.md)
-- [Docs/New-OfficePowerPoint.md](Docs/New-OfficePowerPoint.md)
-- [Docs/ConvertTo-OfficeWordMarkdown.md](Docs/ConvertTo-OfficeWordMarkdown.md)
-- [Docs/ConvertFrom-OfficeWordMarkdown.md](Docs/ConvertFrom-OfficeWordMarkdown.md)
-- [Docs/Add-OfficeExcelTableOfContents.md](Docs/Add-OfficeExcelTableOfContents.md)
-- [Docs/Get-OfficeExcelRange.md](Docs/Get-OfficeExcelRange.md)
-- [Docs/Get-OfficeExcelUsedRange.md](Docs/Get-OfficeExcelUsedRange.md)
-- [Docs/Set-OfficeExcelChartLegend.md](Docs/Set-OfficeExcelChartLegend.md)
-- [Docs/Set-OfficeExcelChartDataLabels.md](Docs/Set-OfficeExcelChartDataLabels.md)
-- [Docs/Set-OfficeExcelChartStyle.md](Docs/Set-OfficeExcelChartStyle.md)
-- [Docs/Add-OfficeExcelImageFromUrl.md](Docs/Add-OfficeExcelImageFromUrl.md)
-- [Docs/Set-OfficeExcelSmartHyperlink.md](Docs/Set-OfficeExcelSmartHyperlink.md)
-- [Docs/Set-OfficeExcelHostHyperlink.md](Docs/Set-OfficeExcelHostHyperlink.md)
-- [Docs/Set-OfficeExcelInternalLinks.md](Docs/Set-OfficeExcelInternalLinks.md)
-- [Docs/Set-OfficeExcelInternalLinksByHeader.md](Docs/Set-OfficeExcelInternalLinksByHeader.md)
-- [Docs/Set-OfficeExcelUrlLinks.md](Docs/Set-OfficeExcelUrlLinks.md)
-- [Docs/Set-OfficeExcelUrlLinksByHeader.md](Docs/Set-OfficeExcelUrlLinksByHeader.md)
-- [Docs/Get-OfficePowerPointSection.md](Docs/Get-OfficePowerPointSection.md)
-- [Docs/Get-OfficePowerPointTheme.md](Docs/Get-OfficePowerPointTheme.md)
-- [Docs/Set-OfficePowerPointSlideTransition.md](Docs/Set-OfficePowerPointSlideTransition.md)
-- [Docs/Set-OfficePowerPointSlideSize.md](Docs/Set-OfficePowerPointSlideSize.md)
-- [Docs/Set-OfficePowerPointSlideLayout.md](Docs/Set-OfficePowerPointSlideLayout.md)
-- [Docs/Set-OfficePowerPointThemeColor.md](Docs/Set-OfficePowerPointThemeColor.md)
-- [Docs/Set-OfficePowerPointThemeFonts.md](Docs/Set-OfficePowerPointThemeFonts.md)
-- [Docs/Set-OfficePowerPointThemeName.md](Docs/Set-OfficePowerPointThemeName.md)
-- [Docs/Update-OfficePowerPointText.md](Docs/Update-OfficePowerPointText.md)
-- [Docs/Copy-OfficePowerPointSlide.md](Docs/Copy-OfficePowerPointSlide.md)
-- [Docs/Import-OfficePowerPointSlide.md](Docs/Import-OfficePowerPointSlide.md)
-
-Recommended examples:
-
-- [Examples/Word/Example-WordBasic.ps1](Examples/Word/Example-WordBasic.ps1)
-- [Examples/Word/Example-WordReplaceText.ps1](Examples/Word/Example-WordReplaceText.ps1)
-- [Examples/Word/Example-WordCharts.ps1](Examples/Word/Example-WordCharts.ps1)
-- [Examples/Word/Example-WordLineBreaks.ps1](Examples/Word/Example-WordLineBreaks.ps1)
-- [Examples/Word/Example-WordTableCalculatedColumns.ps1](Examples/Word/Example-WordTableCalculatedColumns.ps1)
-- [Examples/Word/Example-WordMarkdownConvert.ps1](Examples/Word/Example-WordMarkdownConvert.ps1)
-- [Examples/Excel/Example-ExcelBasic.ps1](Examples/Excel/Example-ExcelBasic.ps1)
-- [Examples/Excel/Example-ExcelAdvanced.ps1](Examples/Excel/Example-ExcelAdvanced.ps1)
-- [Examples/Excel/Example-ExcelNavigationAndRanges.ps1](Examples/Excel/Example-ExcelNavigationAndRanges.ps1)
-- [Examples/Excel/Example-ExcelChartFormatting.ps1](Examples/Excel/Example-ExcelChartFormatting.ps1)
-- [Examples/Excel/Example-ExcelLinksAndImages.ps1](Examples/Excel/Example-ExcelLinksAndImages.ps1)
-- [Examples/Excel/Example-ExcelInternalLinks.ps1](Examples/Excel/Example-ExcelInternalLinks.ps1)
-- [Examples/Excel/Example-ExcelUrlLinks.ps1](Examples/Excel/Example-ExcelUrlLinks.ps1)
-- [Examples/Markdown/Example-MarkdownDsl.ps1](Examples/Markdown/Example-MarkdownDsl.ps1)
-- [Examples/ExamplePowerPoint10-Dsl.ps1](Examples/ExamplePowerPoint10-Dsl.ps1)
-- [Examples/ExamplePowerPoint12-LayoutDsl.ps1](Examples/ExamplePowerPoint12-LayoutDsl.ps1)
-- [Examples/PowerPoint/Example-PowerPointTransitionsAndSizing.ps1](Examples/PowerPoint/Example-PowerPointTransitionsAndSizing.ps1)
-- [Examples/PowerPoint/Example-PowerPointSectionsAndImport.ps1](Examples/PowerPoint/Example-PowerPointSectionsAndImport.ps1)
-- [Examples/PowerPoint/Example-PowerPointCopySlides.ps1](Examples/PowerPoint/Example-PowerPointCopySlides.ps1)
-- [Examples/PowerPoint/Example-PowerPointThemeAndLayout.ps1](Examples/PowerPoint/Example-PowerPointThemeAndLayout.ps1)
+- [OVERVIEW.md](OVERVIEW.md) explains the project scope and design direction.
+- [Docs/Readme.md](Docs/Readme.md) is the generated cmdlet index.
+- [Docs](Docs) contains one generated page per command.
+- [Examples](Examples) contains runnable scripts grouped by Word, Excel, PowerPoint, Markdown, CSV, and shared samples.
 
 ## Build and Test 🧪
 
@@ -306,32 +251,6 @@ pwsh -NoLogo -NoProfile -File .\Build\Validate-PackagedArtefact.ps1
 ```
 
 Development loading is handled through [PSWriteOffice.psm1](PSWriteOffice.psm1), which prefers the local debug build in `Sources\PSWriteOffice\bin\Debug\`.
-
-## Roadmap and Next High-Value Additions 🛣️
-
-Near-term focus stays on Word, Excel, PowerPoint, Markdown, and CSV. PDF and Visio remain intentionally out of scope for now because the risk/rework ratio is much higher.
-
-Highest-value next additions from `OfficeIMO` are:
-
-- Higher-level PowerPoint background/design helpers that build on the newer theme, layout, and slide reuse workflows
-- Additional Word and Excel inspection helpers where the underlying C# APIs are already stable
-- More Excel dashboard/reporting helpers on top of the newer link, URL, and TOC primitives
-
-The general direction is clear: keep PSWriteOffice thin, predictable, and PowerShell-native while steadily exposing the strongest `OfficeIMO` capabilities.
-
-## Dependency Model 🔗
-
-`PSWriteOffice` should stay aligned with `OfficeIMO.*` rather than re-owning lower-level behavior or duplicating file-format logic.
-
-- `OfficeIMO.Word`
-- `OfficeIMO.Word.Markdown`
-- `OfficeIMO.Excel`
-- `OfficeIMO.PowerPoint`
-- `OfficeIMO.Markdown`
-- `OfficeIMO.CSV`
-- `OfficeIMO.Word.Html`
-
-That keeps feature ownership centralized and reduces drift between the PowerShell layer and the underlying document engine.
 
 ## License
 

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointShapeCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointShapeCommand.cs
@@ -2,8 +2,8 @@ using System;
 using System.Management.Automation;
 using System.Reflection;
 using DocumentFormat.OpenXml.Drawing;
+using OfficeIMO.Drawing;
 using OfficeIMO.PowerPoint;
-using SixLabors.ImageSharp;
 using PSWriteOffice.Services.PowerPoint;
 
 namespace PSWriteOffice.Cmdlets.PowerPoint;
@@ -116,9 +116,7 @@ public sealed class AddOfficePowerPointShapeCommand : PSCmdlet
             return null;
         }
 
-        var parsed = Color.Parse(color);
-        var hex = parsed.ToHex().ToLowerInvariant();
-        return hex.Length > 6 ? hex.Substring(0, 6) : hex;
+        return OfficeColor.Parse(color!).ToRgbHex().ToLowerInvariant();
     }
 
     private static ShapeTypeValues ResolveShapeType(string? shapeType)

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointBackgroundCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SetOfficePowerPointBackgroundCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Management.Automation;
+using OfficeIMO.Drawing;
 using OfficeIMO.PowerPoint;
 using PSWriteOffice.Services.PowerPoint;
 namespace PSWriteOffice.Cmdlets.PowerPoint;
@@ -86,8 +87,6 @@ public sealed class SetOfficePowerPointBackgroundCommand : PSCmdlet
             throw new PSArgumentException("Color cannot be empty.", nameof(Color));
         }
 
-        var parsed = SixLabors.ImageSharp.Color.Parse(color);
-        var hex = parsed.ToHex().ToLowerInvariant();
-        return hex.Length > 6 ? hex.Substring(0, 6) : hex;
+        return OfficeColor.Parse(color).ToRgbHex().ToLowerInvariant();
     }
 }

--- a/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordChartCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordChartCommand.cs
@@ -5,9 +5,9 @@ using System.Globalization;
 using System.Linq;
 using System.Management.Automation;
 using DocumentFormat.OpenXml.Drawing.Charts;
+using OfficeIMO.Drawing;
 using OfficeIMO.Word;
 using PSWriteOffice.Services.Word;
-using SixLabors.ImageSharp;
 
 namespace PSWriteOffice.Cmdlets.Word;
 
@@ -264,13 +264,13 @@ public sealed class AddOfficeWordChartCommand : PSCmdlet
         }
     }
 
-    private Color ResolveSeriesColor(int index)
+    private OfficeColor ResolveSeriesColor(int index)
     {
         var colorValue = index < SeriesColor.Length && !string.IsNullOrWhiteSpace(SeriesColor[index])
             ? SeriesColor[index]
             : DefaultSeriesPalette[index % DefaultSeriesPalette.Length];
 
-        return Color.Parse(colorValue);
+        return OfficeColor.Parse(colorValue);
     }
 
     private static LegendPositionValues ResolveLegendPosition(string position)

--- a/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableConditionCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableConditionCommand.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Management.Automation;
+using OfficeIMO.Drawing;
 using OfficeIMO.Word;
 using PSWriteOffice.Services.Word;
-using SixLabors.ImageSharp;
 
 namespace PSWriteOffice.Cmdlets.Word;
 
@@ -57,8 +57,6 @@ public sealed class AddOfficeWordTableConditionCommand : PSCmdlet
             return null;
         }
 
-        var parsed = Color.Parse(color);
-        var hex = parsed.ToHex().ToLowerInvariant();
-        return hex.Length > 6 ? hex.Substring(0, 6) : hex;
+        return OfficeColor.Parse(color!).ToRgbHex().ToLowerInvariant();
     }
 }

--- a/Sources/PSWriteOffice/PSWriteOffice.csproj
+++ b/Sources/PSWriteOffice/PSWriteOffice.csproj
@@ -57,7 +57,8 @@
         <Copy SourceFiles="@(DocFiles)" DestinationFolder="$(PublishDir)" />
     </Target>
 
-    <ItemGroup Condition="Exists('$(OfficeIMORoot)\OfficeIMO.Word\OfficeIMO.Word.csproj')">
+    <ItemGroup Condition="Exists('$(OfficeIMORoot)\OfficeIMO.Drawing\OfficeIMO.Drawing.csproj') And Exists('$(OfficeIMORoot)\OfficeIMO.Word\OfficeIMO.Word.csproj')">
+        <ProjectReference Include="$(OfficeIMORoot)\OfficeIMO.Drawing\OfficeIMO.Drawing.csproj" />
         <ProjectReference Include="$(OfficeIMORoot)\OfficeIMO.Word\OfficeIMO.Word.csproj" />
         <ProjectReference Include="$(OfficeIMORoot)\OfficeIMO.Word.Markdown\OfficeIMO.Word.Markdown.csproj" />
         <ProjectReference Include="$(OfficeIMORoot)\OfficeIMO.Excel\OfficeIMO.Excel.csproj" />
@@ -66,13 +67,14 @@
         <ProjectReference Include="$(OfficeIMORoot)\OfficeIMO.CSV\OfficeIMO.CSV.csproj" />
         <ProjectReference Include="$(OfficeIMORoot)\OfficeIMO.Word.Html\OfficeIMO.Word.Html.csproj" />
     </ItemGroup>
-    <ItemGroup Condition="!Exists('$(OfficeIMORoot)\OfficeIMO.Word\OfficeIMO.Word.csproj')">
-        <PackageReference Include="OfficeIMO.Word" Version="1.0.45" />
-        <PackageReference Include="OfficeIMO.Word.Markdown" Version="1.0.19" />
-        <PackageReference Include="OfficeIMO.Excel" Version="0.6.25" />
-        <PackageReference Include="OfficeIMO.PowerPoint" Version="1.0.20" />
-        <PackageReference Include="OfficeIMO.Markdown" Version="0.6.12" />
-        <PackageReference Include="OfficeIMO.CSV" Version="0.1.25" />
-        <PackageReference Include="OfficeIMO.Word.Html" Version="1.0.19" />
+    <ItemGroup Condition="!Exists('$(OfficeIMORoot)\OfficeIMO.Drawing\OfficeIMO.Drawing.csproj') Or !Exists('$(OfficeIMORoot)\OfficeIMO.Word\OfficeIMO.Word.csproj')">
+        <PackageReference Include="OfficeIMO.Drawing" Version="1.0.0" />
+        <PackageReference Include="OfficeIMO.Word" Version="1.0.46" />
+        <PackageReference Include="OfficeIMO.Word.Markdown" Version="1.0.20" />
+        <PackageReference Include="OfficeIMO.Excel" Version="0.6.26" />
+        <PackageReference Include="OfficeIMO.PowerPoint" Version="1.0.21" />
+        <PackageReference Include="OfficeIMO.Markdown" Version="0.6.13" />
+        <PackageReference Include="OfficeIMO.CSV" Version="0.1.26" />
+        <PackageReference Include="OfficeIMO.Word.Html" Version="1.0.20" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Bumps the OfficeIMO package references to the latest stable NuGet versions.
- Adds explicit OfficeIMO.Drawing project/package references because PSWriteOffice now consumes the OfficeIMO-native color type directly.
- Guards local OfficeIMO project-reference mode so partial/older local checkouts fall back to NuGet package references instead of failing on a missing Drawing project.
- Updates Word and PowerPoint color parsing code from SixLabors ImageSharp to OfficeIMO.Drawing.OfficeColor for the new API surface.
- Sets the next PSWriteOffice build/module version to 1.0.0.
- Cleans the public README by replacing the long recommended-docs/example dump and internal roadmap/dependency notes with a concise documentation entry point.

## Validation
- dotnet build .\Sources\PSWriteOffice\PSWriteOffice.csproj -c Release --no-restore -p:OfficeIMORoot=C:\MissingOfficeIMO -m:1 -nr:false
- dotnet build .\Sources\PSWriteOffice\PSWriteOffice.csproj -c Release -m:1 -nr:false
- dotnet build .\Sources\PSWriteOffice\PSWriteOffice.csproj -c Release --no-restore -p:OfficeIMORoot=$env:TEMP\PSWriteOfficePartialOfficeIMO -m:1 -nr:false
- pwsh -NoLogo -NoProfile -File .\PSWriteOffice.Tests.ps1
- pwsh -NoLogo -NoProfile -File .\Build\Validate-PackagedArtefact.ps1

## Codex review notes
- Addressed the duplicated OfficeIMO.Drawing project-reference guard feedback.
- Left the duplicated named-color compatibility comments unchanged: this is a 1.0 rewrite, backward compatibility with the previous ImageSharp named-color parser is not a release requirement, and OfficeIMO color coverage may be expanded upstream separately.