### PR TITLE
Fix Excel dataset sheet and table name follow-ups

### DIFF
--- a/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableCommand.cs
@@ -67,7 +67,7 @@ public sealed class AddOfficeExcelTableCommand : PSCmdlet
             throw new PSArgumentException("Provide at least one data row.", nameof(Data));
         }
 
-        var table = ExcelTabularInputService.ToDataTable(Data);
+        var table = ExcelTabularInputService.ToDataTable(Data, TableName);
         if (table.Columns.Count == 0)
         {
             throw new InvalidOperationException("Unable to infer columns from the supplied data.");

--- a/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
@@ -242,7 +242,7 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
             throw new PSArgumentException("DataSet must contain at least one DataTable.", nameof(InputObject));
         }
 
-        var sheetNames = BuildDataSetWorksheetNames(dataSet);
+        var sheetNames = BuildDataSetWorksheetNames(document, dataSet, Append.IsPresent || ClearSheet.IsPresent);
         var tableIndex = 1;
         foreach (DataTable sourceTable in dataSet.Tables)
         {
@@ -539,10 +539,13 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
             string.Equals(sheet.Name, normalized, StringComparison.OrdinalIgnoreCase));
     }
 
-    private static string[] BuildDataSetWorksheetNames(DataSet dataSet)
+    private static string[] BuildDataSetWorksheetNames(ExcelDocument document, DataSet dataSet, bool allowExistingMatches)
     {
         var names = new List<string>(dataSet.Tables.Count);
         var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var existing = new HashSet<string>(
+            document.Sheets.Select(sheet => sheet.Name).Where(name => !string.IsNullOrWhiteSpace(name)),
+            StringComparer.OrdinalIgnoreCase);
         var tableIndex = 1;
         foreach (DataTable table in dataSet.Tables)
         {
@@ -550,20 +553,32 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
                 ? $"Table{tableIndex}"
                 : table.TableName;
 
-            var cleaned = NormalizeWorksheetName(requested);
-            var candidate = cleaned;
-            var suffix = 2;
-            while (used.Contains(candidate))
+            var normalized = NormalizeWorksheetNameInfo(requested);
+            var candidate = allowExistingMatches && !normalized.UsedDefaultFallback
+                ? FindExistingWorksheetName(document, requested, normalized.Name)
+                : null;
+
+            string candidateName;
+            if (!string.IsNullOrWhiteSpace(candidate) && !used.Contains(candidate!))
             {
-                var suffixText = $" ({suffix})";
-                var maxBase = 31 - suffixText.Length;
-                var basePart = cleaned.Length > maxBase ? cleaned.Substring(0, maxBase) : cleaned;
-                candidate = basePart + suffixText;
-                suffix++;
+                candidateName = candidate!;
+            }
+            else
+            {
+                candidateName = normalized.Name;
+                var suffix = 2;
+                while (used.Contains(candidateName) || existing.Contains(candidateName))
+                {
+                    var suffixText = $" ({suffix})";
+                    var maxBase = 31 - suffixText.Length;
+                    var basePart = normalized.Name.Length > maxBase ? normalized.Name.Substring(0, maxBase) : normalized.Name;
+                    candidateName = basePart + suffixText;
+                    suffix++;
+                }
             }
 
-            used.Add(candidate);
-            names.Add(candidate);
+            used.Add(candidateName);
+            names.Add(candidateName);
             tableIndex++;
         }
 
@@ -571,6 +586,11 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
     }
 
     private static string NormalizeWorksheetName(string worksheetName)
+    {
+        return NormalizeWorksheetNameInfo(worksheetName).Name;
+    }
+
+    private static (string Name, bool UsedDefaultFallback) NormalizeWorksheetNameInfo(string worksheetName)
     {
         var baseName = (worksheetName ?? string.Empty).Trim().Trim('\'', ' ');
         var chars = new char[baseName.Length];
@@ -581,12 +601,24 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
         }
 
         var cleaned = CollapseUnderscores(new string(chars).Trim()).Trim('_');
