### PR TITLE
Keep Excel cmdlets compatible with packaged OfficeIMO

### DIFF
--- a/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
@@ -306,7 +306,7 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
         sheet.CellValues(cells);
         var endRow = Math.Max(startRow, row - 1);
         var endColumn = StartColumn + table.Columns.Count - 1;
-        return $"{A1.CellReference(startRow, StartColumn)}:{A1.CellReference(endRow, endColumn)}";
+        return $"{ExcelA1Address.CellReference(startRow, StartColumn)}:{ExcelA1Address.CellReference(endRow, endColumn)}";
     }
 
     private string? ResolveAppendTableName(ExcelDocument document, ExcelSheet sheet, bool appendToExistingSheet)

--- a/Sources/PSWriteOffice/Cmdlets/Excel/ImportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ImportOfficeExcelCommand.cs
@@ -109,7 +109,7 @@ public sealed class ImportOfficeExcelCommand : PSCmdlet
                 throw new PSArgumentException("Coordinate bounds must be 1 or greater.");
             }
 
-            return $"{A1.CellReference(StartRow.Value, StartColumn.Value)}:{A1.CellReference(EndRow.Value, EndColumn.Value)}";
+            return $"{ExcelA1Address.CellReference(StartRow.Value, StartColumn.Value)}:{ExcelA1Address.CellReference(EndRow.Value, EndColumn.Value)}";
         }
 
         return sheet.GetUsedRangeA1();

--- a/Sources/PSWriteOffice/Services/Excel/ExcelA1Address.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelA1Address.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace PSWriteOffice.Services.Excel;
+
+internal static class ExcelA1Address
+{
+    internal static string CellReference(int row, int column)
+    {
+        if (row < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(row), "Row index must be 1 or greater.");
+        }
+
+        if (column < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(column), "Column index must be 1 or greater.");
+        }
+
+        var builder = new StringBuilder();
+        var value = column;
+        while (value > 0)
+        {
+            value--;
+            builder.Insert(0, (char)('A' + value % 26));
+            value /= 26;
+        }
+
+        builder.Append(row.ToString(CultureInfo.InvariantCulture));
+        return builder.ToString();
+    }
+}


### PR DESCRIPTION
Summary:
- add a small PSWriteOffice-local A1 cell reference formatter
- avoid depending on the newly added OfficeIMO A1.CellReference helper during CI package-reference builds

Validation:
- package-reference builds passed for net8.0 and net472 with OfficeIMORoot pointed at a missing folder
- local OfficeIMO source builds passed for net8.0 and net472
- PowerShell 7 and Windows PowerShell focused Pester runs passed: PowerPoint.Tests.ps1 and ExcelDsl.Tests.ps1, 31 tests each run