### PR TITLE
Simplify PSPublishModule build import

### DIFF
--- a/Build/Manage-PSWriteOffice.ps1
+++ b/Build/Manage-PSWriteOffice.ps1
@@ -1,24 +1,6 @@
-﻿function Import-PSWriteOfficePSPublishModule {
-    $minimumVersion = [version] '3.0.5'
-    Import-Module -Name PSPublishModule -MinimumVersion $minimumVersion -Force -ErrorAction Stop
-
-    $newConfigurationBuild = Get-Command -Name New-ConfigurationBuild -ErrorAction SilentlyContinue
-    if (-not $newConfigurationBuild -or -not $newConfigurationBuild.Parameters.ContainsKey('NETAssemblyLoadContext')) {
-        throw "PSPublishModule $minimumVersion or newer with New-ConfigurationBuild -NETAssemblyLoadContext support is required."
-    }
-}
-
-Import-PSWriteOfficePSPublishModule
+Import-Module PSPublishModule -Force -ErrorAction Stop
 
 Invoke-ModuleBuild -ModuleName 'PSWriteOffice' {
-    $signModule = if ($env:PSWRITEOFFICE_SIGN_MODULE) {
-        [System.Convert]::ToBoolean($env:PSWRITEOFFICE_SIGN_MODULE)
-    } elseif ($env:GITHUB_ACTIONS -eq 'true' -or $env:CI -eq 'true') {
-        $false
-    } else {
-        $true
-    }
-
     # Usual defaults as per standard module
     $Manifest = [ordered] @{
         # Minimum version of the Windows PowerShell engine required by this module
@@ -116,10 +98,11 @@ Invoke-ModuleBuild -ModuleName 'PSWriteOffice' {
 
     $newConfigurationBuildSplat = @{
         Enable                            = $true
-        SignModule                        = $signModule
+        # lets sign module only on my machine for now
+        SignModule                        = if ($Env:COMPUTERNAME -eq 'EVOMONSTER') { $true } else { $false }
         MergeModuleOnBuild                = $true
         MergeFunctionsFromApprovedModules = $true
-        CertificateThumbprint             = if ($signModule) { '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703' } else { $null }
+        CertificateThumbprint             = '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
         ResolveBinaryConflicts            = $true
         ResolveBinaryConflictsName        = 'PSWriteOffice'
         NETProjectName                    = 'PSWriteOffice'

--- a/Build/Validate-PackagedArtefact.ps1
+++ b/Build/Validate-PackagedArtefact.ps1
@@ -12,18 +12,8 @@ if ($ResolvedArtefactModulePath) {
 }
 $ArtefactManifest = Join-Path $ArtefactModulePath 'PSWriteOffice.psd1'
 
-function Import-PSPublishModule {
-    $minimumVersion = [version] '3.0.5'
-    Import-Module -Name PSPublishModule -MinimumVersion $minimumVersion -Force -ErrorAction Stop
-
-    $newConfigurationBuild = Get-Command -Name New-ConfigurationBuild -ErrorAction SilentlyContinue
-    if (-not $newConfigurationBuild -or -not $newConfigurationBuild.Parameters.ContainsKey('NETAssemblyLoadContext')) {
-        throw "PSPublishModule $minimumVersion or newer with New-ConfigurationBuild -NETAssemblyLoadContext support is required."
-    }
-}
-
 if (-not $SkipBuild -or -not (Test-Path -LiteralPath $ArtefactManifest)) {
-    Import-PSPublishModule
+    Import-Module PSPublishModule -Force -ErrorAction Stop
     $previousOfficeIMORoot = $env:OfficeIMORoot
     try {
         $env:OfficeIMORoot = Join-Path $RepoRoot '.missing-officeimo'


### PR DESCRIPTION
## Summary
- replace the PSPublishModule feature-probing wrapper with a plain import
- remove environment-driven signing fallback logic from the build script
- keep signing scoped to the known signing machine, matching the existing module build pattern

## Validation
- git diff --check
- parsed Build/Manage-PSWriteOffice.ps1 and Build/Validate-PackagedArtefact.ps1
- imported published PSPublishModule 3.0.5.2 and confirmed New-ConfigurationBuild exposes NETAssemblyLoadContext