### PR TITLE
Normalize Office show launch after save

### DIFF
--- a/Sources/PSWriteOffice/Cmdlets/Excel/CloseOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/CloseOfficeExcelCommand.cs
@@ -41,7 +41,10 @@ public sealed class CloseOfficeExcelCommand : PSCmdlet
 
         if (Save.IsPresent || !string.IsNullOrEmpty(Path))
         {
-            ExcelDocumentService.SaveDocument(Document, Show.IsPresent, Path ?? Document.FilePath);
+            var resolvedPath = !string.IsNullOrWhiteSpace(Path)
+                ? SessionState.Path.GetUnresolvedProviderPathFromPSPath(Path)
+                : Document.FilePath;
+            ExcelDocumentService.SaveDocument(Document, Show.IsPresent, resolvedPath);
         }
         else
         {

--- a/Sources/PSWriteOffice/Cmdlets/Excel/SaveOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/SaveOfficeExcelCommand.cs
@@ -1,5 +1,6 @@
 using System.Management.Automation;
 using OfficeIMO.Excel;
+using PSWriteOffice.Services;
 
 namespace PSWriteOffice.Cmdlets.Excel;
 
@@ -45,11 +46,20 @@ public sealed class SaveOfficeExcelCommand : PSCmdlet
 
         if (!string.IsNullOrWhiteSpace(Path))
         {
-            Document.Save(Path!, Show.IsPresent);
+            var resolvedPath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(Path);
+            Document.Save(resolvedPath, false);
+            if (Show.IsPresent)
+            {
+                FileOpenService.Open(resolvedPath);
+            }
         }
         else
         {
-            Document.Save(Show.IsPresent);
+            Document.Save(false);
+            if (Show.IsPresent)
+            {
+                FileOpenService.Open(Document.FilePath);
+            }
         }
 
         if (PassThru.IsPresent)

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointCommand.cs
@@ -27,7 +27,8 @@ public class GetOfficePowerPointCommand : PSCmdlet
     {
         try
         {
-            var presentation = PowerPointDocumentService.LoadPresentation(FilePath);
+            var resolvedPath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(FilePath);
+            var presentation = PowerPointDocumentService.LoadPresentation(resolvedPath);
             WriteObject(presentation);
         }
         catch (FileNotFoundException ex)

--- a/Sources/PSWriteOffice/Cmdlets/Word/CloseOfficeWordCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/CloseOfficeWordCommand.cs
@@ -95,7 +95,10 @@ public sealed class CloseOfficeWordCommand : PSCmdlet
     {
         if (Save.IsPresent || !string.IsNullOrEmpty(Path))
         {
-            WordDocumentService.SaveDocument(document, Show.IsPresent, Path);
+            var resolvedPath = !string.IsNullOrWhiteSpace(Path)
+                ? SessionState.Path.GetUnresolvedProviderPathFromPSPath(Path)
+                : null;
+            WordDocumentService.SaveDocument(document, Show.IsPresent, resolvedPath);
             return;
         }
 

--- a/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordHtmlCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordHtmlCommand.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Management.Automation;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Html;
+using PSWriteOffice.Services;
 
 namespace PSWriteOffice.Cmdlets.Word;
 
@@ -183,11 +184,16 @@ public sealed class ConvertFromOfficeWordHtmlCommand : PSCmdlet
 
                 try
                 {
-                    document.Save(resolvedOutput, Open.IsPresent);
+                    document.Save(resolvedOutput, false);
                 }
                 finally
                 {
                     document.Dispose();
+                }
+
+                if (Open.IsPresent)
+                {
+                    FileOpenService.Open(resolvedOutput);
                 }
 
                 if (PassThru.IsPresent)

--- a/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordMarkdownCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordMarkdownCommand.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using OfficeIMO.Markdown;
 using OfficeIMO.Word;
 using OfficeIMO.Word.Markdown;
+using PSWriteOffice.Services;
 
 namespace PSWriteOffice.Cmdlets.Word;
 
@@ -164,11 +165,16 @@ public sealed class ConvertFromOfficeWordMarkdownCommand : PSCmdlet
 
                 try
                 {
-                    document.Save(resolvedOutput, Open.IsPresent);
+                    document.Save(resolvedOutput, false);
                 }
                 finally
                 {
                     document.Dispose();
+                }
+
+                if (Open.IsPresent)
+                {
+                    FileOpenService.Open(resolvedOutput);
                 }
 
                 if (PassThru.IsPresent)

--- a/Sources/PSWriteOffice/Cmdlets/Word/SaveOfficeWordCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/SaveOfficeWordCommand.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Management.Automation;
 using OfficeIMO.Word;
+using PSWriteOffice.Services;
 
 namespace PSWriteOffice.Cmdlets.Word;
 
@@ -48,11 +49,20 @@ public sealed class SaveOfficeWordCommand : PSCmdlet
 
         if (!string.IsNullOrWhiteSpace(Path))
         {
-            Document.Save(Path!, Show.IsPresent);
+            var resolvedPath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(Path);
+            Document.Save(resolvedPath, false);
+            if (Show.IsPresent)
+            {
+                FileOpenService.Open(resolvedPath);
+            }
         }
         else
         {
-            Document.Save(Show.IsPresent);
+            Document.Save(false);
+            if (Show.IsPresent)
+            {
+                FileOpenService.Open(Document.FilePath);
+            }
         }
 
         if (PassThru.IsPresent)

--- a/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.cs
@@ -13,17 +13,18 @@ internal static class ExcelDocumentService
             throw new ArgumentException("File path cannot be empty.", nameof(filePath));
         }
 
-        return ExcelDocument.Create(filePath, autoSave);
+        return ExcelDocument.Create(Path.GetFullPath(filePath), autoSave);
     }
 
     public static ExcelDocument LoadDocument(string filePath, bool readOnly, bool autoSave)
     {
-        if (!File.Exists(filePath))
+        var resolvedPath = Path.GetFullPath(filePath);
+        if (!File.Exists(resolvedPath))
         {
-            throw new FileNotFoundException($"File '{filePath}' was not found.", filePath);
+            throw new FileNotFoundException($"File '{resolvedPath}' was not found.", resolvedPath);
         }
 
-        return ExcelDocument.Load(filePath, readOnly, autoSave);
+        return ExcelDocument.Load(resolvedPath, readOnly, autoSave);
     }
 
     public static void SaveDocument(ExcelDocument document, bool show, string? filePath)
@@ -36,14 +37,24 @@ internal static class ExcelDocumentService
             var target = filePath!;
             if (!string.Equals(target, currentPath, StringComparison.OrdinalIgnoreCase))
             {
-                document.Save(target, show);
+                document.Save(Path.GetFullPath(target), false);
+                var savedAsPath = document.FilePath ?? target;
                 document.Dispose();
+                if (show)
+                {
+                    FileOpenService.Open(savedAsPath);
+                }
                 return;
             }
         }
 
