### PR TITLE
Support common tabular Excel inputs

### DIFF
--- a/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableCommand.cs
@@ -8,7 +8,7 @@ using PSWriteOffice.Services.Excel;
 namespace PSWriteOffice.Cmdlets.Excel;
 
 /// <summary>Writes tabular data to the current worksheet and formats it as an Excel table.</summary>
-/// <para>Accepts objects (PSCustomObject, hashtables, POCOs) and converts them into an Excel table with optional styling.</para>
+/// <para>Accepts objects, dictionaries, DataTable/DataView/IDataReader inputs, or DataRow sequences and writes them into an Excel table with optional styling.</para>
 /// <example>
 ///   <summary>Insert a table starting at A1.</summary>
 ///   <prefix>PS&gt; </prefix>
@@ -67,8 +67,7 @@ public sealed class AddOfficeExcelTableCommand : PSCmdlet
             throw new PSArgumentException("Provide at least one data row.", nameof(Data));
         }
 
-        var normalized = PowerShellObjectNormalizer.NormalizeItems(Data);
-        var table = ObjectDataTableBuilder.FromObjects(normalized);
+        var table = ExcelTabularInputService.ToDataTable(Data);
         if (table.Columns.Count == 0)
         {
             throw new InvalidOperationException("Unable to infer columns from the supplied data.");
@@ -89,7 +88,7 @@ public sealed class AddOfficeExcelTableCommand : PSCmdlet
             startRow: StartRow,
             startColumn: StartColumn,
             includeHeaders: !NoHeader.IsPresent,
-            tableName: TableName,
+            tableName: ResolveTableName(table),
             style: style,
             includeAutoFilter: !NoAutoFilter.IsPresent);
 
@@ -103,5 +102,15 @@ public sealed class AddOfficeExcelTableCommand : PSCmdlet
         {
             WriteObject(range);
         }
+    }
+
+    private string? ResolveTableName(System.Data.DataTable table)
+    {
+        if (!string.IsNullOrWhiteSpace(TableName))
+        {
+            return TableName;
+        }
+
+        return string.IsNullOrWhiteSpace(table.TableName) ? null : table.TableName;
     }
 }

--- a/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
@@ -169,6 +169,15 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
 
         try
         {
+            var dataSet = ExcelTabularInputService.TryGetSingleDataSet(_input);
+            if (dataSet != null)
+            {
+                ExportDataSet(document, dataSet, style);
+                ExcelDocumentService.SaveDocument(document, Open.IsPresent, resolvedPath);
+                WritePassThru(resolvedPath);
+                return;
+            }
+
             var isAppendingToExistingSheet = Append.IsPresent && SheetExists(document, WorksheetName);
             var sheet = PrepareSheet(document);
             var data = BuildDataTable();
@@ -188,7 +197,7 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
             }
 
             var appendTableName = ResolveAppendTableName(document, sheet, isAppendingToExistingSheet);
