### PR TITLE
Fix append freeze pane rows

### DIFF
--- a/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
@@ -202,7 +202,7 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
 
             if (FreezeTopRow.IsPresent || FreezeFirstColumn.IsPresent)
             {
-                var frozenRows = FreezeTopRow.IsPresent ? Math.Max(1, dataStartRow) : 0;
+                var frozenRows = ResolveFrozenTopRows(document, sheet, isAppendingToExistingSheet, appendTableName, dataStartRow, includeHeaders);
                 var frozenColumns = FreezeFirstColumn.IsPresent ? Math.Max(1, StartColumn) : 0;
                 sheet.Freeze(frozenRows, frozenColumns);
             }
@@ -326,6 +326,32 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
             .ToList();
 
         return sheetTables.Count == 1 ? sheetTables[0].Name : null;
+    }
+
+    private int ResolveFrozenTopRows(ExcelDocument document, ExcelSheet sheet, bool appendToExistingSheet, string? appendTableName, int dataStartRow, bool includeHeaders)
+    {
+        if (!FreezeTopRow.IsPresent)
+        {
+            return 0;
+        }
+
+        if (!appendToExistingSheet)
+        {
+            return Math.Max(1, includeHeaders ? dataStartRow : StartRow);
+        }
+
+        if (!string.IsNullOrWhiteSpace(appendTableName))
+        {
+            var table = document.GetTables().FirstOrDefault(candidate =>
+                string.Equals(candidate.SheetName, sheet.Name, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(candidate.Name, appendTableName, StringComparison.OrdinalIgnoreCase));
+            if (table != null && ExcelA1Address.TryGetRangeStartRow(table.Range, out var tableStartRow))
+            {
+                return Math.Max(1, tableStartRow);
+            }
+        }
+
+        return Math.Max(1, StartRow);
     }
 
     private bool TryAppendDataTableToTable(ExcelSheet sheet, DataTable table, string tableName, out string range)

--- a/Sources/PSWriteOffice/Services/Excel/ExcelA1Address.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelA1Address.cs
@@ -30,4 +30,29 @@ internal static class ExcelA1Address
         builder.Append(row.ToString(CultureInfo.InvariantCulture));
         return builder.ToString();
     }
+
+    internal static bool TryGetRangeStartRow(string? range, out int row)
+    {
+        row = 0;
+        if (string.IsNullOrWhiteSpace(range))
+        {
+            return false;
+        }
+
+        var rangeValue = (range ?? string.Empty).Trim();
+        var separatorIndex = rangeValue.IndexOf(':');
+        var startReference = separatorIndex >= 0 ? rangeValue.Substring(0, separatorIndex) : rangeValue;
+        var digitStart = 0;
+        while (digitStart < startReference.Length && !char.IsDigit(startReference[digitStart]))
+        {
+            digitStart++;
+        }
+
+        if (digitStart >= startReference.Length)
+        {
+            return false;
+        }
+
+        return int.TryParse(startReference.Substring(digitStart), NumberStyles.None, CultureInfo.InvariantCulture, out row);
+    }
 }

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -103,6 +103,25 @@ Describe 'Excel DSL surface' {
         }
     }
 
+    It 'keeps append freeze panes anchored to the existing table header' {
+        $path = Join-Path $TestDrive 'ExportOfficeExcelAppendFreeze.xlsx'
+        $rows = @(
+            [PSCustomObject]@{ Region = 'NA'; Revenue = 100 }
+            [PSCustomObject]@{ Region = 'EMEA'; Revenue = 200 }
+        )
+        $moreRows = @(
+            [PSCustomObject]@{ Region = 'APAC'; Revenue = 150 }
+        )
+
+        $rows | Export-OfficeExcel -Path $path -WorksheetName 'Data' -TableName 'Sales' -Title 'Sales Export' -FreezeTopRow
+        $moreRows | Export-OfficeExcel -Path $path -WorksheetName 'Data' -Append -TableName 'Sales' -FreezeTopRow
+
+        $sheetXml = Get-ZipXmlDocumentLocal -Path $path -Entry 'xl/worksheets/sheet1.xml'
+        $pane = $sheetXml.SelectSingleNode("/*[local-name()='worksheet']/*[local-name()='sheetViews']/*[local-name()='sheetView']/*[local-name()='pane']")
+
+        $pane.GetAttribute('ySplit') | Should -Be '2'
+    }
+
     It 'supports autofit and validation list helpers' {
         $path = Join-Path $TestDrive 'DslExcelExtras.xlsx'
         $rows = @(


### PR DESCRIPTION
Summary:
- freeze appended Excel exports at the existing table header row instead of the append insertion row
- add A1 range start-row parsing to support that behavior without newer OfficeIMO APIs
- add a regression for titled exports followed by append with FreezeTopRow

Validation:
- dotnet build Sources\\PSWriteOffice\\PSWriteOffice.csproj --framework net8.0 --verbosity minimal
- dotnet build Sources\\PSWriteOffice\\PSWriteOffice.csproj --framework net8.0 -p:OfficeIMORoot=C:\\Support\\GitHub\\PSWriteOffice-ci-compat-fix\\.missing-officeimo --verbosity minimal
- dotnet build Sources\\PSWriteOffice\\PSWriteOffice.csproj --framework net472 -p:OfficeIMORoot=C:\\Support\\GitHub\\PSWriteOffice-ci-compat-fix\\.missing-officeimo --verbosity minimal
- dotnet build Sources\\PSWriteOffice\\PSWriteOffice.csproj --framework net472 --verbosity minimal
- pwsh ExcelDsl.Tests.ps1: 17 passed
- Windows PowerShell ExcelDsl.Tests.ps1: 17 passed