### PR TITLE
Address Excel and PowerPoint review followups

### DIFF
--- a/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelSummaryCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/GetOfficeExcelSummaryCommand.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Office2019.Excel.ThreadedComments;
 using DocumentFormat.OpenXml.Office2010.Excel;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
@@ -149,7 +150,7 @@ public sealed class GetOfficeExcelSummaryCommand : PSCmdlet
         var pivotCount = worksheetPart.PivotTableParts.Count();
         var sparklineGroupCount = worksheet.Descendants<SparklineGroups>().Sum(groups => groups.Elements<SparklineGroup>().Count());
         var hyperlinkCount = worksheet.Elements<Hyperlinks>().FirstOrDefault()?.Elements<Hyperlink>().Count() ?? 0;
-        var commentCount = worksheetPart.WorksheetCommentsPart?.Comments?.CommentList?.Elements<Comment>().Count() ?? 0;
+        var commentCount = CountComments(worksheetPart);
 
         record.Properties.Add(new PSNoteProperty("UsedRange", worksheet.SheetDimension?.Reference?.Value));
         record.Properties.Add(new PSNoteProperty("TableCount", tableRecords.Length));
@@ -178,6 +179,14 @@ public sealed class GetOfficeExcelSummaryCommand : PSCmdlet
     {
         return container.Parts.Sum(part =>
             (part.OpenXmlPart is ChartPart ? 1 : 0) + CountChartParts(part.OpenXmlPart));
+    }
+
+    private static int CountComments(WorksheetPart worksheetPart)
+    {
+        var legacyCount = worksheetPart.WorksheetCommentsPart?.Comments?.CommentList?.Elements<Comment>().Count() ?? 0;
+        var threadedCount = worksheetPart.WorksheetThreadedCommentsParts.Sum(part =>
+            part.ThreadedComments?.Elements<ThreadedComment>().Count() ?? 0);
+        return legacyCount + threadedCount;
     }
 
     private static IEnumerable<PSObject> GetTableRecords(WorksheetPart worksheetPart)

--- a/Sources/PSWriteOffice/Cmdlets/Excel/ImportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ImportOfficeExcelCommand.cs
@@ -109,6 +109,16 @@ public sealed class ImportOfficeExcelCommand : PSCmdlet
                 throw new PSArgumentException("Coordinate bounds must be 1 or greater.");
             }
 
