### PR TITLE
Address packaged ALC review feedback

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -191,7 +191,7 @@ jobs:
           $packagePath = Join-Path $conflictRoot 'DocumentFormat.OpenXml.2.20.0.nupkg'
           $extractPath = Join-Path $conflictRoot 'DocumentFormat.OpenXml.2.20.0'
           New-Item -Path $conflictRoot -ItemType Directory -Force | Out-Null
-          Invoke-WebRequest -Uri 'https://www.nuget.org/api/v2/package/DocumentFormat.OpenXml/2.20.0' -OutFile $packagePath
+          Invoke-WebRequest -Uri 'https://www.nuget.org/api/v2/package/DocumentFormat.OpenXml/2.20.0' -OutFile $packagePath -ConnectionTimeoutSeconds 30 -OperationTimeoutSeconds 120
           Expand-Archive -LiteralPath $packagePath -DestinationPath $extractPath -Force
           $openXmlPath = Join-Path $extractPath 'lib\netstandard2.0\DocumentFormat.OpenXml.dll'
           if (-not (Test-Path -LiteralPath $openXmlPath)) {
@@ -208,6 +208,8 @@ jobs:
           ./Build/Manage-PSWriteOffice.ps1
 
       - name: Run packaged ALC conflict test
+        env:
+          PSWRITEOFFICE_REQUIRE_ALC_SMOKE: 'true'
         shell: pwsh
         run: |
           Import-Module Pester -Force

--- a/Build/Manage-PSWriteOffice.ps1
+++ b/Build/Manage-PSWriteOffice.ps1
@@ -1,28 +1,11 @@
 ﻿function Import-PSWriteOfficePSPublishModule {
-    $candidatePaths = @(
-        $env:PSPUBLISHMODULE_MANIFEST
-    ) | Where-Object { $_ }
+    $minimumVersion = [version] '3.0.5'
+    Import-Module -Name PSPublishModule -MinimumVersion $minimumVersion -Force -ErrorAction Stop
 
-    $candidateModules = @(
-        foreach ($candidate in $candidatePaths) {
-            if (Test-Path -LiteralPath $candidate) {
-                Get-Item -LiteralPath $candidate
-            }
-        }
-        Get-Module -ListAvailable -Name PSPublishModule | Sort-Object Version -Descending
-    )
-
-    foreach ($candidate in $candidateModules) {
-        Remove-Module -Name PSPublishModule -Force -ErrorAction SilentlyContinue
-        $candidateModulePath = if ($candidate.FullName) { $candidate.FullName } elseif ($candidate.Path) { $candidate.Path } else { [string] $candidate }
-        Import-Module -Name $candidateModulePath -Force -ErrorAction Stop
-        $newConfigurationBuild = Get-Command -Name New-ConfigurationBuild -ErrorAction SilentlyContinue
-        if ($newConfigurationBuild -and $newConfigurationBuild.Parameters.ContainsKey('NETAssemblyLoadContext')) {
-            return
-        }
+    $newConfigurationBuild = Get-Command -Name New-ConfigurationBuild -ErrorAction SilentlyContinue
+    if (-not $newConfigurationBuild -or -not $newConfigurationBuild.Parameters.ContainsKey('NETAssemblyLoadContext')) {
+        throw "PSPublishModule $minimumVersion or newer with New-ConfigurationBuild -NETAssemblyLoadContext support is required."
     }
-
-    throw 'PSPublishModule with New-ConfigurationBuild -NETAssemblyLoadContext support was not found. Install the current PSPublishModule or set $env:PSPUBLISHMODULE_MANIFEST.'
 }
 
 Import-PSWriteOfficePSPublishModule

--- a/Build/Validate-PackagedArtefact.ps1
+++ b/Build/Validate-PackagedArtefact.ps1
@@ -13,30 +13,13 @@ if ($ResolvedArtefactModulePath) {
 $ArtefactManifest = Join-Path $ArtefactModulePath 'PSWriteOffice.psd1'
 
 function Import-PSPublishModule {
-    $candidatePaths = @(
-        $env:PSPUBLISHMODULE_MANIFEST
-    ) | Where-Object { $_ }
+    $minimumVersion = [version] '3.0.5'
+    Import-Module -Name PSPublishModule -MinimumVersion $minimumVersion -Force -ErrorAction Stop
 
-    $candidateModules = @(
-        foreach ($candidate in $candidatePaths) {
-            if (Test-Path -LiteralPath $candidate) {
-                Get-Item -LiteralPath $candidate
-            }
-        }
-        Get-Module -ListAvailable -Name PSPublishModule | Sort-Object Version -Descending
-    )
-
-    foreach ($candidate in $candidateModules) {
-        Remove-Module -Name PSPublishModule -Force -ErrorAction SilentlyContinue
-        $candidateModulePath = if ($candidate.FullName) { $candidate.FullName } elseif ($candidate.Path) { $candidate.Path } else { [string] $candidate }
-        Import-Module -Name $candidateModulePath -Force -ErrorAction Stop
-        $newConfigurationBuild = Get-Command -Name New-ConfigurationBuild -ErrorAction SilentlyContinue
-        if ($newConfigurationBuild -and $newConfigurationBuild.Parameters.ContainsKey('NETAssemblyLoadContext')) {
-            return
-        }
+    $newConfigurationBuild = Get-Command -Name New-ConfigurationBuild -ErrorAction SilentlyContinue
+    if (-not $newConfigurationBuild -or -not $newConfigurationBuild.Parameters.ContainsKey('NETAssemblyLoadContext')) {
+        throw "PSPublishModule $minimumVersion or newer with New-ConfigurationBuild -NETAssemblyLoadContext support is required."
     }
-
-    throw 'PSPublishModule with New-ConfigurationBuild -NETAssemblyLoadContext support was not found. Install the current PSPublishModule or set $env:PSPUBLISHMODULE_MANIFEST.'
 }
 
 if (-not $SkipBuild -or -not (Test-Path -LiteralPath $ArtefactManifest)) {

--- a/Tests/AssemblyLoadContext.Conflict.Tests.ps1
+++ b/Tests/AssemblyLoadContext.Conflict.Tests.ps1
@@ -4,14 +4,26 @@ Describe 'Packaged AssemblyLoadContext conflict isolation' {
         $packagedModule = Join-Path $packagedModuleRoot 'PSWriteOffice'
         $packagedLoader = Join-Path $packagedModule 'Lib\Core\PSWriteOffice.ModuleLoadContext.dll'
         $conflictOpenXmlPath = $env:PSWRITEOFFICE_CONFLICT_OPENXML_PATH
+        $requirePackagedSmoke = $env:PSWRITEOFFICE_REQUIRE_ALC_SMOKE -eq 'true'
 
-        if ($PSVersionTable.PSEdition -ne 'Core' -or
-            -not (Test-Path -LiteralPath $packagedLoader) -or
-            [string]::IsNullOrWhiteSpace($conflictOpenXmlPath) -or
-            -not (Test-Path -LiteralPath $conflictOpenXmlPath)) {
-            Set-ItResult -Skipped -Because 'packaged Core artifact and conflict Open XML assembly are required'
+        if ($PSVersionTable.PSEdition -ne 'Core') {
+            Set-ItResult -Skipped -Because 'AssemblyLoadContext isolation is only available in PowerShell Core'
             return
         }
+
+        if (-not $requirePackagedSmoke -and (
+                -not (Test-Path -LiteralPath $packagedModule) -or
+                -not (Test-Path -LiteralPath $packagedLoader) -or
+                [string]::IsNullOrWhiteSpace($conflictOpenXmlPath) -or
+                -not (Test-Path -LiteralPath $conflictOpenXmlPath))) {
+            Set-ItResult -Skipped -Because 'packaged ALC smoke prerequisites are supplied by the dedicated packaged-alc-conflict workflow'
+            return
+        }
+
+        Test-Path -LiteralPath $packagedModule | Should -BeTrue -Because 'the packaged module must exist before the ALC smoke test runs'
+        Test-Path -LiteralPath $packagedLoader | Should -BeTrue -Because 'the packaged module must include the module-scoped ALC loader'
+        [string]::IsNullOrWhiteSpace($conflictOpenXmlPath) | Should -BeFalse -Because 'the conflict Open XML assembly path must be provided by the workflow'
+        Test-Path -LiteralPath $conflictOpenXmlPath | Should -BeTrue -Because 'the conflict Open XML assembly must exist before the smoke test runs'
 
         $moduleRootLiteral = $packagedModuleRoot.Replace("'", "''")
         $conflictOpenXmlLiteral = $conflictOpenXmlPath.Replace("'", "''")


### PR DESCRIPTION
## Summary
- import the published PSPublishModule dependency once with -MinimumVersion 3.0.5 instead of probing/removing alternate module candidates in-process
- make the packaged ALC conflict test fail when the packaged module, ALC loader, or conflict OpenXML assembly is missing
- add bounded timeout values to the CI NuGet download used by the ALC conflict job

## Validation
- git diff --check
- Import-Module PSPublishModule -MinimumVersion 3.0.5 and verify New-ConfigurationBuild exposes NETAssemblyLoadContext
- Build/Manage-PSWriteOffice.ps1 with signing disabled
- Build/Validate-PackagedArtefact.ps1 -SkipBuild
- Tests/AssemblyLoadContext.Conflict.Tests.ps1 fails without PSWRITEOFFICE_CONFLICT_OPENXML_PATH and passes with the conflict assembly path set