-            var range = WriteData(sheet, data, dataStartRow, includeHeaders, style, isAppendingToExistingSheet, appendTableName);
+            var range = WriteData(sheet, data, dataStartRow, includeHeaders, style, isAppendingToExistingSheet, appendTableName, ResolveTableName(data));
 
             if (BoldTopRow.IsPresent && includeHeaders)
             {
@@ -222,7 +231,67 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
 
         if (PassThru.IsPresent)
         {
-            WriteObject(new FileInfo(resolvedPath));
+            WritePassThru(resolvedPath);
+        }
+    }
+
+    private void ExportDataSet(ExcelDocument document, DataSet dataSet, TableStyle style)
+    {
+        if (dataSet.Tables.Count == 0)
+        {
+            throw new PSArgumentException("DataSet must contain at least one DataTable.", nameof(InputObject));
+        }
+
+        var tableIndex = 1;
+        foreach (DataTable sourceTable in dataSet.Tables)
+        {
+            var sheetName = string.IsNullOrWhiteSpace(sourceTable.TableName)
+                ? $"Table{tableIndex}"
+                : sourceTable.TableName;
+
+            var sheetExists = SheetExists(document, sheetName);
+            if (ClearSheet.IsPresent && sheetExists)
+            {
+                document.RemoveWorkSheet(sheetName);
+                sheetExists = false;
+            }
+
+            var sheet = document.GetOrCreateSheet(sheetName, SheetNameValidationMode.Sanitize);
+            var table = ApplyExcludedColumns(sourceTable.Copy());
+            if (table.Columns.Count == 0)
+            {
+                throw new InvalidOperationException($"Unable to infer columns from DataTable '{sourceTable.TableName}'.");
+            }
+
+            var isAppendingToExistingSheet = Append.IsPresent && sheetExists;
+            var dataStartRow = ResolveDataStartRow(sheet, isAppendingToExistingSheet);
+            var includeHeaders = !NoHeader.IsPresent && !isAppendingToExistingSheet;
+            var appendTableName = ResolveAppendTableName(document, sheet, isAppendingToExistingSheet);
+            var range = WriteData(sheet, table, dataStartRow, includeHeaders, style, isAppendingToExistingSheet, appendTableName, ResolveTableName(table, allowExplicitOverride: false));
+
+            if (BoldTopRow.IsPresent && includeHeaders)
+            {
+                BoldRow(sheet, dataStartRow, StartColumn, table.Columns.Count);
+            }
+
+            if (AutoFit.IsPresent)
+            {
+                sheet.AutoFitColumnsFor(Enumerable.Range(StartColumn, table.Columns.Count));
+            }
+
+            if (FreezeTopRow.IsPresent || FreezeFirstColumn.IsPresent)
+            {
+                var frozenRows = ResolveFrozenTopRows(document, sheet, isAppendingToExistingSheet, appendTableName, dataStartRow, includeHeaders);
+                var frozenColumns = FreezeFirstColumn.IsPresent ? Math.Max(1, StartColumn) : 0;
+                sheet.Freeze(frozenRows, frozenColumns);
+            }
+
+            if (!string.IsNullOrWhiteSpace(range))
+            {
+                WriteVerbose($"Exported DataTable '{sourceTable.TableName}' to {sheet.Name}!{range}.");
+            }
+
+            tableIndex++;
         }
     }
 
@@ -238,9 +307,12 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
 
     private DataTable BuildDataTable()
     {
-        var normalized = PowerShellObjectNormalizer.NormalizeItems(_input);
-        var table = ObjectDataTableBuilder.FromObjects(normalized);
+        var table = ExcelTabularInputService.ToDataTable(_input);
+        return ApplyExcludedColumns(table);
+    }
 
