### PR TITLE
Use direct data reader exports for Excel

### DIFF
--- a/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
@@ -186,6 +186,21 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
             }
 
             var isAppendingToExistingSheet = Append.IsPresent && SheetExists(document, WorksheetName);
+            var reader = ExcelTabularInputService.TryGetSingleDataReader(_input);
+            if (reader != null && CanExportReaderDirectly(isAppendingToExistingSheet))
+            {
+                var readerSheet = PrepareSheet(document);
+                var readerRange = ExportDataReader(readerSheet, reader, style);
+                if (!string.IsNullOrWhiteSpace(readerRange))
+                {
+                    WriteVerbose($"Exported data reader to {readerSheet.Name}!{readerRange}.");
+                }
+
+                ExcelDocumentService.SaveDocument(document, Open.IsPresent, resolvedPath);
+                WritePassThru(resolvedPath);
+                return;
+            }
+
             var sheet = PrepareSheet(document);
             var data = BuildDataTable();
             if (data.Columns.Count == 0)
@@ -240,6 +255,50 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
         {
             WritePassThru(resolvedPath);
         }
+    }
+
+    private bool CanExportReaderDirectly(bool isAppendingToExistingSheet)
+    {
+        return !isAppendingToExistingSheet && ExcludeProperty is not { Length: > 0 };
+    }
+
+    private string ExportDataReader(ExcelSheet sheet, IDataReader reader, TableStyle style)
+    {
+        var dataStartRow = StartRow;
+        if (!string.IsNullOrWhiteSpace(Title))
+        {
+            sheet.Cell(dataStartRow, StartColumn, Title!);
+            sheet.CellBold(dataStartRow, StartColumn, true);
+            dataStartRow++;
+        }
+
+        var range = sheet.InsertDataReader(
+            reader,
+            startRow: dataStartRow,
+            startColumn: StartColumn,
+            includeHeaders: !NoHeader.IsPresent,
+            tableName: TableName,
+            style: style,
+            includeAutoFilter: !NoAutoFilter.IsPresent,
+            createTable: !NoTable.IsPresent,
+            autoFit: AutoFit.IsPresent);
+
+        if (!string.IsNullOrWhiteSpace(range))
+        {
+            if (BoldTopRow.IsPresent && !NoHeader.IsPresent)
+            {
+                BoldRow(sheet, dataStartRow, StartColumn, reader.FieldCount);
+            }
+
+            if (FreezeTopRow.IsPresent || FreezeFirstColumn.IsPresent)
+            {
+                var frozenRows = FreezeTopRow.IsPresent ? Math.Max(1, !NoHeader.IsPresent ? dataStartRow : StartRow) : 0;
+                var frozenColumns = FreezeFirstColumn.IsPresent ? Math.Max(1, StartColumn) : 0;
+                sheet.Freeze(frozenRows, frozenColumns);
+            }
+        }
+
+        return range;
     }
 
     private void ExportDataSet(ExcelDocument document, DataSet dataSet, TableStyle style)

--- a/Sources/PSWriteOffice/Services/Excel/ExcelTabularInputService.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelTabularInputService.cs
@@ -128,6 +128,34 @@ internal static class ExcelTabularInputService
         return count == 1 ? dataSet : null;
     }
 
+    public static IDataReader? TryGetSingleDataReader(IEnumerable<object?> input)
+    {
+        if (input == null)
+        {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        IDataReader? reader = null;
+        var count = 0;
+        foreach (var item in input)
+        {
+            if (item == null)
+            {
+                continue;
+            }
+
+            count++;
+            if (count > 1)
+            {
+                return null;
+            }
+
+            reader = Unwrap(item) as IDataReader;
+        }
+
+        return count == 1 ? reader : null;
+    }
+
     private static DataTable FromDataRows(IReadOnlyList<DataRow> rows)
     {
         if (rows.Count == 0)

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -264,6 +264,23 @@ Describe 'Excel DSL surface' {
         $imported[0].PSObject.Properties.Name | Should -Not -Contain 'RowError'
     }
 
+    It 'exports IDataReader input without requiring callers to buffer it first' {
+        $path = Join-Path $TestDrive 'ExportOfficeExcelDataReader.xlsx'
+        $table = [System.Data.DataTable]::new('SqlRows')
+        [void] $table.Columns.Add('Name', [string])
+        [void] $table.Columns.Add('Value', [int])
+        [void] $table.Rows.Add('A', 1)
+        [void] $table.Rows.Add('B', 2)
+        $reader = $table.CreateDataReader()
+
+        Export-OfficeExcel -Path $path -InputObject $reader -WorksheetName 'Data' -TableName 'SqlRows' -AutoFit -FreezeTopRow
+
+        $rows = @(Import-OfficeExcel -Path $path -WorksheetName 'Data')
+        $rows.Count | Should -Be 2
+        $rows[0].Name | Should -Be 'A'
+        $rows[1].Value | Should -Be 2
+    }
+
     It 'exports HTML-parser DataTable output with companion link URL columns' {
         $path = Join-Path $TestDrive 'ExportOfficeExcelHtmlDataTable.xlsx'
         $table = [System.Data.DataTable]::new('HtmlLinks')


### PR DESCRIPTION
## Summary
- route single IDataReader inputs in Export-OfficeExcel through OfficeIMO.Excel InsertDataReader instead of DataTable.Load when append/exclude semantics do not require buffering
- keep the existing Export-OfficeExcel surface instead of adding a DB-specific cmdlet
- add Excel DSL coverage for IDataReader export/import round trips

## Validation
- dotnet build Sources\\PSWriteOffice\\PSWriteOffice.csproj -c Release --framework net8.0 --no-restore
- dotnet build Sources\\PSWriteOffice\\PSWriteOffice.csproj -c Debug --framework net8.0 --no-restore
- dotnet build Sources\\PSWriteOffice\\PSWriteOffice.csproj -c Release --framework net472 --no-restore
- Invoke-Pester -Path .\\Tests\\ExcelDsl.Tests.ps1 -Output Detailed with PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES=true
- git diff --check

## Notes
- net472 build still reports existing chart nullability warnings in SetOfficeExcelChartAxisCommand.cs and SetOfficeExcelChartSeriesCommand.cs; this change adds no new build errors.