+            if (StartRow.Value > EndRow.Value)
+            {
+                throw new PSArgumentException("StartRow must be less than or equal to EndRow.");
+            }
+
+            if (StartColumn.Value > EndColumn.Value)
+            {
+                throw new PSArgumentException("StartColumn must be less than or equal to EndColumn.");
+            }
+
             return $"{ExcelA1Address.CellReference(StartRow.Value, StartColumn.Value)}:{ExcelA1Address.CellReference(EndRow.Value, EndColumn.Value)}";
         }
 

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointDesignerDeckCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointDesignerDeckCommand.cs
@@ -111,7 +111,7 @@ public sealed class AddOfficePowerPointDesignerDeckCommand : PSCmdlet
 
         if (Preview.IsPresent)
         {
-            WriteObject(brief.DescribeDeckPlan(Plan, 0), enumerateCollection: true);
+            WriteObject(brief.DescribeDeckPlan(Plan, AlternativeCount), enumerateCollection: true);
             return;
         }
 

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -75,6 +75,11 @@ Describe 'Excel DSL surface' {
         $imported[0].Region | Should -Be 'NA'
         $imported[0].Revenue | Should -Be 100
         $imported[0].PSObject.Properties.Name | Should -Not -Contain 'Internal'
+
+        { Import-OfficeExcel -Path $path -WorksheetName 'Data' -StartRow 4 -EndRow 2 -StartColumn 1 -EndColumn 2 } |
+            Should -Throw '*StartRow must be less than or equal to EndRow*'
+        { Import-OfficeExcel -Path $path -WorksheetName 'Data' -StartRow 2 -EndRow 4 -StartColumn 3 -EndColumn 1 } |
+            Should -Throw '*StartColumn must be less than or equal to EndColumn*'
     }
 
     It 'appends rows without rewriting headers' {
@@ -361,6 +366,42 @@ Describe 'Excel DSL surface' {
         $pageMargins.GetAttribute('right') | Should -Be '0.25'
         $pageMargins.GetAttribute('top') | Should -Be '0.5'
         $pageMargins.GetAttribute('bottom') | Should -Be '0.5'
+    }
+
+    It 'counts threaded comments in workbook summaries' {
+        $path = Join-Path $TestDrive 'DslExcelThreadedComments.xlsx'
+        $rows = @(
+            [PSCustomObject]@{ Region = 'NA'; Sales = 100 }
+        )
+
+        New-OfficeExcel -Path $path {
+            Add-OfficeExcelSheet -Name 'Data' -Content {
+                Add-OfficeExcelTable -Data $rows -TableName 'Sales'
+            }
+        }
+
+        $document = [DocumentFormat.OpenXml.Packaging.SpreadsheetDocument]::Open($path, $true)
+        try {
+            $worksheetPart = @($document.WorkbookPart.WorksheetParts)[0]
+            $addPartMethod = [DocumentFormat.OpenXml.Packaging.WorksheetPart].GetMethods() |
+                Where-Object { $_.Name -eq 'AddNewPart' -and $_.IsGenericMethodDefinition -and $_.GetParameters().Count -eq 0 } |
+                Select-Object -First 1
+            $threadedPart = $addPartMethod.MakeGenericMethod([DocumentFormat.OpenXml.Packaging.WorksheetThreadedCommentsPart]).Invoke($worksheetPart, @())
+            $threadedComments = [DocumentFormat.OpenXml.Office2019.Excel.ThreadedComments.ThreadedComments]::new()
+            $threadedComment = [DocumentFormat.OpenXml.Office2019.Excel.ThreadedComments.ThreadedComment]::new()
+            $threadedComment.Ref = 'A2'
+            $threadedComment.PersonId = '{00000000-0000-0000-0000-000000000001}'
+            $threadedComment.Id = '{00000000-0000-0000-0000-000000000002}'
+            $threadedComment.AppendChild([DocumentFormat.OpenXml.Office2019.Excel.ThreadedComments.ThreadedCommentText]::new('Modern note')) | Out-Null
+            $threadedComments.AppendChild($threadedComment) | Out-Null
+            $threadedComments.Save($threadedPart)
+        } finally {
+            $document.Dispose()
+        }
+
+        $summary = Get-OfficeExcelSummary -Path $path -IncludeSheets
+        $summary.CommentCount | Should -Be 1
+        $summary.Sheets[0].CommentCount | Should -Be 1
     }
 
     It 'adds a table of contents and reads ranges with the new Excel readers' {


### PR DESCRIPTION
Summary:
- reject inverted Import-OfficeExcel coordinate bounds before building A1 ranges
- include modern threaded comments in Get-OfficeExcelSummary comment totals
- honor AlternativeCount when generating PowerPoint designer preview output

Validation:
- dotnet build Sources\\PSWriteOffice\\PSWriteOffice.csproj --framework net8.0 --verbosity minimal
- dotnet build Sources\\PSWriteOffice\\PSWriteOffice.csproj --framework net8.0 -p:OfficeIMORoot=C:\\Support\\GitHub\\PSWriteOffice-ci-compat-fix\\.missing-officeimo --verbosity minimal
- dotnet build Sources\\PSWriteOffice\\PSWriteOffice.csproj --framework net472 -p:OfficeIMORoot=C:\\Support\\GitHub\\PSWriteOffice-ci-compat-fix\\.missing-officeimo --verbosity minimal
- dotnet build Sources\\PSWriteOffice\\PSWriteOffice.csproj --framework net472 --verbosity minimal
- PowerShell 7 focused Pester: ExcelDsl.Tests.ps1 and PowerPoint.Tests.ps1, 33 passed
- Windows PowerShell focused Pester: ExcelDsl.Tests.ps1 and PowerPoint.Tests.ps1, 33 passed