+    private DataTable ApplyExcludedColumns(DataTable table)
+    {
         if (ExcludeProperty is { Length: > 0 })
         {
             var excluded = new HashSet<string>(
@@ -259,7 +331,15 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
         return table;
     }
 
-    private string WriteData(ExcelSheet sheet, DataTable table, int startRow, bool includeHeaders, TableStyle style, bool appendRawRows, string? appendTableName)
+    private void WritePassThru(string resolvedPath)
+    {
+        if (PassThru.IsPresent)
+        {
+            WriteObject(new FileInfo(resolvedPath));
+        }
+    }
+
+    private string WriteData(ExcelSheet sheet, DataTable table, int startRow, bool includeHeaders, TableStyle style, bool appendRawRows, string? appendTableName, string? tableName)
     {
         if (appendRawRows &&
             !NoTable.IsPresent &&
@@ -276,7 +356,7 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
                 startRow,
                 StartColumn,
                 includeHeaders,
-                TableName,
+                tableName,
                 style,
                 includeAutoFilter: !NoAutoFilter.IsPresent);
         }
@@ -326,6 +406,16 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
             .ToList();
 
         return sheetTables.Count == 1 ? sheetTables[0].Name : null;
+    }
+
+    private string? ResolveTableName(DataTable table, bool allowExplicitOverride = true)
+    {
+        if (allowExplicitOverride && !string.IsNullOrWhiteSpace(TableName))
+        {
+            return TableName;
+        }
+
+        return string.IsNullOrWhiteSpace(table.TableName) ? null : table.TableName;
     }
 
     private int ResolveFrozenTopRows(ExcelDocument document, ExcelSheet sheet, bool appendToExistingSheet, string? appendTableName, int dataStartRow, bool includeHeaders)
@@ -411,6 +501,12 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
         if (value is PSObject psObject)
         {
             value = psObject.BaseObject is PSCustomObject ? psObject : psObject.BaseObject;
+        }
+
+        if (value is DataSet || value is DataTable || value is DataView || value is IDataReader)
+        {
+            _input.Add(value);
+            return;
         }
 
         if (value is IEnumerable enumerable && value is not string && value is not IDictionary)

--- a/Sources/PSWriteOffice/Services/Excel/ExcelTabularInputService.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelTabularInputService.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using OfficeIMO.Excel;
+using PSWriteOffice.Services;
+
+namespace PSWriteOffice.Services.Excel;
+
+internal static class ExcelTabularInputService
+{
+    public static DataTable ToDataTable(IEnumerable<object?> input, string tableName = "Data")
+    {
+        if (input == null)
+        {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        var items = input.Where(item => item != null).ToList();
+        if (items.Count == 0)
+        {
+            throw new ArgumentException("Provide at least one data row.", nameof(input));
+        }
+
+        if (items.Count == 1)
+        {
+            var single = Unwrap(items[0]);
+            if (single is DataTable dataTable)
+            {
+                return dataTable.Copy();
+            }
+
+            if (single is DataView dataView)
+            {
+                return dataView.ToTable();
+            }
+
+            if (single is IDataReader reader)
+            {
+                var dataTableFromReader = new DataTable(tableName);
+                dataTableFromReader.Load(reader);
+                return dataTableFromReader;
+            }
+        }
+
+        if (items.All(item => Unwrap(item) is DataRow))
+        {
+            return FromDataRows(items.Select(item => (DataRow)Unwrap(item)!).ToList());
+        }
+
+        if (items.All(item => Unwrap(item) is DataRowView))
+        {
+            return FromDataRows(items.Select(item => ((DataRowView)Unwrap(item)!).Row).ToList());
+        }
+
+        var normalized = PowerShellObjectNormalizer.NormalizeItems(items);
+        return ObjectDataTableBuilder.FromObjects(normalized, tableName);
+    }
+
+    public static DataSet? TryGetSingleDataSet(IEnumerable<object?> input)
+    {
+        if (input == null)
+        {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        var items = input.Where(item => item != null).Select(Unwrap).ToList();
+        return items.Count == 1 ? items[0] as DataSet : null;
+    }
+
+    private static DataTable FromDataRows(IReadOnlyList<DataRow> rows)
+    {
+        if (rows.Count == 0)
+        {
+            throw new ArgumentException("Provide at least one data row.", nameof(rows));
+        }
+
+        var source = rows[0].Table;
+        var result = source.Clone();
+        foreach (var row in rows)
+        {
+            if (!ReferenceEquals(row.Table, source))
+            {
+                throw new InvalidOperationException("DataRow inputs must come from the same DataTable.");
+            }
+
+            result.ImportRow(row);
+        }
+
+        return result;
+    }
+
+    private static object? Unwrap(object? item)
+    {
+        if (item is System.Management.Automation.PSObject psObject)
+        {
+            return psObject.BaseObject;
+        }
+
+        return item;
+    }
+}

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -108,6 +108,72 @@ Describe 'Excel DSL surface' {
         }
     }
 
+    It 'exports DataTable input without exposing DataRow metadata' {
+        $path = Join-Path $TestDrive 'ExportOfficeExcelDataTable.xlsx'
+        $table = [System.Data.DataTable]::new('Sales')
+        [void] $table.Columns.Add('Region', [string])
+        [void] $table.Columns.Add('Revenue', [int])
+        [void] $table.Rows.Add('NA', 100)
+        [void] $table.Rows.Add('EMEA', 200)
+
+        Export-OfficeExcel -Path $path -InputObject $table -WorksheetName 'Data' -TableName 'Sales' -AutoFit
+
+        $imported = @(Import-OfficeExcel -Path $path -WorksheetName 'Data' -Range 'A1:B3')
+        $imported.Count | Should -Be 2
+        $imported[0].Region | Should -Be 'NA'
+        $imported[0].Revenue | Should -Be 100
+        $imported[0].PSObject.Properties.Name | Should -Not -Contain 'RowError'
+    }
+
+    It 'exports DataSet input as one worksheet per table' {
+        $path = Join-Path $TestDrive 'ExportOfficeExcelDataSet.xlsx'
+        $dataSet = [System.Data.DataSet]::new('Report')
+
+        $sales = [System.Data.DataTable]::new('Sales:2026')
+        [void] $sales.Columns.Add('Region', [string])
+        [void] $sales.Columns.Add('Revenue', [int])
+        [void] $sales.Rows.Add('NA', 100)
+        [void] $dataSet.Tables.Add($sales)
+
+        $inventory = [System.Data.DataTable]::new('Inventory')
+        [void] $inventory.Columns.Add('Item', [string])
+        [void] $inventory.Columns.Add('Count', [int])
+        [void] $inventory.Rows.Add('Laptop', 5)
+        [void] $dataSet.Tables.Add($inventory)
+
+        Export-OfficeExcel -Path $path -InputObject $dataSet -TableName 'IgnoredForDataSet' -AutoFit
+
+        $salesRows = @(Import-OfficeExcel -Path $path -WorksheetName 'Sales_2026' -Range 'A1:B2')
+        $inventoryRows = @(Import-OfficeExcel -Path $path -WorksheetName 'Inventory' -Range 'A1:B2')
+
+        $salesRows.Count | Should -Be 1
+        $salesRows[0].Region | Should -Be 'NA'
+        $salesRows[0].Revenue | Should -Be 100
+        $inventoryRows.Count | Should -Be 1
+        $inventoryRows[0].Item | Should -Be 'Laptop'
+        $inventoryRows[0].Count | Should -Be 5
+    }
+
+    It 'adds a DataTable inside the Excel DSL table command' {
+        $path = Join-Path $TestDrive 'DslExcelDataTable.xlsx'
+        $table = [System.Data.DataTable]::new('Items')
+        [void] $table.Columns.Add('Name', [string])
+        [void] $table.Columns.Add('Quantity', [int])
+        [void] $table.Rows.Add('Laptop', 5)
+        [void] $table.Rows.Add('Tablet', 12)
+
+        New-OfficeExcel -Path $path {
+            Add-OfficeExcelSheet -Name 'Data' -Content {
+                Add-OfficeExcelTable -Data $table -TableName 'Items' -AutoFit
+            }
+        }
+
+        $imported = @(Import-OfficeExcel -Path $path -WorksheetName 'Data' -Range 'A1:B3')
+        $imported.Count | Should -Be 2
+        $imported[0].Name | Should -Be 'Laptop'
+        $imported[0].Quantity | Should -Be 5
+    }
+
     It 'keeps append freeze panes anchored to the existing table header' {
         $path = Join-Path $TestDrive 'ExportOfficeExcelAppendFreeze.xlsx'
         $rows = @(


### PR DESCRIPTION
## Summary
- add PSWriteOffice tabular input normalization for DataTable, DataSet, DataView, IDataReader, DataRow, and DataRowView
- preserve DataTable/DataSet shape instead of projecting DataRow metadata
- keep the implementation on published OfficeIMO APIs so CI does not need unreleased engine packages

## Validation
- dotnet build Sources/PSWriteOffice/PSWriteOffice.csproj --framework net8.0 /p:OfficeIMORoot=C:/Support/GitHub/_missing_OfficeIMO /p:UseSharedCompilation=false
- dotnet build Sources/PSWriteOffice/PSWriteOffice.csproj --framework net472 /p:OfficeIMORoot=C:/Support/GitHub/_missing_OfficeIMO /p:UseSharedCompilation=false
- pwsh -NoProfile -Command "$env:PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES='true'; Import-Module ./PSWriteOffice.psd1 -Force; Invoke-Pester -Path ./Tests/ExcelDsl.Tests.ps1 -Output Detailed"
- git diff --check