-        document.Save(show);
+        document.Save(false);
+        var savedPath = document.FilePath ?? filePath ?? throw new InvalidOperationException("No saved file path was available.");
         document.Dispose();
+        if (show)
+        {
+            FileOpenService.Open(savedPath);
+        }
     }
 
     public static void CloseDocument(ExcelDocument document)

--- a/Sources/PSWriteOffice/Services/FileOpenService.cs
+++ b/Sources/PSWriteOffice/Services/FileOpenService.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace PSWriteOffice.Services;
+
+internal static class FileOpenService
+{
+    public static void Open(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            throw new ArgumentException("File path cannot be empty.", nameof(filePath));
+        }
+
+        var resolvedPath = Path.GetFullPath(filePath);
+        if (!File.Exists(resolvedPath))
+        {
+            throw new FileNotFoundException($"File {resolvedPath} doesn't exist.", resolvedPath);
+        }
+
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = resolvedPath,
+            UseShellExecute = true
+        });
+    }
+}

--- a/Sources/PSWriteOffice/Services/PowerPoint/PowerPointDocumentService.cs
+++ b/Sources/PSWriteOffice/Services/PowerPoint/PowerPointDocumentService.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.IO;
 using OfficeIMO.PowerPoint;
+using PSWriteOffice.Services;
 
 namespace PSWriteOffice.Services.PowerPoint;
 
@@ -19,21 +19,23 @@ public static class PowerPointDocumentService
             throw new ArgumentException("File path cannot be empty.", nameof(filePath));
         }
 
