### PR TITLE
Enable packaged ALC loading

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -165,6 +165,58 @@ jobs:
             Artefacts/Reports/**
             Artefacts/Unpacked/**
 
+  packaged-alc-conflict:
+    name: 'Windows Packaged ALC conflict'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Install PowerShell modules
+        shell: pwsh
+        run: |
+          Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+          Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+          Install-Module -Name PSPublishModule -Repository PSGallery -MinimumVersion 3.0.5 -Force -SkipPublisherCheck -AllowClobber
+
+      - name: Prepare default-context Open XML conflict
+        shell: pwsh
+        run: |
+          $conflictRoot = Join-Path $env:RUNNER_TEMP 'pswriteoffice-conflict'
+          $packagePath = Join-Path $conflictRoot 'DocumentFormat.OpenXml.2.20.0.nupkg'
+          $extractPath = Join-Path $conflictRoot 'DocumentFormat.OpenXml.2.20.0'
+          New-Item -Path $conflictRoot -ItemType Directory -Force | Out-Null
+          Invoke-WebRequest -Uri 'https://www.nuget.org/api/v2/package/DocumentFormat.OpenXml/2.20.0' -OutFile $packagePath
+          Expand-Archive -LiteralPath $packagePath -DestinationPath $extractPath -Force
+          $openXmlPath = Join-Path $extractPath 'lib\netstandard2.0\DocumentFormat.OpenXml.dll'
+          if (-not (Test-Path -LiteralPath $openXmlPath)) {
+            throw "Conflict Open XML assembly not found: $openXmlPath"
+          }
+          "PSWRITEOFFICE_CONFLICT_OPENXML_PATH=$openXmlPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Build packaged module with ALC
+        env:
+          RefreshPSD1Only: 'false'
+        shell: pwsh
+        run: |
+          $env:OfficeIMORoot = Join-Path (Get-Location) '.missing-officeimo'
+          ./Build/Manage-PSWriteOffice.ps1
+
+      - name: Run packaged ALC conflict test
+        shell: pwsh
+        run: |
+          Import-Module Pester -Force
+          $config = [PesterConfiguration]::Default
+          $config.Run.Path = 'Tests/AssemblyLoadContext.Conflict.Tests.ps1'
+          $config.Run.Exit = $true
+          $config.Output.Verbosity = 'Detailed'
+          Invoke-Pester -Configuration $config
+
   test-ubuntu:
     needs: refresh-psd1
     name: 'Ubuntu PowerShell 7'

--- a/Build/Manage-PSWriteOffice.ps1
+++ b/Build/Manage-PSWriteOffice.ps1
@@ -1,4 +1,33 @@
-﻿Invoke-ModuleBuild -ModuleName 'PSWriteOffice' {
+﻿function Import-PSWriteOfficePSPublishModule {
+    $candidatePaths = @(
+        $env:PSPUBLISHMODULE_MANIFEST
+    ) | Where-Object { $_ }
+
+    $candidateModules = @(
+        foreach ($candidate in $candidatePaths) {
+            if (Test-Path -LiteralPath $candidate) {
+                Get-Item -LiteralPath $candidate
+            }
+        }
+        Get-Module -ListAvailable -Name PSPublishModule | Sort-Object Version -Descending
+    )
+
+    foreach ($candidate in $candidateModules) {
+        Remove-Module -Name PSPublishModule -Force -ErrorAction SilentlyContinue
+        $candidateModulePath = if ($candidate.FullName) { $candidate.FullName } elseif ($candidate.Path) { $candidate.Path } else { [string] $candidate }
+        Import-Module -Name $candidateModulePath -Force -ErrorAction Stop
+        $newConfigurationBuild = Get-Command -Name New-ConfigurationBuild -ErrorAction SilentlyContinue
+        if ($newConfigurationBuild -and $newConfigurationBuild.Parameters.ContainsKey('NETAssemblyLoadContext')) {
+            return
+        }
+    }
+
+    throw 'PSPublishModule with New-ConfigurationBuild -NETAssemblyLoadContext support was not found. Install the current PSPublishModule or set $env:PSPUBLISHMODULE_MANIFEST.'
+}
+
+Import-PSWriteOfficePSPublishModule
+
+Invoke-ModuleBuild -ModuleName 'PSWriteOffice' {
     $signModule = if ($env:PSWRITEOFFICE_SIGN_MODULE) {
         [System.Convert]::ToBoolean($env:PSWRITEOFFICE_SIGN_MODULE)
     } elseif ($env:GITHUB_ACTIONS -eq 'true' -or $env:CI -eq 'true') {
@@ -16,7 +45,7 @@
         # ID used to uniquely identify this module
         GUID                   = 'd75a279d-30c2-4c2d-ae0d-12f1f3bf4d39'
         # Version number of this module.
-        ModuleVersion          = '1.0.0'
+        ModuleVersion          = '1.0.1'
         # Author of this module
         Author                 = 'Przemyslaw Klys'
         # Company or vendor of this module
@@ -85,6 +114,23 @@
 
     New-ConfigurationImportModule -ImportSelf
 
+    $refreshPSD1Only = $false
+    if (-not [string]::IsNullOrWhiteSpace($env:RefreshPSD1Only)) {
+        switch -Regex ($env:RefreshPSD1Only.Trim()) {
+            '^(1|true|yes|on)$' {
+                $refreshPSD1Only = $true
+                break
+            }
+            '^(0|false|no|off)$' {
+                $refreshPSD1Only = $false
+                break
+            }
+            default {
+                throw "RefreshPSD1Only must be a boolean value or numeric flag, but received '$env:RefreshPSD1Only'."
+            }
+        }
+    }
+
     $newConfigurationBuildSplat = @{
         Enable                            = $true
         SignModule                        = $signModule
@@ -93,17 +139,18 @@
         CertificateThumbprint             = if ($signModule) { '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703' } else { $null }
         ResolveBinaryConflicts            = $true
         ResolveBinaryConflictsName        = 'PSWriteOffice'
-        NETProjectPath                    = 'Sources\PSWriteOffice'
         NETProjectName                    = 'PSWriteOffice'
         NETConfiguration                  = 'Release'
         NETFramework                      = 'net8.0', 'net472'
         NETHandleAssemblyWithSameName     = $true
+        NETProjectPath                    = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\Sources\PSWriteOffice\PSWriteOffice.csproj')).Path
+        NETAssemblyLoadContext            = $true
         #NETMergeLibraryDebugging          = $true
         DotSourceLibraries                = $true
         DotSourceClasses                  = $true
         DeleteTargetModuleBeforeBuild     = $true
         NETBinaryModuleDocumentation      = $true
-        RefreshPSD1Only                   = $false
+        RefreshPSD1Only                   = $refreshPSD1Only
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat

--- a/Build/Validate-PackagedArtefact.ps1
+++ b/Build/Validate-PackagedArtefact.ps1
@@ -14,27 +14,29 @@ $ArtefactManifest = Join-Path $ArtefactModulePath 'PSWriteOffice.psd1'
 
 function Import-PSPublishModule {
     $candidatePaths = @(
-        $env:PSPUBLISHMODULE_MANIFEST,
-        'C:\Support\GitHub\PSPublishModule\Module\Artefacts\Unpacked\v3.0.1\Modules\PSPublishModule\PSPublishModule.psd1',
-        'C:\Support\GitHub\PSPublishModule\Module\Artefacts\Unpacked\Modules\PSPublishModule\PSPublishModule.psd1'
+        $env:PSPUBLISHMODULE_MANIFEST
     ) | Where-Object { $_ }
 
-    foreach ($candidate in $candidatePaths) {
-        if (Test-Path -LiteralPath $candidate) {
-            Import-Module -Name $candidate -Force
+    $candidateModules = @(
+        foreach ($candidate in $candidatePaths) {
+            if (Test-Path -LiteralPath $candidate) {
+                Get-Item -LiteralPath $candidate
+            }
+        }
+        Get-Module -ListAvailable -Name PSPublishModule | Sort-Object Version -Descending
+    )
+
+    foreach ($candidate in $candidateModules) {
+        Remove-Module -Name PSPublishModule -Force -ErrorAction SilentlyContinue
+        $candidateModulePath = if ($candidate.FullName) { $candidate.FullName } elseif ($candidate.Path) { $candidate.Path } else { [string] $candidate }
+        Import-Module -Name $candidateModulePath -Force -ErrorAction Stop
+        $newConfigurationBuild = Get-Command -Name New-ConfigurationBuild -ErrorAction SilentlyContinue
+        if ($newConfigurationBuild -and $newConfigurationBuild.Parameters.ContainsKey('NETAssemblyLoadContext')) {
             return
         }
     }
 
-    $availableModule = Get-Module -ListAvailable -Name PSPublishModule |
-        Sort-Object Version -Descending |
-        Select-Object -First 1
-
-    if (-not $availableModule) {
-        throw 'PSPublishModule was not found. Install it from PSGallery or set $env:PSPUBLISHMODULE_MANIFEST to the module manifest path.'
-    }
-
-    Import-Module -Name $availableModule.Path -Force
+    throw 'PSPublishModule with New-ConfigurationBuild -NETAssemblyLoadContext support was not found. Install the current PSPublishModule or set $env:PSPUBLISHMODULE_MANIFEST.'
 }
 
 if (-not $SkipBuild -or -not (Test-Path -LiteralPath $ArtefactManifest)) {

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+#### 1.0.1 - 2026.05.10
+- Added packaged module-scoped AssemblyLoadContext loading for the binary module on PowerShell 7.
+- Added a packaged ALC conflict smoke test that verifies PSWriteOffice and OfficeIMO/Open XML dependencies stay isolated from the default load context.
+
 #### 0.3.0 - 2025.12.29
 - Rebooted on OfficeIMO.* (Word/Excel/PowerPoint/Markdown/CSV/Word.Html) with breaking changes.
 - Removed legacy external dependencies and old cmdlet surface.

--- a/PSWriteOffice.psd1
+++ b/PSWriteOffice.psd1
@@ -9,7 +9,7 @@
     DotNetFrameworkVersion = '4.7.2'
     FunctionsToExport      = @()
     GUID                   = 'd75a279d-30c2-4c2d-ae0d-12f1f3bf4d39'
-    ModuleVersion          = '1.0.0'
+    ModuleVersion          = '1.0.1'
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{

--- a/Sources/PSWriteOffice/PSWriteOffice.csproj
+++ b/Sources/PSWriteOffice/PSWriteOffice.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <Company>Evotec</Company>
         <Authors>Przemyslaw Klys</Authors>
-        <VersionPrefix>1.0.0</VersionPrefix>
+        <VersionPrefix>1.0.1</VersionPrefix>
         <TargetFrameworks>net472;net8.0</TargetFrameworks>
         <AssemblyName>PSWriteOffice</AssemblyName>
 

--- a/Tests/AssemblyLoadContext.Conflict.Tests.ps1
+++ b/Tests/AssemblyLoadContext.Conflict.Tests.ps1
@@ -1,0 +1,87 @@
+Describe 'Packaged AssemblyLoadContext conflict isolation' {
+    It 'loads after a default-context Open XML assembly without sharing the default ALC' {
+        $packagedModuleRoot = Join-Path $PSScriptRoot '..\Artefacts\Unpacked\Modules'
+        $packagedModule = Join-Path $packagedModuleRoot 'PSWriteOffice'
+        $packagedLoader = Join-Path $packagedModule 'Lib\Core\PSWriteOffice.ModuleLoadContext.dll'
+        $conflictOpenXmlPath = $env:PSWRITEOFFICE_CONFLICT_OPENXML_PATH
+
+        if ($PSVersionTable.PSEdition -ne 'Core' -or
+            -not (Test-Path -LiteralPath $packagedLoader) -or
+            [string]::IsNullOrWhiteSpace($conflictOpenXmlPath) -or
+            -not (Test-Path -LiteralPath $conflictOpenXmlPath)) {
+            Set-ItResult -Skipped -Because 'packaged Core artifact and conflict Open XML assembly are required'
+            return
+        }
+
+        $moduleRootLiteral = $packagedModuleRoot.Replace("'", "''")
+        $conflictOpenXmlLiteral = $conflictOpenXmlPath.Replace("'", "''")
+        $script = @"
+`$ErrorActionPreference = 'Stop'
+`$WarningPreference = 'SilentlyContinue'
+`$moduleRoot = '$moduleRootLiteral'
+`$conflictOpenXmlPath = '$conflictOpenXmlLiteral'
+`$env:PSModulePath = `$moduleRoot + [IO.Path]::PathSeparator + `$env:PSModulePath
+
+Add-Type -Path `$conflictOpenXmlPath -ErrorAction Stop
+`$defaultOpenXmlAssembly = [AppDomain]::CurrentDomain.GetAssemblies() |
+    Where-Object { `$_.GetName().Name -eq 'DocumentFormat.OpenXml' } |
+    Select-Object -First 1
+`$defaultOpenXmlAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$defaultOpenXmlAssembly)
+
+Import-Module PSWriteOffice -Force
+`$command = Get-Command New-OfficeWord -ErrorAction Stop
+`$commandAssembly = `$command.ImplementingType.Assembly
+`$commandAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$commandAssembly)
+`$loadedAssemblies = [System.Runtime.Loader.AssemblyLoadContext]::All |
+    ForEach-Object {
+        `$alc = `$_
+        foreach (`$assembly in `$alc.Assemblies) {
+            if (`$assembly.GetName().Name -in @('PSWriteOffice', 'OfficeIMO.Word', 'DocumentFormat.OpenXml')) {
+                [pscustomobject]@{
+                    Assembly = `$assembly.GetName().Name
+                    Version = `$assembly.GetName().Version.ToString()
+                    ALC = `$alc.Name
+                    IsDefault = [object]::ReferenceEquals(`$alc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+                    Location = `$assembly.Location
+                }
+            }
+        }
+    }
+
+[pscustomobject]@{
+    DefaultOpenXmlAssembly = `$defaultOpenXmlAssembly.Location
+    DefaultOpenXmlVersion = `$defaultOpenXmlAssembly.GetName().Version.ToString()
+    DefaultOpenXmlALC = `$defaultOpenXmlAlc.Name
+    DefaultOpenXmlALCIsDefault = [object]::ReferenceEquals(`$defaultOpenXmlAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    NewOfficeWordAssembly = `$commandAssembly.Location
+    NewOfficeWordALC = `$commandAlc.Name
+    NewOfficeWordALCIsDefault = [object]::ReferenceEquals(`$commandAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    LoadedAssemblies = @(`$loadedAssemblies)
+} | ConvertTo-Json -Depth 6 -Compress
+"@
+        $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($script))
+        $output = pwsh -NoProfile -ExecutionPolicy Bypass -EncodedCommand $encoded 2>&1
+        $LASTEXITCODE | Should -Be 0 -Because ($output -join [Environment]::NewLine)
+
+        $json = $output | Where-Object { $_ -is [string] -and $_.TrimStart().StartsWith('{') } | Select-Object -Last 1
+        $json | Should -Not -BeNullOrEmpty -Because ($output -join [Environment]::NewLine)
+        $result = $json | ConvertFrom-Json
+
+        $result.DefaultOpenXmlAssembly | Should -Be $conflictOpenXmlPath
+        $result.DefaultOpenXmlALCIsDefault | Should -BeTrue
+        $result.NewOfficeWordAssembly | Should -BeLike '*\Artefacts\Unpacked\Modules\PSWriteOffice\Lib\Core\PSWriteOffice.dll'
+        $result.NewOfficeWordALC | Should -Be 'PSWriteOffice'
+        $result.NewOfficeWordALCIsDefault | Should -BeFalse
+
+        $loadedAssemblies = @($result.LoadedAssemblies)
+        $psWriteOfficeAssembly = $loadedAssemblies | Where-Object { $_.Assembly -eq 'PSWriteOffice' -and $_.ALC -eq 'PSWriteOffice' } | Select-Object -First 1
+        $officeImoAssembly = $loadedAssemblies | Where-Object { $_.Assembly -eq 'OfficeIMO.Word' -and $_.ALC -eq 'PSWriteOffice' } | Select-Object -First 1
+        $moduleOpenXmlAssembly = $loadedAssemblies | Where-Object { $_.Assembly -eq 'DocumentFormat.OpenXml' -and $_.ALC -eq 'PSWriteOffice' } | Select-Object -First 1
+        $defaultOpenXmlAssembly = $loadedAssemblies | Where-Object { $_.Assembly -eq 'DocumentFormat.OpenXml' -and $_.IsDefault } | Select-Object -First 1
+
+        $psWriteOfficeAssembly.IsDefault | Should -BeFalse
+        $officeImoAssembly.IsDefault | Should -BeFalse
+        $moduleOpenXmlAssembly.IsDefault | Should -BeFalse
+        $defaultOpenXmlAssembly.IsDefault | Should -BeTrue
+    }
+}


### PR DESCRIPTION
## Summary
- enable PSPublishModule module-scoped AssemblyLoadContext packaging for PSWriteOffice on PowerShell 7
- bump PSWriteOffice to 1.0.1 for the release build
- add a packaged ALC conflict smoke test that loads OpenXML 2.20.0 in the default context before importing the packaged module

## Validation
- dotnet build .\Sources\PSWriteOffice.sln --configuration Debug
- .\Build\Manage-PSWriteOffice.ps1 with signing disabled and gallery PSPublishModule 3.0.5+
- .\Build\Validate-PackagedArtefact.ps1 -SkipBuild
- Tests\AssemblyLoadContext.Conflict.Tests.ps1 via Pester