+        var usedDefaultFallback = false;
         if (string.IsNullOrEmpty(cleaned))
         {
             cleaned = "Sheet1";
+            usedDefaultFallback = true;
         }
 
-        return cleaned.Length > 31 ? cleaned.Substring(0, 31) : cleaned;
+        var name = cleaned.Length > 31 ? cleaned.Substring(0, 31) : cleaned;
+        return (name, usedDefaultFallback);
+    }
+
+    private static string? FindExistingWorksheetName(ExcelDocument document, string requestedName, string normalizedName)
+    {
+        return document.Sheets
+            .Select(sheet => sheet.Name)
+            .FirstOrDefault(name =>
+                string.Equals(name, requestedName, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(name, normalizedName, StringComparison.OrdinalIgnoreCase));
     }
 
     private static string CollapseUnderscores(string value)

--- a/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
@@ -242,12 +242,11 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
             throw new PSArgumentException("DataSet must contain at least one DataTable.", nameof(InputObject));
         }
 
+        var sheetNames = BuildDataSetWorksheetNames(dataSet);
         var tableIndex = 1;
         foreach (DataTable sourceTable in dataSet.Tables)
         {
-            var sheetName = string.IsNullOrWhiteSpace(sourceTable.TableName)
-                ? $"Table{tableIndex}"
-                : sourceTable.TableName;
+            var sheetName = sheetNames[tableIndex - 1];
 
             var sheetExists = SheetExists(document, sheetName);
             if (ClearSheet.IsPresent && sheetExists)
@@ -307,7 +306,7 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
 
     private DataTable BuildDataTable()
     {
-        var table = ExcelTabularInputService.ToDataTable(_input);
+        var table = ExcelTabularInputService.ToDataTable(_input, TableName);
         return ApplyExcludedColumns(table);
     }
 
@@ -534,6 +533,88 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
 
     private static bool SheetExists(ExcelDocument document, string worksheetName)
     {
-        return document.Sheets.Any(sheet => string.Equals(sheet.Name, worksheetName, StringComparison.OrdinalIgnoreCase));
+        var normalized = NormalizeWorksheetName(worksheetName);
+        return document.Sheets.Any(sheet =>
+            string.Equals(sheet.Name, worksheetName, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(sheet.Name, normalized, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string[] BuildDataSetWorksheetNames(DataSet dataSet)
+    {
+        var names = new List<string>(dataSet.Tables.Count);
+        var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var tableIndex = 1;
+        foreach (DataTable table in dataSet.Tables)
+        {
+            var requested = string.IsNullOrWhiteSpace(table.TableName)
+                ? $"Table{tableIndex}"
+                : table.TableName;
+
+            var cleaned = NormalizeWorksheetName(requested);
+            var candidate = cleaned;
+            var suffix = 2;
+            while (used.Contains(candidate))
+            {
+                var suffixText = $" ({suffix})";
+                var maxBase = 31 - suffixText.Length;
+                var basePart = cleaned.Length > maxBase ? cleaned.Substring(0, maxBase) : cleaned;
+                candidate = basePart + suffixText;
+                suffix++;
+            }
+
+            used.Add(candidate);
+            names.Add(candidate);
+            tableIndex++;
+        }
+
+        return names.ToArray();
+    }
+
+    private static string NormalizeWorksheetName(string worksheetName)
+    {
+        var baseName = (worksheetName ?? string.Empty).Trim().Trim('\'', ' ');
+        var chars = new char[baseName.Length];
+        for (var i = 0; i < baseName.Length; i++)
+        {
+            var ch = baseName[i];
+            chars[i] = ch is ':' or '\\' or '/' or '?' or '*' or '[' or ']' ? '_' : ch;
+        }
+
+        var cleaned = CollapseUnderscores(new string(chars).Trim()).Trim('_');
+        if (string.IsNullOrEmpty(cleaned))
+        {
+            cleaned = "Sheet1";
+        }
+
+        return cleaned.Length > 31 ? cleaned.Substring(0, 31) : cleaned;
+    }
+
+    private static string CollapseUnderscores(string value)
+    {
+        if (value.IndexOf("__", StringComparison.Ordinal) < 0)
+        {
+            return value;
+        }
+
+        var result = new System.Text.StringBuilder(value.Length);
+        var previousWasUnderscore = false;
+        foreach (var ch in value)
+        {
+            if (ch == '_')
+            {
+                if (!previousWasUnderscore)
+                {
+                    result.Append(ch);
+                }
+
+                previousWasUnderscore = true;
+                continue;
+            }
+
+            result.Append(ch);
+            previousWasUnderscore = false;
+        }
+
+        return result.ToString();
     }
 }

--- a/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
@@ -555,7 +555,7 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
 
             var normalized = NormalizeWorksheetNameInfo(requested);
             var candidate = allowExistingMatches && !normalized.UsedDefaultFallback
-                ? FindExistingWorksheetName(document, requested, normalized.Name)
+                ? FindExistingWorksheetName(document, requested, normalized.Name, used)
                 : null;
 
             string candidateName;
@@ -569,10 +569,7 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
                 var suffix = 2;
                 while (used.Contains(candidateName) || existing.Contains(candidateName))
                 {
-                    var suffixText = $" ({suffix})";
-                    var maxBase = 31 - suffixText.Length;
-                    var basePart = normalized.Name.Length > maxBase ? normalized.Name.Substring(0, maxBase) : normalized.Name;
-                    candidateName = basePart + suffixText;
+                    candidateName = AppendWorksheetSuffix(normalized.Name, suffix);
                     suffix++;
                 }
             }
@@ -612,13 +609,40 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
         return (name, usedDefaultFallback);
     }
 
-    private static string? FindExistingWorksheetName(ExcelDocument document, string requestedName, string normalizedName)
+    private static string? FindExistingWorksheetName(ExcelDocument document, string requestedName, string normalizedName, ISet<string> usedNames)
     {
-        return document.Sheets
+        var existing = document.Sheets
             .Select(sheet => sheet.Name)
-            .FirstOrDefault(name =>
-                string.Equals(name, requestedName, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(name, normalizedName, StringComparison.OrdinalIgnoreCase));
+            .Where(name => !string.IsNullOrWhiteSpace(name) && !usedNames.Contains(name))
+            .ToArray();
+
+        var directMatch = existing.FirstOrDefault(name =>
+            string.Equals(name, requestedName, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(name, normalizedName, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(directMatch))
+        {
+            return directMatch;
+        }
+
+        for (var suffix = 2; suffix <= existing.Length + usedNames.Count + 1; suffix++)
+        {
+            var suffixedName = AppendWorksheetSuffix(normalizedName, suffix);
+            var match = existing.FirstOrDefault(name => string.Equals(name, suffixedName, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrWhiteSpace(match))
+            {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    private static string AppendWorksheetSuffix(string worksheetName, int suffix)
+    {
+        var suffixText = $" ({suffix})";
+        var maxBase = 31 - suffixText.Length;
+        var basePart = worksheetName.Length > maxBase ? worksheetName.Substring(0, maxBase) : worksheetName;
+        return basePart + suffixText;
     }
 
     private static string CollapseUnderscores(string value)

--- a/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
@@ -554,8 +554,8 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
                 : table.TableName;
 
             var normalized = NormalizeWorksheetNameInfo(requested);
-            var candidate = allowExistingMatches && !normalized.UsedDefaultFallback
-                ? FindExistingWorksheetName(document, requested, normalized.Name, used)
+            var candidate = allowExistingMatches
+                ? FindExistingWorksheetName(document, requested, normalized.Name, used, allowDirectNormalizedMatch: !normalized.UsedDefaultFallback)
                 : null;
 
             string candidateName;
@@ -609,7 +609,12 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
         return (name, usedDefaultFallback);
     }
 
-    private static string? FindExistingWorksheetName(ExcelDocument document, string requestedName, string normalizedName, ISet<string> usedNames)
+    private static string? FindExistingWorksheetName(
+        ExcelDocument document,
+        string requestedName,
+        string normalizedName,
+        ISet<string> usedNames,
+        bool allowDirectNormalizedMatch)
     {
         var existing = document.Sheets
             .Select(sheet => sheet.Name)
@@ -618,7 +623,7 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
 
         var directMatch = existing.FirstOrDefault(name =>
             string.Equals(name, requestedName, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(name, normalizedName, StringComparison.OrdinalIgnoreCase));
+            (allowDirectNormalizedMatch && string.Equals(name, normalizedName, StringComparison.OrdinalIgnoreCase)));
         if (!string.IsNullOrWhiteSpace(directMatch))
         {
             return directMatch;

--- a/Sources/PSWriteOffice/Services/Excel/ExcelTabularInputService.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelTabularInputService.cs
@@ -9,7 +9,7 @@ namespace PSWriteOffice.Services.Excel;
 
 internal static class ExcelTabularInputService
 {
-    public static DataTable ToDataTable(IEnumerable<object?> input, string tableName = "Data")
+    public static DataTable ToDataTable(IEnumerable<object?> input, string? tableName = null)
     {
         if (input == null)
         {
@@ -37,7 +37,9 @@ internal static class ExcelTabularInputService
 
             if (single is IDataReader reader)
             {
-                var dataTableFromReader = new DataTable(tableName);
+                var dataTableFromReader = string.IsNullOrWhiteSpace(tableName)
+                    ? new DataTable()
+                    : new DataTable(tableName);
                 dataTableFromReader.Load(reader);
                 return dataTableFromReader;
             }
@@ -54,7 +56,7 @@ internal static class ExcelTabularInputService
         }
 
         var normalized = PowerShellObjectNormalizer.NormalizeItems(items);
-        return ObjectDataTableBuilder.FromObjects(normalized, tableName);
+        return ObjectDataTableBuilder.FromObjects(normalized, tableName ?? string.Empty);
     }
 
     public static DataSet? TryGetSingleDataSet(IEnumerable<object?> input)

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -226,6 +226,44 @@ Describe 'Excel DSL surface' {
         $rows.Count | Should -Be 1
         $rows[0].Region | Should -Be 'NA'
         $rows[0].Revenue | Should -Be 100
+
+        $appendSet = [System.Data.DataSet]::new('Report')
+        $appendTable = [System.Data.DataTable]::new(':')
+        [void] $appendTable.Columns.Add('Region', [string])
+        [void] $appendTable.Columns.Add('Revenue', [int])
+        [void] $appendTable.Rows.Add('EMEA', 200)
+        [void] $appendSet.Tables.Add($appendTable)
+
+        Export-OfficeExcel -Path $path -InputObject $appendSet -Append
+
+        $appendedRows = @(Import-OfficeExcel -Path $path -WorksheetName 'Sheet1 (2)' -Range 'A1:B3')
+        $appendedRows.Count | Should -Be 2
+        $appendedRows[1].Region | Should -Be 'EMEA'
+        $appendedRows[1].Revenue | Should -Be 200
+
+        $replacementSet = [System.Data.DataSet]::new('Report')
+        $replacementTable = [System.Data.DataTable]::new(':')
+        [void] $replacementTable.Columns.Add('Region', [string])
+        [void] $replacementTable.Columns.Add('Revenue', [int])
+        [void] $replacementTable.Rows.Add('APAC', 300)
+        [void] $replacementSet.Tables.Add($replacementTable)
+
+        Export-OfficeExcel -Path $path -InputObject $replacementSet -ClearSheet
+
+        $replacedRows = @(Import-OfficeExcel -Path $path -WorksheetName 'Sheet1 (2)' -Range 'A1:B2')
+        $replacedRows.Count | Should -Be 1
+        $replacedRows[0].Region | Should -Be 'APAC'
+        $replacedRows[0].Revenue | Should -Be 300
+
+        $doc = Get-OfficeExcel -Path $path -ReadOnly
+        try {
+            $existingText = $null
+            $doc['Sheet1'].TryGetCellText(1, 1, [ref] $existingText) | Should -BeTrue
+            $existingText | Should -Be 'Existing'
+            $doc.Sheets.Name | Should -Not -Contain 'Sheet1 (3)'
+        } finally {
+            Close-OfficeExcel -Document $doc
+        }
     }
 
     It 'reuses existing suffixed DataSet sheets when appending and clearing sanitized duplicates' {

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -228,6 +228,76 @@ Describe 'Excel DSL surface' {
         $rows[0].Revenue | Should -Be 100
     }
 
+    It 'reuses existing suffixed DataSet sheets when appending and clearing sanitized duplicates' {
+        $path = Join-Path $TestDrive 'ExportOfficeExcelDataSetDuplicateSanitizedAppend.xlsx'
+
+        $dataSet = [System.Data.DataSet]::new('Report')
+        $salesColon = [System.Data.DataTable]::new('Sales:2026')
+        [void] $salesColon.Columns.Add('Region', [string])
+        [void] $salesColon.Columns.Add('Revenue', [int])
+        [void] $salesColon.Rows.Add('NA', 100)
+        [void] $dataSet.Tables.Add($salesColon)
+
+        $salesSlash = [System.Data.DataTable]::new('Sales/2026')
+        [void] $salesSlash.Columns.Add('Region', [string])
+        [void] $salesSlash.Columns.Add('Revenue', [int])
+        [void] $salesSlash.Rows.Add('EMEA', 200)
+        [void] $dataSet.Tables.Add($salesSlash)
+
+        Export-OfficeExcel -Path $path -InputObject $dataSet
+
+        $appendSet = [System.Data.DataSet]::new('Report')
+        $appendColon = [System.Data.DataTable]::new('Sales:2026')
+        [void] $appendColon.Columns.Add('Region', [string])
+        [void] $appendColon.Columns.Add('Revenue', [int])
+        [void] $appendColon.Rows.Add('APAC', 300)
+        [void] $appendSet.Tables.Add($appendColon)
+
+        $appendSlash = [System.Data.DataTable]::new('Sales/2026')
+        [void] $appendSlash.Columns.Add('Region', [string])
+        [void] $appendSlash.Columns.Add('Revenue', [int])
+        [void] $appendSlash.Rows.Add('LATAM', 400)
+        [void] $appendSet.Tables.Add($appendSlash)
+
+        Export-OfficeExcel -Path $path -InputObject $appendSet -Append
+
+        $firstRows = @(Import-OfficeExcel -Path $path -WorksheetName 'Sales_2026' -Range 'A1:B3')
+        $secondRows = @(Import-OfficeExcel -Path $path -WorksheetName 'Sales_2026 (2)' -Range 'A1:B3')
+        $firstRows.Count | Should -Be 2
+        $secondRows.Count | Should -Be 2
+        $firstRows[1].Region | Should -Be 'APAC'
+        $secondRows[1].Region | Should -Be 'LATAM'
+
+        $doc = Get-OfficeExcel -Path $path -ReadOnly
+        try {
+            $doc.Sheets.Name | Should -Not -Contain 'Sales_2026 (3)'
+        } finally {
+            Close-OfficeExcel -Document $doc
+        }
+
+        $replacementSet = [System.Data.DataSet]::new('Report')
+        $replacementColon = [System.Data.DataTable]::new('Sales:2026')
+        [void] $replacementColon.Columns.Add('Region', [string])
+        [void] $replacementColon.Columns.Add('Revenue', [int])
+        [void] $replacementColon.Rows.Add('NA', 500)
+        [void] $replacementSet.Tables.Add($replacementColon)
+
+        $replacementSlash = [System.Data.DataTable]::new('Sales/2026')
+        [void] $replacementSlash.Columns.Add('Region', [string])
+        [void] $replacementSlash.Columns.Add('Revenue', [int])
+        [void] $replacementSlash.Rows.Add('EMEA', 600)
+        [void] $replacementSet.Tables.Add($replacementSlash)
+
+        Export-OfficeExcel -Path $path -InputObject $replacementSet -ClearSheet
+
+        $replacedFirst = @(Import-OfficeExcel -Path $path -WorksheetName 'Sales_2026' -Range 'A1:B2')
+        $replacedSecond = @(Import-OfficeExcel -Path $path -WorksheetName 'Sales_2026 (2)' -Range 'A1:B2')
+        $replacedFirst.Count | Should -Be 1
+        $replacedSecond.Count | Should -Be 1
+        $replacedFirst[0].Revenue | Should -Be 500
+        $replacedSecond[0].Revenue | Should -Be 600
+    }
+
     It 'adds a DataTable inside the Excel DSL table command' {
         $path = Join-Path $TestDrive 'DslExcelDataTable.xlsx'
         $table = [System.Data.DataTable]::new('Items')

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -154,6 +154,47 @@ Describe 'Excel DSL surface' {
         $inventoryRows[0].Count | Should -Be 5
     }
 
+    It 'appends and clears DataSet sheets using sanitized worksheet names' {
+        $path = Join-Path $TestDrive 'ExportOfficeExcelDataSetSanitizedAppend.xlsx'
+
+        $dataSet = [System.Data.DataSet]::new('Report')
+        $sales = [System.Data.DataTable]::new('Sales:2026')
+        [void] $sales.Columns.Add('Region', [string])
+        [void] $sales.Columns.Add('Revenue', [int])
+        [void] $sales.Rows.Add('NA', 100)
+        [void] $dataSet.Tables.Add($sales)
+
+        Export-OfficeExcel -Path $path -InputObject $dataSet
+
+        $appendSet = [System.Data.DataSet]::new('Report')
+        $appendSales = [System.Data.DataTable]::new('Sales:2026')
+        [void] $appendSales.Columns.Add('Region', [string])
+        [void] $appendSales.Columns.Add('Revenue', [int])
+        [void] $appendSales.Rows.Add('EMEA', 200)
+        [void] $appendSet.Tables.Add($appendSales)
+
+        Export-OfficeExcel -Path $path -InputObject $appendSet -Append
+
+        $rows = @(Import-OfficeExcel -Path $path -WorksheetName 'Sales_2026' -Range 'A1:B3')
+        $rows.Count | Should -Be 2
+        $rows[1].Region | Should -Be 'EMEA'
+        $rows[1].Revenue | Should -Be 200
+
+        $replacementSet = [System.Data.DataSet]::new('Report')
+        $replacementSales = [System.Data.DataTable]::new('Sales:2026')
+        [void] $replacementSales.Columns.Add('Region', [string])
+        [void] $replacementSales.Columns.Add('Revenue', [int])
+        [void] $replacementSales.Rows.Add('APAC', 300)
+        [void] $replacementSet.Tables.Add($replacementSales)
+
+        Export-OfficeExcel -Path $path -InputObject $replacementSet -ClearSheet
+
+        $replaced = @(Import-OfficeExcel -Path $path -WorksheetName 'Sales_2026' -Range 'A1:B2')
+        $replaced.Count | Should -Be 1
+        $replaced[0].Region | Should -Be 'APAC'
+        $replaced[0].Revenue | Should -Be 300
+    }
+
     It 'adds a DataTable inside the Excel DSL table command' {
         $path = Join-Path $TestDrive 'DslExcelDataTable.xlsx'
         $table = [System.Data.DataTable]::new('Items')
@@ -172,6 +213,26 @@ Describe 'Excel DSL surface' {
         $imported.Count | Should -Be 2
         $imported[0].Name | Should -Be 'Laptop'
         $imported[0].Quantity | Should -Be 5
+    }
+
+    It 'lets OfficeIMO generate table names when the DSL caller omits them' {
+        $path = Join-Path $TestDrive 'DslExcelGeneratedTableNames.xlsx'
+        $rows = @(
+            [PSCustomObject]@{ Region = 'NA'; Revenue = 100 }
+        )
+
+        New-OfficeExcel -Path $path {
+            Add-OfficeExcelSheet -Name 'First' -Content {
+                Add-OfficeExcelTable -Data $rows
+            }
+            Add-OfficeExcelSheet -Name 'Second' -Content {
+                Add-OfficeExcelTable -Data $rows
+            }
+        }
+
+        $tables = @(Get-OfficeExcelTable -Path $path)
+        $tables.Count | Should -Be 2
+        @($tables.Name | Select-Object -Unique).Count | Should -Be 2
     }
 
     It 'keeps append freeze panes anchored to the existing table header' {

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -195,6 +195,39 @@ Describe 'Excel DSL surface' {
         $replaced[0].Revenue | Should -Be 300
     }
 
+    It 'keeps DataSet fallback sheet names unique against existing workbook sheets' {
+        $path = Join-Path $TestDrive 'ExportOfficeExcelDataSetFallbackCollision.xlsx'
+
+        New-OfficeExcel -Path $path {
+            Add-OfficeExcelSheet -Name 'Sheet1' -Content {
+                Set-OfficeExcelCell -Address 'A1' -Value 'Existing'
+            }
+        }
+
+        $dataSet = [System.Data.DataSet]::new('Report')
+        $table = [System.Data.DataTable]::new(':')
+        [void] $table.Columns.Add('Region', [string])
+        [void] $table.Columns.Add('Revenue', [int])
+        [void] $table.Rows.Add('NA', 100)
+        [void] $dataSet.Tables.Add($table)
+
+        Export-OfficeExcel -Path $path -InputObject $dataSet -Append
+
+        $doc = Get-OfficeExcel -Path $path -ReadOnly
+        try {
+            $existingText = $null
+            $doc['Sheet1'].TryGetCellText(1, 1, [ref] $existingText) | Should -BeTrue
+            $existingText | Should -Be 'Existing'
+        } finally {
+            Close-OfficeExcel -Document $doc
+        }
+
+        $rows = @(Import-OfficeExcel -Path $path -WorksheetName 'Sheet1 (2)' -Range 'A1:B2')
+        $rows.Count | Should -Be 1
+        $rows[0].Region | Should -Be 'NA'
+        $rows[0].Revenue | Should -Be 100
+    }
+
     It 'adds a DataTable inside the Excel DSL table command' {
         $path = Join-Path $TestDrive 'DslExcelDataTable.xlsx'
         $table = [System.Data.DataTable]::new('Items')


### PR DESCRIPTION
## Summary
- match DataSet worksheets by sanitized names for append and clear flows
- stop assigning a default Data table name when callers omit -TableName
- pass explicit table names through object/reader conversion only when requested

## Tests
- dotnet build Sources\PSWriteOffice\PSWriteOffice.csproj -f net8.0 /p:OfficeIMORoot=C:\Support\GitHub\OfficeIMO-excel-review-followups
- dotnet build Sources\PSWriteOffice\PSWriteOffice.csproj -f net472 /p:OfficeIMORoot=C:\Support\GitHub\OfficeIMO-excel-review-followups
- pwsh -NoProfile -File .\PSWriteOffice.Tests.ps1 -SkipDependencyInstall -TestsPath .\Tests\ExcelDsl.Tests.ps1
- git diff --check