-        var presentation = PowerPointPresentation.Create(filePath);
-        Presentations[presentation] = filePath;
+        var resolvedPath = Path.GetFullPath(filePath);
+        var presentation = PowerPointPresentation.Create(resolvedPath);
+        Presentations[presentation] = resolvedPath;
         return presentation;
     }
 
     /// <summary>Loads an existing presentation.</summary>
     public static PowerPointPresentation LoadPresentation(string filePath)
     {
-        if (!File.Exists(filePath))
+        var resolvedPath = Path.GetFullPath(filePath);
+        if (!File.Exists(resolvedPath))
         {
-            throw new FileNotFoundException($"File {filePath} doesn't exist.", filePath);
+            throw new FileNotFoundException($"File {resolvedPath} doesn't exist.", resolvedPath);
         }
 
-        var presentation = PowerPointPresentation.Open(filePath);
-        Presentations[presentation] = filePath;
+        var presentation = PowerPointPresentation.Open(resolvedPath);
+        Presentations[presentation] = resolvedPath;
         return presentation;
     }
 
@@ -45,19 +47,14 @@ public static class PowerPointDocumentService
             throw new ArgumentException("Presentation was not created or loaded via this service.", nameof(presentation));
         }
 
+        var resolvedPath = Path.GetFullPath(filePath);
         presentation.Save();
+        presentation.Dispose();
+        Presentations.TryRemove(presentation, out _);
 
         if (show)
         {
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = filePath,
-                UseShellExecute = true
-            };
-            Process.Start(startInfo);
+            FileOpenService.Open(resolvedPath);
         }
-
-        presentation.Dispose();
-        Presentations.TryRemove(presentation, out _);
     }
 }

--- a/Sources/PSWriteOffice/Services/Word/WordDocumentService.Document.cs
+++ b/Sources/PSWriteOffice/Services/Word/WordDocumentService.Document.cs
@@ -17,18 +17,19 @@ public static partial class WordDocumentService
     /// <summary>Loads an existing Word document.</summary>
     public static WordDocument LoadDocument(string filePath, bool readOnly, bool autoSave)
     {
-        if (!File.Exists(filePath))
+        var resolvedPath = Path.GetFullPath(filePath);
+        if (!File.Exists(resolvedPath))
         {
-            throw new FileNotFoundException($"File {filePath} doesn't exist.", filePath);
+            throw new FileNotFoundException($"File {resolvedPath} doesn't exist.", resolvedPath);
         }
 
-        return RegisterDocument(WordDocument.Load(filePath, readOnly, autoSave));
+        return RegisterDocument(WordDocument.Load(resolvedPath, readOnly, autoSave));
     }
 
     /// <summary>Creates a new Word document at the specified path.</summary>
     public static WordDocument CreateDocument(string filePath, bool autoSave)
     {
-        return RegisterDocument(WordDocument.Create(filePath, autoSave));
+        return RegisterDocument(WordDocument.Create(Path.GetFullPath(filePath), autoSave));
     }
 
     /// <summary>Disposes the Word document.</summary>
@@ -66,14 +67,20 @@ public static partial class WordDocumentService
 
         if (filePath != null)
         {
-            document.Save(filePath, show);
+            document.Save(Path.GetFullPath(filePath), false);
         }
         else
         {
-            document.Save(show);
+            document.Save(false);
         }
 
+        var savedPath = document.FilePath ?? filePath ?? throw new InvalidOperationException("No saved file path was available.");
         CloseDocument(document);
+
+        if (show)
+        {
+            FileOpenService.Open(savedPath);
+        }
     }
 
     /// <summary>Returns the most recently tracked Word document for the current runspace.</summary>


### PR DESCRIPTION
## Summary
- add a shared PSWriteOffice file opener that resolves paths and opens only existing files
- normalize Word, Excel, and PowerPoint save/show paths through PSWriteOffice instead of mixed OfficeIMO open calls
- save and close/dispose close-style and conversion outputs before launching them
- resolve save-as paths through the PowerShell provider in Save/Close cmdlets

## Validation
- dotnet build Sources/PSWriteOffice/PSWriteOffice.csproj --framework net8.0
- dotnet build Sources/PSWriteOffice/PSWriteOffice.csproj --framework net472