### PR TITLE
Optimize PowerShell object normalization

### DIFF
--- a/Sources/PSWriteOffice/Services/PowerShellObjectNormalizer.cs
+++ b/Sources/PSWriteOffice/Services/PowerShellObjectNormalizer.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Management.Automation;
 
 namespace PSWriteOffice.Services;
@@ -11,7 +10,17 @@ internal static class PowerShellObjectNormalizer
     public static IReadOnlyList<object?> NormalizeItems(IEnumerable<object?> items)
     {
         if (items == null) throw new ArgumentNullException(nameof(items));
-        return items.Select(NormalizeItem).ToList();
+
+        var result = items is ICollection<object?> collection
+            ? new List<object?>(collection.Count)
+            : new List<object?>();
+
+        foreach (var item in items)
+        {
+            result.Add(NormalizeItem(item));
+        }
+
+        return result;
     }
 
     public static object? NormalizeItem(object? item)
@@ -27,19 +36,27 @@ internal static class PowerShellObjectNormalizer
             return dict;
         }
 
-        var properties = ps.Properties
-            .Where(p => p.MemberType == PSMemberTypes.NoteProperty || p.MemberType == PSMemberTypes.Property)
-            .Select(p => p.Name)
-            .Where(n => !string.IsNullOrWhiteSpace(n))
-            .ToList();
-
-        if (properties.Count > 0)
+        Dictionary<string, object?>? result = null;
+        foreach (var property in ps.Properties)
         {
-            var result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-            foreach (var name in properties)
+            if (property.MemberType != PSMemberTypes.NoteProperty &&
+                property.MemberType != PSMemberTypes.Property)
             {
-                result[name] = ps.Properties[name]?.Value;
+                continue;
             }
+
+            string name = property.Name;
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            result ??= new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+            result[name] = property.Value;
+        }
+
+        if (result != null)
+        {
             return result;
         }
 


### PR DESCRIPTION
## Summary
- make PowerShell object normalization a single-pass projection
- remove LINQ chaining and repeated property lookup during export normalization
- preserve the existing public API and output shape for dictionaries and PSObject properties

## Why
The Excel export hot path normalizes PowerShell pipeline objects before handing them to OfficeIMO. The old path built intermediate property-name lists and looked properties up again by name for every row. This change keeps the same behavior while reducing wrapper overhead.

## Validation
- focused 25k-row default export A/B: optimized normalizer `254.704 ms` median vs old normalizer `307.946 ms`
- `dotnet build .\Sources\PSWriteOffice\PSWriteOffice.csproj -c Release --framework net8.0 --no-restore`
- `dotnet build .\Sources\PSWriteOffice\PSWriteOffice.csproj -c Release --framework net472 --no-restore`
- `Invoke-Pester -Path .\Tests\ExcelDsl.Tests.ps1 -CI`: `44 passed`
- release smoke export/import passed for typed `PSCustomObject` rows and dictionary rows
- combined PSWriteOffice + optimized OfficeIMO benchmark at 25k rows: default export `182.99 ms` median vs ExcelFast `198.31 ms`, while preserving numeric/bool/date types
