### PR TITLE
Normalize table views and Markdown template insertion

### DIFF
--- a/Docs/Add-OfficeExcelPivotTable.md
+++ b/Docs/Add-OfficeExcelPivotTable.md
@@ -33,7 +33,7 @@ PS> $rows = @(
 )
 New-OfficeExcel -Path .\SalesPivot.xlsx {
     Add-OfficeExcelSheet -Name Data {
-        Add-OfficeExcelTable -Data $rows -TableName Sales -AutoFit
+        Add-OfficeExcelTable -InputObject $rows -TableName Sales -AutoFit
         Add-OfficeExcelPivotTable -SourceRange 'A1:C4' -DestinationCell 'E2' -Name 'SalesByRegion' -RowField Region -ColumnField Product -DataField Sales -DataFunction Sum -PivotStyle PivotStyleMedium9
     }
 }

--- a/Docs/Add-OfficeExcelReportKpiRow.md
+++ b/Docs/Add-OfficeExcelReportKpiRow.md
@@ -38,7 +38,7 @@ Hashtable or objects with Label/Value, Key/Value, Name/Value, or Title/Value pro
 ```yaml
 Type: Object
 Parameter Sets: __AllParameterSets
-Aliases: None
+Aliases: Data
 Possible values:
 
 Required: True

--- a/Docs/Add-OfficeExcelReportKpiRow.md
+++ b/Docs/Add-OfficeExcelReportKpiRow.md
@@ -11,7 +11,7 @@ Adds a KPI row to the current Excel report sheet.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Add-OfficeExcelReportKpiRow [-Data] <Object> [-PerRow <int>] [-LabelFillColor <string>] [<CommonParameters>]
+Add-OfficeExcelReportKpiRow [-InputObject] <Object> [-PerRow <int>] [-LabelFillColor <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -23,7 +23,7 @@ Adds a KPI row to the current Excel report sheet.
 ```powershell
 PS> New-OfficeExcel -Path .\Operations.xlsx {
     Add-OfficeExcelReportSheet -Name Summary {
-        Add-OfficeExcelReportKpiRow -Data @{ Revenue = 125000; Incidents = 3; Status = 'Ready' } -PerRow 3
+        Add-OfficeExcelReportKpiRow -InputObject @{ Revenue = 125000; Incidents = 3; Status = 'Ready' } -PerRow 3
     }
 }
 ```
@@ -32,7 +32,7 @@ Renders PowerShell key/value data as a KPI row through the OfficeIMO sheet compo
 
 ## PARAMETERS
 
-### -Data
+### -InputObject
 Hashtable or objects with Label/Value, Key/Value, Name/Value, or Title/Value properties.
 
 ```yaml

--- a/Docs/Add-OfficeExcelReportLegend.md
+++ b/Docs/Add-OfficeExcelReportLegend.md
@@ -11,7 +11,7 @@ Adds a legend table to the current Excel report sheet.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Add-OfficeExcelReportLegend [[-Title] <string>] -Headers <string[]> -Rows <Object[]> [-FirstColumnFillByValue <hashtable>] [-HeaderFillColor <string>] [-CaseSensitive] [<CommonParameters>]
+Add-OfficeExcelReportLegend [[-Title] <string>] -Header <string[]> -InputObject <Object[]> [-FirstColumnFillByValue <hashtable>] [-HeaderFillColor <string>] [-CaseSensitive] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -27,7 +27,7 @@ PS> $legendRows = @(
 )
 New-OfficeExcel -Path .\Operations.xlsx {
     Add-OfficeExcelReportSheet -Name Summary {
-        Add-OfficeExcelReportLegend -Title 'Status legend' -Headers Status, Meaning -Rows $legendRows -FirstColumnFillByValue @{ Ready = '#d9f7be'; Review = '#fff7e6' }
+        Add-OfficeExcelReportLegend -Title 'Status legend' -Header Status, Meaning -InputObject $legendRows -FirstColumnFillByValue @{ Ready = '#d9f7be'; Review = '#fff7e6' }
     }
 }
 ```
@@ -68,6 +68,22 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -Header
+Column headers.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -HeaderFillColor
 Optional header fill color.
 
@@ -84,23 +100,7 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
-### -Headers
-Column headers.
-
-```yaml
-Type: String[]
-Parameter Sets: __AllParameterSets
-Aliases: None
-Possible values:
-
-Required: True
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: True
-```
-
-### -Rows
+### -InputObject
 Rows. Each row may be an array, enumerable, hashtable, or object.
 
 ```yaml

--- a/Docs/Add-OfficeExcelReportLegend.md
+++ b/Docs/Add-OfficeExcelReportLegend.md
@@ -74,7 +74,7 @@ Column headers.
 ```yaml
 Type: String[]
 Parameter Sets: __AllParameterSets
-Aliases: None
+Aliases: Headers
 Possible values:
 
 Required: True
@@ -106,7 +106,7 @@ Rows. Each row may be an array, enumerable, hashtable, or object.
 ```yaml
 Type: Object[]
 Parameter Sets: __AllParameterSets
-Aliases: None
+Aliases: Rows
 Possible values:
 
 Required: True

--- a/Docs/Add-OfficeExcelReportSheet.md
+++ b/Docs/Add-OfficeExcelReportSheet.md
@@ -24,7 +24,7 @@ Creates a worksheet through the OfficeIMO sheet composer and runs report-block c
 PS> New-OfficeExcel -Path .\report.xlsx {
   Add-OfficeExcelReportSheet -Name Summary {
     Add-OfficeExcelReportTitle -Title 'Operational Summary' -Subtitle 'Current view'
-    Add-OfficeExcelReportKpiRow -Data @{ Ready = 12; Blocked = 2 }
+    Add-OfficeExcelReportKpiRow -InputObject @{ Ready = 12; Blocked = 2 }
   }
 }
 ```

--- a/Docs/Add-OfficeExcelReportTable.md
+++ b/Docs/Add-OfficeExcelReportTable.md
@@ -11,7 +11,7 @@ Adds an object table to the current Excel report sheet using the OfficeIMO sheet
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Add-OfficeExcelReportTable [-Data] <Object[]> [[-Title] <string>] [-TableStyle <string>] [-NoAutoFilter] [-NoFreezeHeaderRow] [-NoAutoFormatDynamicCollections] [-PassThru] [<CommonParameters>]
+Add-OfficeExcelReportTable [-InputObject] <Object[]> [[-Title] <string>] [-TableStyle <string>] [-NoAutoFilter] [-NoFreezeHeaderRow] [-NoAutoFormatDynamicCollections] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -27,7 +27,7 @@ PS> $rows = @(
 )
 New-OfficeExcel -Path .\Operations.xlsx {
     Add-OfficeExcelReportSheet -Name Summary {
-        Add-OfficeExcelReportTable -Data $rows -Title 'Documentation coverage' -TableStyle TableStyleMedium9
+        Add-OfficeExcelReportTable -InputObject $rows -Title 'Documentation coverage' -TableStyle TableStyleMedium9
     }
 }
 ```
@@ -36,7 +36,7 @@ Renders object rows as a formatted Excel table through the sheet composer.
 
 ## PARAMETERS
 
-### -Data
+### -InputObject
 Objects to flatten and render as a table.
 
 ```yaml

--- a/Docs/Add-OfficeExcelReportTable.md
+++ b/Docs/Add-OfficeExcelReportTable.md
@@ -42,7 +42,7 @@ Objects to flatten and render as a table.
 ```yaml
 Type: Object[]
 Parameter Sets: __AllParameterSets
-Aliases: None
+Aliases: Data
 Possible values:
 
 Required: True

--- a/Docs/Add-OfficeExcelReportTitle.md
+++ b/Docs/Add-OfficeExcelReportTitle.md
@@ -24,7 +24,7 @@ Adds a title block to the current Excel report sheet.
 PS> New-OfficeExcel -Path .\Operations.xlsx {
     Add-OfficeExcelReportSheet -Name Summary {
         Add-OfficeExcelReportTitle -Title 'Operational Summary' -Subtitle 'Current month'
-        Add-OfficeExcelReportKpiRow -Data @{ Revenue = 125000; Incidents = 3; Status = 'Ready' }
+        Add-OfficeExcelReportKpiRow -InputObject @{ Revenue = 125000; Incidents = 3; Status = 'Ready' }
     }
 }
 ```

--- a/Docs/Add-OfficeExcelTable.md
+++ b/Docs/Add-OfficeExcelTable.md
@@ -9,14 +9,9 @@ schema: 2.0.0
 Writes tabular data to the current worksheet and formats it as an Excel table.
 
 ## SYNTAX
-### Objects (Default)
+### __AllParameterSets
 ```powershell
-Add-OfficeExcelTable -Data <Object[]> [-StartRow <int>] [-StartColumn <int>] [-NoHeader] [-TableName <string>] [-TableStyle <string>] [-NoAutoFilter] [-AutoFit] [-PassThru] [<CommonParameters>]
-```
-
-### DataTable
-```powershell
-Add-OfficeExcelTable -DataTable <DataTable> [-StartRow <int>] [-StartColumn <int>] [-NoHeader] [-TableName <string>] [-TableStyle <string>] [-NoAutoFilter] [-AutoFit] [-PassThru] [<CommonParameters>]
+Add-OfficeExcelTable [-InputObject] <Object> [-StartRow <int>] [-StartColumn <int>] [-NoHeader] [-View <OfficeTableView>] [-TableName <string>] [-TableStyle <string>] [-NoAutoFilter] [-AutoFit] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -27,7 +22,7 @@ Accepts objects, dictionaries, DataTable/DataView/IDataReader inputs, or DataRow
 ### EXAMPLE 1
 ```powershell
 PS> $data = @([pscustomobject]@{ Region='NA'; Revenue=100 }, [pscustomobject]@{ Region='EMEA'; Revenue=150 })
-ExcelSheet 'Data' { Add-OfficeExcelTable -Data $data -TableName 'Sales' }
+ExcelSheet 'Data' { Add-OfficeExcelTable -InputObject $data -TableName 'Sales' }
 ```
 
 Writes two rows and formats them as a styled Excel table.
@@ -39,7 +34,7 @@ Auto-fit the table columns after insertion.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Objects, DataTable
+Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
 
@@ -50,33 +45,17 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
-### -Data
-Source objects to convert into table rows.
+### -InputObject
+Source objects, dictionaries, DataTable/DataView/IDataReader inputs, or DataRow sequences to convert into table rows.
 
 ```yaml
-Type: Object[]
-Parameter Sets: Objects
+Type: Object
+Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
 
 Required: True
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: True
-```
-
-### -DataTable
-Source DataTable to write directly.
-
-```yaml
-Type: DataTable
-Parameter Sets: DataTable
-Aliases: None
-Possible values:
-
-Required: True
-Position: named
+Position: 0
 Default value: None
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: True
@@ -87,7 +66,7 @@ Disable AutoFilter dropdowns.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Objects, DataTable
+Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
 
@@ -103,7 +82,7 @@ Skip writing headers.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Objects, DataTable
+Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
 
@@ -119,7 +98,7 @@ Return the created range string.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Objects, DataTable
+Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
 
@@ -135,7 +114,7 @@ Starting column for the data (1-based).
 
 ```yaml
 Type: Int32
-Parameter Sets: Objects, DataTable
+Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
 
@@ -151,7 +130,7 @@ Starting row for the data (1-based).
 
 ```yaml
 Type: Int32
-Parameter Sets: Objects, DataTable
+Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
 
@@ -167,7 +146,7 @@ Name to assign to the table.
 
 ```yaml
 Type: String
-Parameter Sets: Objects, DataTable
+Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
 
@@ -183,9 +162,25 @@ Built-in table style to apply.
 
 ```yaml
 Type: String
-Parameter Sets: Objects, DataTable
+Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -View
+Projection to apply before writing the table.
+
+```yaml
+Type: OfficeTableView
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Normal, Transpose
 
 Required: False
 Position: named
@@ -199,7 +194,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-- `System.Data.DataTable`
+- `System.Object`
 
 ## OUTPUTS
 

--- a/Docs/Add-OfficeExcelTable.md
+++ b/Docs/Add-OfficeExcelTable.md
@@ -51,7 +51,7 @@ Source objects, dictionaries, DataTable/DataView/IDataReader inputs, or DataRow 
 ```yaml
 Type: Object
 Parameter Sets: __AllParameterSets
-Aliases: None
+Aliases: Data, DataTable
 Possible values:
 
 Required: True

--- a/Docs/Add-OfficeMarkdownFrontMatter.md
+++ b/Docs/Add-OfficeMarkdownFrontMatter.md
@@ -11,12 +11,12 @@ Adds YAML front matter to a Markdown document.
 ## SYNTAX
 ### Context (Default)
 ```powershell
-Add-OfficeMarkdownFrontMatter [-Data] <Object> [-PassThru] [<CommonParameters>]
+Add-OfficeMarkdownFrontMatter [-InputObject] <Object> [-PassThru] [<CommonParameters>]
 ```
 
 ### Document
 ```powershell
-Add-OfficeMarkdownFrontMatter [-Data] <Object> -Document <MarkdownDoc> [-PassThru] [<CommonParameters>]
+Add-OfficeMarkdownFrontMatter [-InputObject] <Object> -Document <MarkdownDoc> [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -26,28 +26,12 @@ Adds YAML front matter to a Markdown document.
 
 ### EXAMPLE 1
 ```powershell
-PS> MarkdownFrontMatter -Data @{ title = 'Weekly Report'; tags = @('ops','summary') }
+PS> MarkdownFrontMatter -InputObject @{ title = 'Weekly Report'; tags = @('ops','summary') }
 ```
 
 Sets the document header using the supplied key/value pairs.
 
 ## PARAMETERS
-
-### -Data
-Front matter data expressed as a hashtable or object.
-
-```yaml
-Type: Object
-Parameter Sets: Context, Document
-Aliases: None
-Possible values:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: True
-```
 
 ### -Document
 Markdown document to update outside the DSL context.
@@ -62,6 +46,22 @@ Required: True
 Position: named
 Default value: None
 Accept pipeline input: True (ByValue)
+Accept wildcard characters: True
+```
+
+### -InputObject
+Front matter data expressed as a hashtable or object.
+
+```yaml
+Type: Object
+Parameter Sets: Context, Document
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: True
 ```
 

--- a/Docs/Add-OfficeMarkdownFrontMatter.md
+++ b/Docs/Add-OfficeMarkdownFrontMatter.md
@@ -55,7 +55,7 @@ Front matter data expressed as a hashtable or object.
 ```yaml
 Type: Object
 Parameter Sets: Context, Document
-Aliases: None
+Aliases: Data
 Possible values:
 
 Required: True

--- a/Docs/Add-OfficeMarkdownTable.md
+++ b/Docs/Add-OfficeMarkdownTable.md
@@ -19,6 +19,11 @@ Add-OfficeMarkdownTable [-InputObject] <Object> [-View <OfficeTableView>] [-Disa
 Add-OfficeMarkdownTable [-InputObject] <Object> -Document <MarkdownDoc> [-View <OfficeTableView>] [-DisableAutoAlign] [-PassThru] [<CommonParameters>]
 ```
 
+### PipelineDocument
+```powershell
+Add-OfficeMarkdownTable [-InputObject] <Object> -Document <MarkdownDoc> [-View <OfficeTableView>] [-DisableAutoAlign] [-PassThru] [<CommonParameters>]
+```
+
 ## DESCRIPTION
 Adds a Markdown table from objects.
 
@@ -46,7 +51,7 @@ Disable automatic alignment heuristics for tables.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Context, Document
+Parameter Sets: Context, Document, PipelineDocument
 Aliases: None
 Possible values:
 
@@ -62,7 +67,7 @@ Markdown document to update outside the DSL context.
 
 ```yaml
 Type: MarkdownDoc
-Parameter Sets: Document
+Parameter Sets: Document, PipelineDocument
 Aliases: None
 Possible values:
 
@@ -78,7 +83,7 @@ Objects to convert into a Markdown table.
 
 ```yaml
 Type: Object
-Parameter Sets: Context, Document
+Parameter Sets: Context, Document, PipelineDocument
 Aliases: None
 Possible values:
 
@@ -94,7 +99,7 @@ Emit the Markdown document after appending the table.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Context, Document
+Parameter Sets: Context, Document, PipelineDocument
 Aliases: None
 Possible values:
 
@@ -110,7 +115,7 @@ Projection to apply before writing the table.
 
 ```yaml
 Type: OfficeTableView
-Parameter Sets: Context, Document
+Parameter Sets: Context, Document, PipelineDocument
 Aliases: None
 Possible values: Normal, Transpose
 

--- a/Docs/Add-OfficeMarkdownTable.md
+++ b/Docs/Add-OfficeMarkdownTable.md
@@ -11,12 +11,12 @@ Adds a Markdown table from objects.
 ## SYNTAX
 ### Context (Default)
 ```powershell
-Add-OfficeMarkdownTable [-InputObject <Object>] [-DisableAutoAlign] [-PassThru] [<CommonParameters>]
+Add-OfficeMarkdownTable [-InputObject] <Object> [-View <OfficeTableView>] [-DisableAutoAlign] [-PassThru] [<CommonParameters>]
 ```
 
 ### Document
 ```powershell
-Add-OfficeMarkdownTable -Document <MarkdownDoc> [-InputObject <Object>] [-DisableAutoAlign] [-PassThru] [<CommonParameters>]
+Add-OfficeMarkdownTable [-InputObject] <Object> -Document <MarkdownDoc> [-View <OfficeTableView>] [-DisableAutoAlign] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -82,8 +82,8 @@ Parameter Sets: Context, Document
 Aliases: None
 Possible values:
 
-Required: False
-Position: named
+Required: True
+Position: 0
 Default value: None
 Accept pipeline input: True (ByValue)
 Accept wildcard characters: True
@@ -97,6 +97,22 @@ Type: SwitchParameter
 Parameter Sets: Context, Document
 Aliases: None
 Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -View
+Projection to apply before writing the table.
+
+```yaml
+Type: OfficeTableView
+Parameter Sets: Context, Document
+Aliases: None
+Possible values: Normal, Transpose
 
 Required: False
 Position: named

--- a/Docs/Add-OfficePdfTable.md
+++ b/Docs/Add-OfficePdfTable.md
@@ -11,12 +11,12 @@ Adds a table to a PDF document.
 ## SYNTAX
 ### Context (Default)
 ```powershell
-Add-OfficePdfTable [-InputObject] <Object[]> [-Property <string[]>] [-Header <string[]>] [-Align <PdfAlign>] [-PassThru] [<CommonParameters>]
+Add-OfficePdfTable [-InputObject] <Object> [-Property <string[]>] [-Header <string[]>] [-View <OfficeTableView>] [-Align <PdfAlign>] [-PassThru] [<CommonParameters>]
 ```
 
 ### Document
 ```powershell
-Add-OfficePdfTable [-InputObject] <Object[]> -Document <PdfDocument> [-Property <string[]>] [-Header <string[]>] [-Align <PdfAlign>] [-PassThru] [<CommonParameters>]
+Add-OfficePdfTable [-InputObject] <Object> -Document <PdfDocument> [-Property <string[]>] [-Header <string[]>] [-View <OfficeTableView>] [-Align <PdfAlign>] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -92,7 +92,7 @@ Accept wildcard characters: True
 Objects or row arrays to render as a table.
 
 ```yaml
-Type: Object[]
+Type: Object
 Parameter Sets: Context, Document
 Aliases: None
 Possible values:
@@ -100,7 +100,7 @@ Possible values:
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: True
 ```
 
@@ -136,12 +136,29 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -View
+Projection to apply before writing the table.
+
+```yaml
+Type: OfficeTableView
+Parameter Sets: Context, Document
+Aliases: None
+Possible values: Normal, Transpose
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
-- `OfficeIMO.Pdf.PdfDocument`
+- `OfficeIMO.Pdf.PdfDocument
+System.Object`
 
 ## OUTPUTS
 

--- a/Docs/Add-OfficePdfTable.md
+++ b/Docs/Add-OfficePdfTable.md
@@ -19,6 +19,11 @@ Add-OfficePdfTable [-InputObject] <Object> [-Property <string[]>] [-Header <stri
 Add-OfficePdfTable [-InputObject] <Object> -Document <PdfDocument> [-Property <string[]>] [-Header <string[]>] [-View <OfficeTableView>] [-Align <PdfAlign>] [-PassThru] [<CommonParameters>]
 ```
 
+### PipelineDocument
+```powershell
+Add-OfficePdfTable [-InputObject] <Object> -Document <PdfDocument> [-Property <string[]>] [-Header <string[]>] [-View <OfficeTableView>] [-Align <PdfAlign>] [-PassThru] [<CommonParameters>]
+```
+
 ## DESCRIPTION
 Adds a table to a PDF document.
 
@@ -45,7 +50,7 @@ Table alignment.
 
 ```yaml
 Type: PdfAlign
-Parameter Sets: Context, Document
+Parameter Sets: Context, Document, PipelineDocument
 Aliases: None
 Possible values: Left, Center, Right, Justify
 
@@ -61,7 +66,7 @@ PDF document to update outside the DSL context.
 
 ```yaml
 Type: PdfDocument
-Parameter Sets: Document
+Parameter Sets: Document, PipelineDocument
 Aliases: None
 Possible values:
 
@@ -77,7 +82,7 @@ Header labels. Defaults to property names.
 
 ```yaml
 Type: String[]
-Parameter Sets: Context, Document
+Parameter Sets: Context, Document, PipelineDocument
 Aliases: None
 Possible values:
 
@@ -93,7 +98,7 @@ Objects or row arrays to render as a table.
 
 ```yaml
 Type: Object
-Parameter Sets: Context, Document
+Parameter Sets: Context, Document, PipelineDocument
 Aliases: None
 Possible values:
 
@@ -109,7 +114,7 @@ Emit the updated document.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Context, Document
+Parameter Sets: Context, Document, PipelineDocument
 Aliases: None
 Possible values:
 
@@ -125,7 +130,7 @@ Specific object properties to include.
 
 ```yaml
 Type: String[]
-Parameter Sets: Context, Document
+Parameter Sets: Context, Document, PipelineDocument
 Aliases: None
 Possible values:
 
@@ -141,7 +146,7 @@ Projection to apply before writing the table.
 
 ```yaml
 Type: OfficeTableView
-Parameter Sets: Context, Document
+Parameter Sets: Context, Document, PipelineDocument
 Aliases: None
 Possible values: Normal, Transpose
 

--- a/Docs/Add-OfficePowerPointChart.md
+++ b/Docs/Add-OfficePowerPointChart.md
@@ -97,7 +97,7 @@ Source objects used to build chart data.
 ```yaml
 Type: Object[]
 Parameter Sets: Categorical, Scatter
-Aliases: None
+Aliases: Data
 Possible values:
 
 Required: True

--- a/Docs/Add-OfficePowerPointChart.md
+++ b/Docs/Add-OfficePowerPointChart.md
@@ -16,12 +16,12 @@ Add-OfficePowerPointChart [-Slide <PowerPointSlide>] [-Type <PowerPointChartType
 
 ### Categorical
 ```powershell
-Add-OfficePowerPointChart -Data <Object[]> -CategoryProperty <string> -SeriesProperty <string[]> [-Slide <PowerPointSlide>] [-Type <PowerPointChartType>] [-X <double>] [-Y <double>] [-Width <double>] [-Height <double>] [-Title <string>] [<CommonParameters>]
+Add-OfficePowerPointChart -InputObject <Object[]> -CategoryProperty <string> -SeriesProperty <string[]> [-Slide <PowerPointSlide>] [-Type <PowerPointChartType>] [-X <double>] [-Y <double>] [-Width <double>] [-Height <double>] [-Title <string>] [<CommonParameters>]
 ```
 
 ### Scatter
 ```powershell
-Add-OfficePowerPointChart -Data <Object[]> -XProperty <string> -YProperty <string[]> [-Slide <PowerPointSlide>] [-Type <PowerPointChartType>] [-X <double>] [-Y <double>] [-Width <double>] [-Height <double>] [-Title <string>] [<CommonParameters>]
+Add-OfficePowerPointChart -InputObject <Object[]> -XProperty <string> -YProperty <string[]> [-Slide <PowerPointSlide>] [-Type <PowerPointChartType>] [-X <double>] [-Y <double>] [-Width <double>] [-Height <double>] [-Title <string>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -37,7 +37,7 @@ PS> $rows = @(
 )
 New-OfficePowerPoint -Path .\Examples\Documents\PowerPointChart.pptx {
     $slide = Add-OfficePowerPointSlide -Layout 1
-    Add-OfficePowerPointChart -Slide $slide -Data $rows -CategoryProperty Month -SeriesProperty Sales,Profit -Title 'Monthly performance'
+    Add-OfficePowerPointChart -Slide $slide -InputObject $rows -CategoryProperty Month -SeriesProperty Sales,Profit -Title 'Monthly performance'
 }
 ```
 
@@ -51,7 +51,7 @@ PS> $rows = @(
 )
 New-OfficePowerPoint -Path .\Examples\Documents\PowerPointScatter.pptx {
     $slide = Add-OfficePowerPointSlide -Layout 1
-    Add-OfficePowerPointChart -Slide $slide -Type Scatter -Data $rows -XProperty Quarter -YProperty Revenue -Title 'Revenue trend'
+    Add-OfficePowerPointChart -Slide $slide -Type Scatter -InputObject $rows -XProperty Quarter -YProperty Revenue -Title 'Revenue trend'
 }
 ```
 
@@ -75,22 +75,6 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
-### -Data
-Source objects used to build chart data.
-
-```yaml
-Type: Object[]
-Parameter Sets: Categorical, Scatter
-Aliases: None
-Possible values:
-
-Required: True
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: True
-```
-
 ### -Height
 Chart height in points.
 
@@ -101,6 +85,22 @@ Aliases: None
 Possible values:
 
 Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -InputObject
+Source objects used to build chart data.
+
+```yaml
+Type: Object[]
+Parameter Sets: Categorical, Scatter
+Aliases: None
+Possible values:
+
+Required: True
 Position: named
 Default value: None
 Accept pipeline input: False

--- a/Docs/Add-OfficePowerPointTable.md
+++ b/Docs/Add-OfficePowerPointTable.md
@@ -56,7 +56,7 @@ Optional header order to apply to the table.
 ```yaml
 Type: String[]
 Parameter Sets: InputObject
-Aliases: None
+Aliases: Headers
 Possible values:
 
 Required: False

--- a/Docs/Add-OfficePowerPointTable.md
+++ b/Docs/Add-OfficePowerPointTable.md
@@ -88,7 +88,7 @@ Source objects to convert into table rows.
 ```yaml
 Type: Object
 Parameter Sets: InputObject
-Aliases: None
+Aliases: Data
 Possible values:
 
 Required: True

--- a/Docs/Add-OfficePowerPointTable.md
+++ b/Docs/Add-OfficePowerPointTable.md
@@ -9,9 +9,9 @@ schema: 2.0.0
 Adds a table to a PowerPoint slide.
 
 ## SYNTAX
-### Data (Default)
+### InputObject (Default)
 ```powershell
-Add-OfficePowerPointTable [[-Slide] <PowerPointSlide>] -Data <Object[]> [-Headers <string[]>] [-NoHeader] [-X <double>] [-Y <double>] [-Width <double>] [-Height <double>] [-StyleId <string>] [<CommonParameters>]
+Add-OfficePowerPointTable [[-Slide] <PowerPointSlide>] [-InputObject] <Object> [-Header <string[]>] [-NoHeader] [-View <OfficeTableView>] [-X <double>] [-Y <double>] [-Width <double>] [-Height <double>] [-StyleId <string>] [<CommonParameters>]
 ```
 
 ### Size
@@ -27,7 +27,7 @@ Builds a table from data rows or creates a blank grid with a fixed size.
 ### EXAMPLE 1
 ```powershell
 PS> $rows = @([pscustomobject]@{ Item='Alpha'; Qty=2 }, [pscustomobject]@{ Item='Beta'; Qty=4 })
-Add-OfficePowerPointTable -Slide $slide -Data $rows -X 60 -Y 140 -Width 420 -Height 200
+Add-OfficePowerPointTable -Slide $slide -InputObject $rows -X 60 -Y 140 -Width 420 -Height 200
 ```
 
 Creates a table with headers and two data rows.
@@ -50,28 +50,12 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
-### -Data
-Source objects to convert into table rows.
-
-```yaml
-Type: Object[]
-Parameter Sets: Data
-Aliases: None
-Possible values:
-
-Required: True
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: True
-```
-
-### -Headers
+### -Header
 Optional header order to apply to the table.
 
 ```yaml
 Type: String[]
-Parameter Sets: Data
+Parameter Sets: InputObject
 Aliases: None
 Possible values:
 
@@ -87,7 +71,7 @@ Table height in points.
 
 ```yaml
 Type: Double
-Parameter Sets: Data, Size
+Parameter Sets: InputObject, Size
 Aliases: None
 Possible values:
 
@@ -98,12 +82,28 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -InputObject
+Source objects to convert into table rows.
+
+```yaml
+Type: Object
+Parameter Sets: InputObject
+Aliases: None
+Possible values:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -NoHeader
 Skip writing header row.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Data
+Parameter Sets: InputObject
 Aliases: None
 Possible values:
 
@@ -135,7 +135,7 @@ Target slide that will receive the table (optional inside DSL).
 
 ```yaml
 Type: PowerPointSlide
-Parameter Sets: Data, Size
+Parameter Sets: InputObject, Size
 Aliases: None
 Possible values:
 
@@ -151,9 +151,25 @@ Optional table style ID (GUID string).
 
 ```yaml
 Type: String
-Parameter Sets: Data, Size
+Parameter Sets: InputObject, Size
 Aliases: None
 Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -View
+Projection to apply before writing the table.
+
+```yaml
+Type: OfficeTableView
+Parameter Sets: InputObject
+Aliases: None
+Possible values: Normal, Transpose
 
 Required: False
 Position: named
@@ -167,7 +183,7 @@ Table width in points.
 
 ```yaml
 Type: Double
-Parameter Sets: Data, Size
+Parameter Sets: InputObject, Size
 Aliases: None
 Possible values:
 
@@ -183,7 +199,7 @@ Left offset (in points) from the slide origin.
 
 ```yaml
 Type: Double
-Parameter Sets: Data, Size
+Parameter Sets: InputObject, Size
 Aliases: None
 Possible values:
 
@@ -199,7 +215,7 @@ Top offset (in points) from the slide origin.
 
 ```yaml
 Type: Double
-Parameter Sets: Data, Size
+Parameter Sets: InputObject, Size
 Aliases: None
 Possible values:
 

--- a/Docs/Add-OfficeWordChart.md
+++ b/Docs/Add-OfficeWordChart.md
@@ -11,17 +11,17 @@ Adds a chart to a Word document.
 ## SYNTAX
 ### Context (Default)
 ```powershell
-Add-OfficeWordChart -Data <Object[]> -CategoryProperty <string> -SeriesProperty <string[]> [-Type <WordChartType>] [-WidthPixels <int>] [-HeightPixels <int>] [-Title <string>] [-SeriesColor <string[]>] [-Legend] [-LegendPosition <string>] [-XAxisTitle <string>] [-YAxisTitle <string>] [-FitToPageWidth] [-WidthFraction <double>] [-PassThru] [<CommonParameters>]
+Add-OfficeWordChart -InputObject <Object[]> -CategoryProperty <string> -SeriesProperty <string[]> [-Type <WordChartType>] [-WidthPixels <int>] [-HeightPixels <int>] [-Title <string>] [-SeriesColor <string[]>] [-Legend] [-LegendPosition <string>] [-XAxisTitle <string>] [-YAxisTitle <string>] [-FitToPageWidth] [-WidthFraction <double>] [-PassThru] [<CommonParameters>]
 ```
 
 ### Document
 ```powershell
-Add-OfficeWordChart -Data <Object[]> -CategoryProperty <string> -SeriesProperty <string[]> [-Document <WordDocument>] [-Type <WordChartType>] [-WidthPixels <int>] [-HeightPixels <int>] [-Title <string>] [-SeriesColor <string[]>] [-Legend] [-LegendPosition <string>] [-XAxisTitle <string>] [-YAxisTitle <string>] [-FitToPageWidth] [-WidthFraction <double>] [-PassThru] [<CommonParameters>]
+Add-OfficeWordChart -InputObject <Object[]> -CategoryProperty <string> -SeriesProperty <string[]> [-Document <WordDocument>] [-Type <WordChartType>] [-WidthPixels <int>] [-HeightPixels <int>] [-Title <string>] [-SeriesColor <string[]>] [-Legend] [-LegendPosition <string>] [-XAxisTitle <string>] [-YAxisTitle <string>] [-FitToPageWidth] [-WidthFraction <double>] [-PassThru] [<CommonParameters>]
 ```
 
 ### Paragraph
 ```powershell
-Add-OfficeWordChart -Data <Object[]> -CategoryProperty <string> -SeriesProperty <string[]> [-Paragraph <WordParagraph>] [-Type <WordChartType>] [-WidthPixels <int>] [-HeightPixels <int>] [-Title <string>] [-SeriesColor <string[]>] [-Legend] [-LegendPosition <string>] [-XAxisTitle <string>] [-YAxisTitle <string>] [-FitToPageWidth] [-WidthFraction <double>] [-PassThru] [<CommonParameters>]
+Add-OfficeWordChart -InputObject <Object[]> -CategoryProperty <string> -SeriesProperty <string[]> [-Paragraph <WordParagraph>] [-Type <WordChartType>] [-WidthPixels <int>] [-HeightPixels <int>] [-Title <string>] [-SeriesColor <string[]>] [-Legend] [-LegendPosition <string>] [-XAxisTitle <string>] [-YAxisTitle <string>] [-FitToPageWidth] [-WidthFraction <double>] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -38,8 +38,8 @@ PS> $rows = @(
 )
 New-OfficeWord -Path .\RegionalReport.docx {
     Add-OfficeWordParagraph -Text 'Regional revenue'
-    Add-OfficeWordChart -Type Pie -Data $rows -CategoryProperty Region -SeriesProperty Revenue -Title 'Revenue mix' -FitToPageWidth -WidthFraction 0.75
-    Add-OfficeWordChart -Type Bar -Data $rows -CategoryProperty Region -SeriesProperty Revenue, Profit -Legend -XAxisTitle 'Region' -YAxisTitle 'Amount'
+    Add-OfficeWordChart -Type Pie -InputObject $rows -CategoryProperty Region -SeriesProperty Revenue -Title 'Revenue mix' -FitToPageWidth -WidthFraction 0.75
+    Add-OfficeWordChart -Type Bar -InputObject $rows -CategoryProperty Region -SeriesProperty Revenue, Profit -Legend -XAxisTitle 'Region' -YAxisTitle 'Amount'
 }
 ```
 
@@ -53,7 +53,7 @@ PS> $trend = @(
     [pscustomobject]@{ Month = 'Mar'; Sales = 15; Profit = 7 }
 )
 $doc = New-OfficeWord -Path .\Trend.docx -PassThru
-Add-OfficeWordChart -Document $doc -Type Line -Data $trend -CategoryProperty Month -SeriesProperty Sales, Profit -Legend -Title 'Quarter trend'
+Add-OfficeWordChart -Document $doc -Type Line -InputObject $trend -CategoryProperty Month -SeriesProperty Sales, Profit -Legend -Title 'Quarter trend'
 Save-OfficeWord -Document $doc
 ```
 
@@ -66,22 +66,6 @@ Property name used for category labels.
 
 ```yaml
 Type: String
-Parameter Sets: Context, Document, Paragraph
-Aliases: None
-Possible values:
-
-Required: True
-Position: named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: True
-```
-
-### -Data
-Source objects used to build chart data.
-
-```yaml
-Type: Object[]
 Parameter Sets: Context, Document, Paragraph
 Aliases: None
 Possible values:
@@ -135,6 +119,22 @@ Aliases: None
 Possible values:
 
 Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -InputObject
+Source objects used to build chart data.
+
+```yaml
+Type: Object[]
+Parameter Sets: Context, Document, Paragraph
+Aliases: None
+Possible values:
+
+Required: True
 Position: named
 Default value: None
 Accept pipeline input: False

--- a/Docs/Add-OfficeWordChart.md
+++ b/Docs/Add-OfficeWordChart.md
@@ -131,7 +131,7 @@ Source objects used to build chart data.
 ```yaml
 Type: Object[]
 Parameter Sets: Context, Document, Paragraph
-Aliases: None
+Aliases: Data
 Possible values:
 
 Required: True

--- a/Docs/Add-OfficeWordTable.md
+++ b/Docs/Add-OfficeWordTable.md
@@ -11,7 +11,7 @@ Creates a table from PowerShell objects.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Add-OfficeWordTable [-InputObject] <Object> [[-Content] <scriptblock>] [-Style <WordTableStyle>] [-Layout <string>] [-NoHeader] [-View <OfficeTableView>] [-PassThru] [<CommonParameters>]
+Add-OfficeWordTable [-InputObject] <Object> [[-Content] <scriptblock>] [-Style <WordTableStyle>] [-Layout <string>] [-NoHeader] [-View <OfficeTableView>] [-Transpose] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -116,6 +116,22 @@ Type: WordTableStyle
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values: TableNormal, TableGrid, PlainTable1, PlainTable2, PlainTable3, PlainTable4, PlainTable5, GridTable1Light, GridTable1LightAccent1, GridTable1LightAccent2, GridTable1LightAccent3, GridTable1LightAccent4, GridTable1LightAccent5, GridTable1LightAccent6, GridTable2, GridTable2Accent1, GridTable2Accent2, GridTable2Accent3, GridTable2Accent4, GridTable2Accent5, GridTable2Accent6, GridTable3, GridTable3Accent1, GridTable3Accent2, GridTable3Accent3, GridTable3Accent4, GridTable3Accent5, GridTable3Accent6, GridTable4, GridTable4Accent1, GridTable4Accent2, GridTable4Accent3, GridTable4Accent4, GridTable4Accent5, GridTable4Accent6, GridTable5Dark, GridTable5DarkAccent1, GridTable5DarkAccent2, GridTable5DarkAccent3, GridTable5DarkAccent4, GridTable5DarkAccent5, GridTable5DarkAccent6, GridTable6Colorful, GridTable6ColorfulAccent1, GridTable6ColorfulAccent2, GridTable6ColorfulAccent3, GridTable6ColorfulAccent4, GridTable6ColorfulAccent5, GridTable6ColorfulAccent6, GridTable7Colorful, GridTable7ColorfulAccent1, GridTable7ColorfulAccent2, GridTable7ColorfulAccent3, GridTable7ColorfulAccent4, GridTable7ColorfulAccent5, GridTable7ColorfulAccent6, ListTable1Light, ListTable1LightAccent1, ListTable1LightAccent2, ListTable1LightAccent3, ListTable1LightAccent4, ListTable1LightAccent5, ListTable1LightAccent6, ListTable2, ListTable2Accent1, ListTable2Accent2, ListTable2Accent3, ListTable2Accent4, ListTable2Accent5, ListTable2Accent6, ListTable3, ListTable3Accent1, ListTable3Accent2, ListTable3Accent3, ListTable3Accent4, ListTable3Accent5, ListTable3Accent6, ListTable4, ListTable4Accent1, ListTable4Accent2, ListTable4Accent3, ListTable4Accent4, ListTable4Accent5, ListTable4Accent6, ListTable5Dark, ListTable5DarkAccent1, ListTable5DarkAccent2, ListTable5DarkAccent3, ListTable5DarkAccent4, ListTable5DarkAccent5, ListTable5DarkAccent6, ListTable6Colorful, ListTable6ColorfulAccent1, ListTable6ColorfulAccent2, ListTable6ColorfulAccent3, ListTable6ColorfulAccent4, ListTable6ColorfulAccent5, ListTable6ColorfulAccent6, ListTable7Colorful, ListTable7ColorfulAccent1, ListTable7ColorfulAccent2, ListTable7ColorfulAccent3, ListTable7ColorfulAccent4, ListTable7ColorfulAccent5, ListTable7ColorfulAccent6
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -Transpose
+Legacy switch that maps to Transpose.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
 
 Required: False
 Position: named

--- a/Docs/Add-OfficeWordTable.md
+++ b/Docs/Add-OfficeWordTable.md
@@ -50,7 +50,7 @@ Input data (array, list, DataTable, etc.).
 ```yaml
 Type: Object
 Parameter Sets: __AllParameterSets
-Aliases: None
+Aliases: Data
 Possible values:
 
 Required: True
@@ -82,7 +82,7 @@ Skip writing header row.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: __AllParameterSets
-Aliases: None
+Aliases: SkipHeader
 Possible values:
 
 Required: False

--- a/Docs/Add-OfficeWordTable.md
+++ b/Docs/Add-OfficeWordTable.md
@@ -11,7 +11,7 @@ Creates a table from PowerShell objects.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Add-OfficeWordTable [-InputObject] <Object> [[-Content] <scriptblock>] [-Style <WordTableStyle>] [-Layout <string>] [-SkipHeader] [-Transpose] [-PassThru] [<CommonParameters>]
+Add-OfficeWordTable [-InputObject] <Object> [[-Content] <scriptblock>] [-Style <WordTableStyle>] [-Layout <string>] [-NoHeader] [-View <OfficeTableView>] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -50,13 +50,13 @@ Input data (array, list, DataTable, etc.).
 ```yaml
 Type: Object
 Parameter Sets: __AllParameterSets
-Aliases: Data
+Aliases: None
 Possible values:
 
 Required: True
 Position: 0
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByValue)
 Accept wildcard characters: True
 ```
 
@@ -76,8 +76,8 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
-### -PassThru
-Emit the created WordTable.
+### -NoHeader
+Skip writing header row.
 
 ```yaml
 Type: SwitchParameter
@@ -92,8 +92,8 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
-### -SkipHeader
-Skip writing header row.
+### -PassThru
+Emit the created WordTable.
 
 ```yaml
 Type: SwitchParameter
@@ -124,14 +124,14 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
-### -Transpose
-Transpose rows into property-oriented output.
+### -View
+Projection to apply before writing the table.
 
 ```yaml
-Type: SwitchParameter
+Type: OfficeTableView
 Parameter Sets: __AllParameterSets
 Aliases: None
-Possible values:
+Possible values: Normal, Transpose
 
 Required: False
 Position: named
@@ -145,7 +145,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## INPUTS
 
-- `None`
+- `System.Object`
 
 ## OUTPUTS
 

--- a/Docs/Add-OfficeWordTableCell.md
+++ b/Docs/Add-OfficeWordTableCell.md
@@ -26,7 +26,7 @@ Use this to add paragraphs, lists, images, or nested tables inside a cell select
 
 ### EXAMPLE 1
 ```powershell
-PS> WordTable -Data $Rows { WordTableCell -Row 1 -Column 0 { WordParagraph { WordText 'Details' } } }
+PS> WordTable -InputObject $Rows { WordTableCell -Row 1 -Column 0 { WordParagraph { WordText 'Details' } } }
 ```
 
 Targets the data cell at row 1, column 0 and writes text inside it.

--- a/Docs/ConvertFrom-OfficeWordMarkdown.md
+++ b/Docs/ConvertFrom-OfficeWordMarkdown.md
@@ -11,17 +11,17 @@ Creates a Word document from Markdown.
 ## SYNTAX
 ### Markdown (Default)
 ```powershell
-ConvertFrom-OfficeWordMarkdown [-Markdown] <string> [-OutputPath <string>] [-FontFamily <string>] [-BaseUri <string>] [-AllowLocalImages] [-AllowedImageDirectory <string[]>] [-AllowRemoteImages] [-ReaderOptions <MarkdownReaderOptions>] [-FitImagesToPageContentWidth] [-FitImagesToContextWidth] [-MaxImageWidthPixels <double>] [-MaxImageHeightPixels <double>] [-MaxImageWidthPercentOfContent <double>] [-Open] [-PassThru] [<CommonParameters>]
+ConvertFrom-OfficeWordMarkdown [-Markdown] <string> [-OutputPath <string>] [-TemplatePath <string>] [-BookmarkName <string>] [-ContentControlTag <string>] [-ContentControlAlias <string>] [-KeepPlaceholder] [-RenderFrontMatter] [-FontFamily <string>] [-BaseUri <string>] [-AllowLocalImages] [-AllowedImageDirectory <string[]>] [-AllowRemoteImages] [-ReaderOptions <MarkdownReaderOptions>] [-FitImagesToPageContentWidth] [-FitImagesToContextWidth] [-MaxImageWidthPixels <double>] [-MaxImageHeightPixels <double>] [-MaxImageWidthPercentOfContent <double>] [-Open] [-PassThru] [<CommonParameters>]
 ```
 
 ### Path
 ```powershell
-ConvertFrom-OfficeWordMarkdown [-FilePath] <string> [-OutputPath <string>] [-FontFamily <string>] [-BaseUri <string>] [-AllowLocalImages] [-AllowedImageDirectory <string[]>] [-AllowRemoteImages] [-ReaderOptions <MarkdownReaderOptions>] [-FitImagesToPageContentWidth] [-FitImagesToContextWidth] [-MaxImageWidthPixels <double>] [-MaxImageHeightPixels <double>] [-MaxImageWidthPercentOfContent <double>] [-Open] [-PassThru] [<CommonParameters>]
+ConvertFrom-OfficeWordMarkdown [-FilePath] <string> [-OutputPath <string>] [-TemplatePath <string>] [-BookmarkName <string>] [-ContentControlTag <string>] [-ContentControlAlias <string>] [-KeepPlaceholder] [-RenderFrontMatter] [-FontFamily <string>] [-BaseUri <string>] [-AllowLocalImages] [-AllowedImageDirectory <string[]>] [-AllowRemoteImages] [-ReaderOptions <MarkdownReaderOptions>] [-FitImagesToPageContentWidth] [-FitImagesToContextWidth] [-MaxImageWidthPixels <double>] [-MaxImageHeightPixels <double>] [-MaxImageWidthPercentOfContent <double>] [-Open] [-PassThru] [<CommonParameters>]
 ```
 
 ### Document
 ```powershell
-ConvertFrom-OfficeWordMarkdown -Document <MarkdownDoc> [-OutputPath <string>] [-FontFamily <string>] [-BaseUri <string>] [-AllowLocalImages] [-AllowedImageDirectory <string[]>] [-AllowRemoteImages] [-ReaderOptions <MarkdownReaderOptions>] [-FitImagesToPageContentWidth] [-FitImagesToContextWidth] [-MaxImageWidthPixels <double>] [-MaxImageHeightPixels <double>] [-MaxImageWidthPercentOfContent <double>] [-Open] [-PassThru] [<CommonParameters>]
+ConvertFrom-OfficeWordMarkdown -Document <MarkdownDoc> [-OutputPath <string>] [-TemplatePath <string>] [-BookmarkName <string>] [-ContentControlTag <string>] [-ContentControlAlias <string>] [-KeepPlaceholder] [-RenderFrontMatter] [-FontFamily <string>] [-BaseUri <string>] [-AllowLocalImages] [-AllowedImageDirectory <string[]>] [-AllowRemoteImages] [-ReaderOptions <MarkdownReaderOptions>] [-FitImagesToPageContentWidth] [-FitImagesToContextWidth] [-MaxImageWidthPixels <double>] [-MaxImageHeightPixels <double>] [-MaxImageWidthPercentOfContent <double>] [-Open] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -42,6 +42,13 @@ PS> Get-OfficeMarkdown -Path .\README.md | ConvertFrom-OfficeWordMarkdown
 ```
 
 Returns a Word document instance for further edits.
+
+### EXAMPLE 3
+```powershell
+PS> ConvertFrom-OfficeWordMarkdown -Path .\SOP.md -TemplatePath .\Template.docx -BookmarkName MainContent -OutputPath .\SOP.docx
+```
+
+Copies the template and replaces the bookmark paragraph with generated Markdown content.
 
 ## PARAMETERS
 
@@ -100,6 +107,54 @@ Base URI used to resolve relative links and images.
 Type: String
 Parameter Sets: Markdown, Path, Document
 Aliases: BasePath
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -BookmarkName
+Bookmark name that marks where Markdown content should be inserted in the template.
+
+```yaml
+Type: String
+Parameter Sets: Markdown, Path, Document
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -ContentControlAlias
+Block content control alias that marks where Markdown content should be inserted in the template.
+
+```yaml
+Type: String
+Parameter Sets: Markdown, Path, Document
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -ContentControlTag
+Block content control tag that marks where Markdown content should be inserted in the template.
+
+```yaml
+Type: String
+Parameter Sets: Markdown, Path, Document
+Aliases: None
 Possible values:
 
 Required: False
@@ -178,6 +233,22 @@ Optional font family applied during conversion.
 
 ```yaml
 Type: String
+Parameter Sets: Markdown, Path, Document
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -KeepPlaceholder
+Keep the target bookmark or content-control placeholder after inserting Markdown content.
+
+```yaml
+Type: SwitchParameter
 Parameter Sets: Markdown, Path, Document
 Aliases: None
 Possible values:
@@ -308,6 +379,38 @@ Optional Markdown reader options used before Word conversion.
 Type: MarkdownReaderOptions
 Parameter Sets: Markdown, Path, Document
 Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -RenderFrontMatter
+Render YAML front matter as visible Word content. Template conversions hide front matter by default.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Markdown, Path, Document
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -TemplatePath
+Optional Word template document to copy before inserting Markdown content.
+
+```yaml
+Type: String
+Parameter Sets: Markdown, Path, Document
+Aliases: Template
 Possible values:
 
 Required: False

--- a/Docs/Invoke-OfficeWordMailMerge.md
+++ b/Docs/Invoke-OfficeWordMailMerge.md
@@ -11,7 +11,7 @@ Executes a simple mail merge against MERGEFIELD values in a Word document.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Invoke-OfficeWordMailMerge [-Data] <Object> [-Document <WordDocument>] [-PreserveFields] [-PassThru] [<CommonParameters>]
+Invoke-OfficeWordMailMerge [-InputObject] <Object> [-Document <WordDocument>] [-PreserveFields] [-PassThru] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -21,28 +21,12 @@ Executes a simple mail merge against MERGEFIELD values in a Word document.
 
 ### EXAMPLE 1
 ```powershell
-PS> Invoke-OfficeWordMailMerge -Data @{ FirstName = 'John'; OrderId = 12345 }
+PS> Invoke-OfficeWordMailMerge -InputObject @{ FirstName = 'John'; OrderId = 12345 }
 ```
 
 Updates MERGEFIELD values in the active Word document.
 
 ## PARAMETERS
-
-### -Data
-Hashtable or object whose properties map to MERGEFIELD names.
-
-```yaml
-Type: Object
-Parameter Sets: __AllParameterSets
-Aliases: Values
-Possible values:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: True
-```
 
 ### -Document
 Document to update when provided explicitly.
@@ -57,6 +41,22 @@ Required: False
 Position: named
 Default value: None
 Accept pipeline input: True (ByValue)
+Accept wildcard characters: True
+```
+
+### -InputObject
+Hashtable or object whose properties map to MERGEFIELD names.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: True
 ```
 

--- a/Docs/Invoke-OfficeWordMailMerge.md
+++ b/Docs/Invoke-OfficeWordMailMerge.md
@@ -50,7 +50,7 @@ Hashtable or object whose properties map to MERGEFIELD names.
 ```yaml
 Type: Object
 Parameter Sets: __AllParameterSets
-Aliases: None
+Aliases: Data, Values
 Possible values:
 
 Required: True

--- a/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelPivotTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelPivotTableCommand.cs
@@ -21,7 +21,7 @@ namespace PSWriteOffice.Cmdlets.Excel;
 /// )
 /// New-OfficeExcel -Path .\SalesPivot.xlsx {
 ///     Add-OfficeExcelSheet -Name Data {
-///         Add-OfficeExcelTable -Data $rows -TableName Sales -AutoFit
+///         Add-OfficeExcelTable -InputObject $rows -TableName Sales -AutoFit
 ///         Add-OfficeExcelPivotTable -SourceRange 'A1:C4' -DestinationCell 'E2' -Name 'SalesByRegion' -RowField Region -ColumnField Product -DataField Sales -DataFunction Sum -PivotStyle PivotStyleMedium9
 ///     }
 /// }</code>

--- a/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelReportSheetCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelReportSheetCommand.cs
@@ -11,7 +11,7 @@ namespace PSWriteOffice.Cmdlets.Excel;
 ///   <code>New-OfficeExcel -Path .\report.xlsx {
 ///     Add-OfficeExcelReportSheet -Name Summary {
 ///       Add-OfficeExcelReportTitle -Title 'Operational Summary' -Subtitle 'Current view'
-///       Add-OfficeExcelReportKpiRow -Data @{ Ready = 12; Blocked = 2 }
+///       Add-OfficeExcelReportKpiRow -InputObject @{ Ready = 12; Blocked = 2 }
 ///     }
 ///   }</code>
 ///   <para>Creates a report-oriented worksheet with title and KPI blocks.</para>

--- a/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableCommand.cs
@@ -1,11 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
 using System.Management.Automation;
 using OfficeIMO.Excel;
-using PSWriteOffice.Services;
 using PSWriteOffice.Services.Excel;
+using PSWriteOffice.Services.Table;
 
 namespace PSWriteOffice.Cmdlets.Excel;
 
@@ -15,23 +14,18 @@ namespace PSWriteOffice.Cmdlets.Excel;
 ///   <summary>Insert a table starting at A1.</summary>
 ///   <prefix>PS&gt; </prefix>
 ///   <code>$data = @([pscustomobject]@{ Region='NA'; Revenue=100 }, [pscustomobject]@{ Region='EMEA'; Revenue=150 })
-///   ExcelSheet 'Data' { Add-OfficeExcelTable -Data $data -TableName 'Sales' }</code>
+///   ExcelSheet 'Data' { Add-OfficeExcelTable -InputObject $data -TableName 'Sales' }</code>
 ///   <para>Writes two rows and formats them as a styled Excel table.</para>
 /// </example>
-[Cmdlet(VerbsCommon.Add, "OfficeExcelTable", DefaultParameterSetName = ParameterSetObjects)]
+[Cmdlet(VerbsCommon.Add, "OfficeExcelTable")]
 [Alias("ExcelTable")]
 public sealed class AddOfficeExcelTableCommand : PSCmdlet
 {
-    private const string ParameterSetObjects = "Objects";
-    private const string ParameterSetDataTable = "DataTable";
+    private readonly List<object?> _items = new();
 
-    /// <summary>Source objects to convert into table rows.</summary>
-    [Parameter(Mandatory = true, ParameterSetName = ParameterSetObjects)]
-    public object[] Data { get; set; } = Array.Empty<object>();
-
-    /// <summary>Source <see cref="DataTable"/> to write directly.</summary>
-    [Parameter(Mandatory = true, ParameterSetName = ParameterSetDataTable, ValueFromPipeline = true)]
-    public DataTable? DataTable { get; set; }
+    /// <summary>Source objects, dictionaries, DataTable/DataView/IDataReader inputs, or DataRow sequences to convert into table rows.</summary>
+    [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    public object? InputObject { get; set; }
 
     /// <summary>Starting row for the data (1-based).</summary>
     [Parameter]
@@ -44,6 +38,10 @@ public sealed class AddOfficeExcelTableCommand : PSCmdlet
     /// <summary>Skip writing headers.</summary>
     [Parameter]
     public SwitchParameter NoHeader { get; set; }
+
+    /// <summary>Projection to apply before writing the table.</summary>
+    [Parameter]
+    public OfficeTableView View { get; set; } = OfficeTableView.Normal;
 
     /// <summary>Name to assign to the table.</summary>
     [Parameter]
@@ -68,10 +66,18 @@ public sealed class AddOfficeExcelTableCommand : PSCmdlet
     /// <inheritdoc />
     protected override void ProcessRecord()
     {
+        TableInputCollector.AddInput(_items, InputObject, preserveTabularInput: true);
+    }
+
+    /// <inheritdoc />
+    protected override void EndProcessing()
+    {
         var context = ExcelDslContext.Require(this);
         var sheet = context.RequireSheet();
 
-        var table = ExcelTabularInputService.ToDataTable(GetSourceInput(), TableName);
+        var rows = TableInputCollector.RequireRows(_items, nameof(InputObject));
+        var projectedRows = TableViewProjection.Project(rows, View);
+        var table = ExcelTabularInputService.ToDataTable(projectedRows, TableName);
         if (table.Columns.Count == 0)
         {
             throw new InvalidOperationException("Unable to infer columns from the supplied data.");
@@ -118,25 +124,5 @@ public sealed class AddOfficeExcelTableCommand : PSCmdlet
         }
 
         return string.IsNullOrWhiteSpace(table.TableName) ? null : table.TableName;
-    }
-
-    private IEnumerable<object?> GetSourceInput()
-    {
-        if (ParameterSetName == ParameterSetDataTable)
-        {
-            if (DataTable == null)
-            {
-                throw new PSArgumentNullException(nameof(DataTable));
-            }
-
-            return new object?[] { DataTable };
-        }
-
-        if (Data == null || Data.Length == 0)
-        {
-            throw new PSArgumentException("Provide at least one data row.", nameof(Data));
-        }
-
-        return Data;
     }
 }

--- a/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableCommand.cs
@@ -25,6 +25,7 @@ public sealed class AddOfficeExcelTableCommand : PSCmdlet
 
     /// <summary>Source objects, dictionaries, DataTable/DataView/IDataReader inputs, or DataRow sequences to convert into table rows.</summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    [Alias("Data", "DataTable")]
     public object? InputObject { get; set; }
 
     /// <summary>Starting row for the data (1-based).</summary>

--- a/Sources/PSWriteOffice/Cmdlets/Excel/OfficeExcelReportBlockCommands.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/OfficeExcelReportBlockCommands.cs
@@ -16,7 +16,7 @@ namespace PSWriteOffice.Cmdlets.Excel;
 ///   <code>New-OfficeExcel -Path .\Operations.xlsx {
 ///     Add-OfficeExcelReportSheet -Name Summary {
 ///         Add-OfficeExcelReportTitle -Title 'Operational Summary' -Subtitle 'Current month'
-///         Add-OfficeExcelReportKpiRow -Data @{ Revenue = 125000; Incidents = 3; Status = 'Ready' }
+///         Add-OfficeExcelReportKpiRow -InputObject @{ Revenue = 125000; Incidents = 3; Status = 'Ready' }
 ///     }
 /// }</code>
 ///   <para>Uses the OfficeIMO sheet composer through PSWriteOffice's thin report-block wrapper.</para>
@@ -167,7 +167,7 @@ public sealed class AddOfficeExcelReportCalloutCommand : PSCmdlet
 ///   <prefix>PS&gt; </prefix>
 ///   <code>New-OfficeExcel -Path .\Operations.xlsx {
 ///     Add-OfficeExcelReportSheet -Name Summary {
-///         Add-OfficeExcelReportKpiRow -Data @{ Revenue = 125000; Incidents = 3; Status = 'Ready' } -PerRow 3
+///         Add-OfficeExcelReportKpiRow -InputObject @{ Revenue = 125000; Incidents = 3; Status = 'Ready' } -PerRow 3
 ///     }
 /// }</code>
 ///   <para>Renders PowerShell key/value data as a KPI row through the OfficeIMO sheet composer.</para>
@@ -178,7 +178,7 @@ public sealed class AddOfficeExcelReportKpiRowCommand : PSCmdlet
 {
     /// <summary>Hashtable or objects with Label/Value, Key/Value, Name/Value, or Title/Value properties.</summary>
     [Parameter(Mandatory = true, Position = 0)]
-    public object Data { get; set; } = null!;
+    public object InputObject { get; set; } = null!;
 
     /// <summary>Number of KPI cards per rendered row.</summary>
     [Parameter]
@@ -191,7 +191,7 @@ public sealed class AddOfficeExcelReportKpiRowCommand : PSCmdlet
     /// <inheritdoc />
     protected override void ProcessRecord()
     {
-        ExcelDslContext.Require(this).RequireComposer().KpiRow(ReportBlockInput.ToPairs(Data), PerRow, LabelFillColor);
+        ExcelDslContext.Require(this).RequireComposer().KpiRow(ReportBlockInput.ToPairs(InputObject), PerRow, LabelFillColor);
     }
 }
 
@@ -205,7 +205,7 @@ public sealed class AddOfficeExcelReportKpiRowCommand : PSCmdlet
 /// )
 /// New-OfficeExcel -Path .\Operations.xlsx {
 ///     Add-OfficeExcelReportSheet -Name Summary {
-///         Add-OfficeExcelReportLegend -Title 'Status legend' -Headers Status, Meaning -Rows $legendRows -FirstColumnFillByValue @{ Ready = '#d9f7be'; Review = '#fff7e6' }
+///         Add-OfficeExcelReportLegend -Title 'Status legend' -Header Status, Meaning -InputObject $legendRows -FirstColumnFillByValue @{ Ready = '#d9f7be'; Review = '#fff7e6' }
 ///     }
 /// }</code>
 ///   <para>Renders legend rows and applies optional fill colors keyed by the first column.</para>
@@ -220,11 +220,11 @@ public sealed class AddOfficeExcelReportLegendCommand : PSCmdlet
 
     /// <summary>Column headers.</summary>
     [Parameter(Mandatory = true)]
-    public string[] Headers { get; set; } = Array.Empty<string>();
+    public string[] Header { get; set; } = Array.Empty<string>();
 
     /// <summary>Rows. Each row may be an array, enumerable, hashtable, or object.</summary>
     [Parameter(Mandatory = true)]
-    public object[] Rows { get; set; } = Array.Empty<object>();
+    public object[] InputObject { get; set; } = Array.Empty<object>();
 
     /// <summary>Optional first-column fill colors keyed by first-column value.</summary>
     [Parameter]
@@ -243,8 +243,8 @@ public sealed class AddOfficeExcelReportLegendCommand : PSCmdlet
     {
         ExcelDslContext.Require(this).RequireComposer().SectionLegend(
             Title,
-            Headers,
-            Rows.Select(row => ReportBlockInput.ToRow(row, Headers)),
+            Header,
+            InputObject.Select(row => ReportBlockInput.ToRow(row, Header)),
             ReportBlockInput.ToStringMap(FirstColumnFillByValue, CaseSensitive.IsPresent),
             HeaderFillColor);
     }
@@ -260,7 +260,7 @@ public sealed class AddOfficeExcelReportLegendCommand : PSCmdlet
 /// )
 /// New-OfficeExcel -Path .\Operations.xlsx {
 ///     Add-OfficeExcelReportSheet -Name Summary {
-///         Add-OfficeExcelReportTable -Data $rows -Title 'Documentation coverage' -TableStyle TableStyleMedium9
+///         Add-OfficeExcelReportTable -InputObject $rows -Title 'Documentation coverage' -TableStyle TableStyleMedium9
 ///     }
 /// }</code>
 ///   <para>Renders object rows as a formatted Excel table through the sheet composer.</para>
@@ -271,7 +271,7 @@ public sealed class AddOfficeExcelReportTableCommand : PSCmdlet
 {
     /// <summary>Objects to flatten and render as a table.</summary>
     [Parameter(Mandatory = true, Position = 0)]
-    public object[] Data { get; set; } = Array.Empty<object>();
+    public object[] InputObject { get; set; } = Array.Empty<object>();
 
     /// <summary>Optional section title displayed above the table.</summary>
     [Parameter(Position = 1)]
@@ -300,9 +300,9 @@ public sealed class AddOfficeExcelReportTableCommand : PSCmdlet
     /// <inheritdoc />
     protected override void ProcessRecord()
     {
-        if (Data.Length == 0)
+        if (InputObject.Length == 0)
         {
-            throw new PSArgumentException("Provide at least one data row.", nameof(Data));
+            throw new PSArgumentException("Provide at least one data row.", nameof(InputObject));
         }
 
         if (!Enum.TryParse(TableStyle, ignoreCase: true, out TableStyle style))
@@ -312,7 +312,7 @@ public sealed class AddOfficeExcelReportTableCommand : PSCmdlet
 
         var composer = ExcelDslContext.Require(this).RequireComposer();
         var range = composer.TableFrom(
-            Data,
+            InputObject,
             Title,
             style: style,
             autoFilter: !NoAutoFilter.IsPresent,

--- a/Sources/PSWriteOffice/Cmdlets/Excel/OfficeExcelReportBlockCommands.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/OfficeExcelReportBlockCommands.cs
@@ -178,6 +178,7 @@ public sealed class AddOfficeExcelReportKpiRowCommand : PSCmdlet
 {
     /// <summary>Hashtable or objects with Label/Value, Key/Value, Name/Value, or Title/Value properties.</summary>
     [Parameter(Mandatory = true, Position = 0)]
+    [Alias("Data")]
     public object InputObject { get; set; } = null!;
 
     /// <summary>Number of KPI cards per rendered row.</summary>
@@ -220,10 +221,12 @@ public sealed class AddOfficeExcelReportLegendCommand : PSCmdlet
 
     /// <summary>Column headers.</summary>
     [Parameter(Mandatory = true)]
+    [Alias("Headers")]
     public string[] Header { get; set; } = Array.Empty<string>();
 
     /// <summary>Rows. Each row may be an array, enumerable, hashtable, or object.</summary>
     [Parameter(Mandatory = true)]
+    [Alias("Rows")]
     public object[] InputObject { get; set; } = Array.Empty<object>();
 
     /// <summary>Optional first-column fill colors keyed by first-column value.</summary>
@@ -271,6 +274,7 @@ public sealed class AddOfficeExcelReportTableCommand : PSCmdlet
 {
     /// <summary>Objects to flatten and render as a table.</summary>
     [Parameter(Mandatory = true, Position = 0)]
+    [Alias("Data")]
     public object[] InputObject { get; set; } = Array.Empty<object>();
 
     /// <summary>Optional section title displayed above the table.</summary>

--- a/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartAxisCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartAxisCommand.cs
@@ -93,24 +93,28 @@ public sealed class SetOfficeExcelChartAxisCommand : PSCmdlet
     {
         try
         {
-            if (!string.IsNullOrWhiteSpace(CategoryTitle))
+            var categoryTitle = CategoryTitle;
+            if (!string.IsNullOrWhiteSpace(categoryTitle))
             {
-                Chart.SetCategoryAxisTitle(CategoryTitle, AxisGroup);
+                Chart.SetCategoryAxisTitle(categoryTitle!, AxisGroup);
             }
 
-            if (!string.IsNullOrWhiteSpace(ValueTitle))
+            var valueTitle = ValueTitle;
+            if (!string.IsNullOrWhiteSpace(valueTitle))
             {
-                Chart.SetValueAxisTitle(ValueTitle, AxisGroup);
+                Chart.SetValueAxisTitle(valueTitle!, AxisGroup);
             }
 
-            if (!string.IsNullOrWhiteSpace(CategoryNumberFormat))
+            var categoryNumberFormat = CategoryNumberFormat;
+            if (!string.IsNullOrWhiteSpace(categoryNumberFormat))
             {
-                Chart.SetCategoryAxisNumberFormat(CategoryNumberFormat, SourceLinked, AxisGroup);
+                Chart.SetCategoryAxisNumberFormat(categoryNumberFormat!, SourceLinked, AxisGroup);
             }
 
-            if (!string.IsNullOrWhiteSpace(ValueNumberFormat))
+            var valueNumberFormat = ValueNumberFormat;
+            if (!string.IsNullOrWhiteSpace(valueNumberFormat))
             {
-                Chart.SetValueAxisNumberFormat(ValueNumberFormat, SourceLinked, AxisGroup);
+                Chart.SetValueAxisNumberFormat(valueNumberFormat!, SourceLinked, AxisGroup);
             }
 
             if (ValueMinimum.HasValue || ValueMaximum.HasValue || ValueMajorUnit.HasValue || ValueMinorUnit.HasValue)
@@ -118,30 +122,33 @@ public sealed class SetOfficeExcelChartAxisCommand : PSCmdlet
                 Chart.SetValueAxisScale(ValueMinimum, ValueMaximum, ValueMajorUnit, ValueMinorUnit, axisGroup: AxisGroup);
             }
 
+            var categoryGridlineColor = CategoryGridlineColor;
+            var valueGridlineColor = ValueGridlineColor;
+
             bool categoryGridlinesRequested = ShowCategoryMajorGridlines.IsPresent ||
                 ShowCategoryMinorGridlines.IsPresent ||
-                !string.IsNullOrWhiteSpace(CategoryGridlineColor);
+                !string.IsNullOrWhiteSpace(categoryGridlineColor);
             bool valueGridlinesRequested = ShowValueMajorGridlines.IsPresent ||
                 ShowValueMinorGridlines.IsPresent ||
-                !string.IsNullOrWhiteSpace(ValueGridlineColor);
+                !string.IsNullOrWhiteSpace(valueGridlineColor);
             bool widthOnlyRequest = GridlineWidthPoints.HasValue && !categoryGridlinesRequested && !valueGridlinesRequested;
 
-            bool categoryStyleRequested = !string.IsNullOrWhiteSpace(CategoryGridlineColor) ||
+            bool categoryStyleRequested = !string.IsNullOrWhiteSpace(categoryGridlineColor) ||
                 (GridlineWidthPoints.HasValue && (categoryGridlinesRequested || widthOnlyRequest));
             if (categoryGridlinesRequested || widthOnlyRequest)
             {
                 bool showMajor = ShowCategoryMajorGridlines.IsPresent || ShowCategoryMinorGridlines.IsPresent || categoryStyleRequested;
                 Chart.SetCategoryAxisGridlines(showMajor,
-                    ShowCategoryMinorGridlines.IsPresent, CategoryGridlineColor, GridlineWidthPoints, AxisGroup);
+                    ShowCategoryMinorGridlines.IsPresent, categoryGridlineColor, GridlineWidthPoints, AxisGroup);
             }
 
-            bool valueStyleRequested = !string.IsNullOrWhiteSpace(ValueGridlineColor) ||
+            bool valueStyleRequested = !string.IsNullOrWhiteSpace(valueGridlineColor) ||
                 (GridlineWidthPoints.HasValue && (valueGridlinesRequested || widthOnlyRequest));
             if (valueGridlinesRequested || widthOnlyRequest)
             {
                 bool showMajor = ShowValueMajorGridlines.IsPresent || ShowValueMinorGridlines.IsPresent || valueStyleRequested;
                 Chart.SetValueAxisGridlines(showMajor,
-                    ShowValueMinorGridlines.IsPresent, ValueGridlineColor, GridlineWidthPoints, AxisGroup);
+                    ShowValueMinorGridlines.IsPresent, valueGridlineColor, GridlineWidthPoints, AxisGroup);
             }
 
             WriteObject(Chart);

--- a/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartSeriesCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/SetOfficeExcelChartSeriesCommand.cs
@@ -74,40 +74,42 @@ public sealed class SetOfficeExcelChartSeriesCommand : PSCmdlet
     {
         try
         {
-            if (!string.IsNullOrWhiteSpace(FillColor))
+            var fillColor = FillColor;
+            if (!string.IsNullOrWhiteSpace(fillColor))
             {
                 if (ParameterSetName == ParameterSetSeriesName)
                 {
-                    Chart.SetSeriesFillColor(SeriesName, FillColor, IgnoreCase);
+                    Chart.SetSeriesFillColor(SeriesName, fillColor!, IgnoreCase);
                 }
                 else
                 {
-                    Chart.SetSeriesFillColor(SeriesIndex, FillColor);
+                    Chart.SetSeriesFillColor(SeriesIndex, fillColor!);
                 }
             }
 
-            if (!string.IsNullOrWhiteSpace(LineColor) || LineWidthPoints.HasValue)
+            var lineColor = LineColor;
+            if (!string.IsNullOrWhiteSpace(lineColor) || LineWidthPoints.HasValue)
             {
-                if (string.IsNullOrWhiteSpace(LineColor))
+                if (string.IsNullOrWhiteSpace(lineColor))
                 {
                     throw new PSArgumentException("LineColor is required when LineWidthPoints is used because the current OfficeIMO chart API applies series line width together with a line color.");
                 }
 
                 if (ParameterSetName == ParameterSetSeriesName)
                 {
-                    Chart.SetSeriesLineColor(SeriesName, LineColor, LineWidthPoints, IgnoreCase);
+                    Chart.SetSeriesLineColor(SeriesName, lineColor!, LineWidthPoints, IgnoreCase);
                 }
                 else
                 {
-                    Chart.SetSeriesLineColor(SeriesIndex, LineColor, LineWidthPoints);
+                    Chart.SetSeriesLineColor(SeriesIndex, lineColor!, LineWidthPoints);
                 }
             }
 
+            var markerStyleName = string.IsNullOrWhiteSpace(MarkerStyle) ? "Circle" : MarkerStyle!;
             bool markerRequested = !string.IsNullOrWhiteSpace(MarkerStyle) || MarkerSize.HasValue ||
                 !string.IsNullOrWhiteSpace(MarkerFillColor) || !string.IsNullOrWhiteSpace(MarkerLineColor) || MarkerLineWidthPoints.HasValue;
             if (markerRequested)
             {
-                string markerStyleName = string.IsNullOrWhiteSpace(MarkerStyle) ? "Circle" : MarkerStyle;
                 if (!OpenXmlValueParser.TryParse(markerStyleName, out C.MarkerStyleValues markerStyle))
                 {
                     throw new PSArgumentException($"Unknown MarkerStyle '{MarkerStyle}'.");

--- a/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownFrontMatterCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownFrontMatterCommand.cs
@@ -12,7 +12,7 @@ namespace PSWriteOffice.Cmdlets.Markdown;
 /// <example>
 ///   <summary>Add front matter from a hashtable.</summary>
 ///   <prefix>PS&gt; </prefix>
-///   <code>MarkdownFrontMatter -Data @{ title = 'Weekly Report'; tags = @('ops','summary') }</code>
+///   <code>MarkdownFrontMatter -InputObject @{ title = 'Weekly Report'; tags = @('ops','summary') }</code>
 ///   <para>Sets the document header using the supplied key/value pairs.</para>
 /// </example>
 [Cmdlet(VerbsCommon.Add, "OfficeMarkdownFrontMatter", DefaultParameterSetName = ParameterSetContext)]
@@ -29,7 +29,7 @@ public sealed class AddOfficeMarkdownFrontMatterCommand : PSCmdlet
 
     /// <summary>Front matter data expressed as a hashtable or object.</summary>
     [Parameter(Mandatory = true, Position = 0)]
-    public object Data { get; set; } = null!;
+    public object InputObject { get; set; } = null!;
 
     /// <summary>Emit the updated Markdown document.</summary>
     [Parameter]
@@ -39,7 +39,7 @@ public sealed class AddOfficeMarkdownFrontMatterCommand : PSCmdlet
     protected override void ProcessRecord()
     {
         var doc = ResolveDocument();
-        doc.FrontMatter(NormalizeData(Data));
+        doc.FrontMatter(NormalizeInputObject(InputObject));
 
         if (PassThru.IsPresent)
         {
@@ -47,11 +47,11 @@ public sealed class AddOfficeMarkdownFrontMatterCommand : PSCmdlet
         }
     }
 
-    private static object NormalizeData(object? value)
+    private static object NormalizeInputObject(object? value)
     {
         if (value == null)
         {
-            throw new PSArgumentNullException(nameof(Data));
+            throw new PSArgumentNullException(nameof(InputObject));
         }
 
         if (value is IDictionary dictionary)

--- a/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownFrontMatterCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownFrontMatterCommand.cs
@@ -29,6 +29,7 @@ public sealed class AddOfficeMarkdownFrontMatterCommand : PSCmdlet
 
     /// <summary>Front matter data expressed as a hashtable or object.</summary>
     [Parameter(Mandatory = true, Position = 0)]
+    [Alias("Data")]
     public object InputObject { get; set; } = null!;
 
     /// <summary>Emit the updated Markdown document.</summary>

--- a/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableCommand.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Management.Automation;
 using OfficeIMO.Markdown;
 using PSWriteOffice.Services.Markdown;
+using PSWriteOffice.Services.Table;
 
 namespace PSWriteOffice.Cmdlets.Markdown;
 
@@ -37,8 +38,13 @@ public sealed class AddOfficeMarkdownTableCommand : PSCmdlet
     public MarkdownDoc Document { get; set; } = null!;
 
     /// <summary>Objects to convert into a Markdown table.</summary>
-    [Parameter(ValueFromPipeline = true)]
+    [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = ParameterSetContext)]
+    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetDocument)]
     public object? InputObject { get; set; }
+
+    /// <summary>Projection to apply before writing the table.</summary>
+    [Parameter]
+    public OfficeTableView View { get; set; } = OfficeTableView.Normal;
 
     /// <summary>Disable automatic alignment heuristics for tables.</summary>
     [Parameter]
@@ -51,7 +57,10 @@ public sealed class AddOfficeMarkdownTableCommand : PSCmdlet
     /// <inheritdoc />
     protected override void BeginProcessing()
     {
-        _document = ResolveDocument();
+        if (ParameterSetName == ParameterSetContext)
+        {
+            _document = ResolveDocument();
+        }
     }
 
     /// <inheritdoc />
@@ -63,19 +72,17 @@ public sealed class AddOfficeMarkdownTableCommand : PSCmdlet
     /// <inheritdoc />
     protected override void EndProcessing()
     {
-        if (_items.Count == 0)
-        {
-            return;
-        }
-
         var doc = _document ?? ResolveDocument();
+        var rows = TableInputCollector.RequireRows(_items, nameof(InputObject));
+        var projectedRows = TableViewProjection.Project(rows, View);
+        var normalizedRows = projectedRows.Select(NormalizeItem).ToArray();
         if (DisableAutoAlign.IsPresent)
         {
-            doc.TableFrom(_items);
+            doc.TableFrom(normalizedRows);
         }
         else
         {
-            doc.TableFromAuto(_items);
+            doc.TableFromAuto(normalizedRows);
         }
 
         if (PassThru.IsPresent)
@@ -86,16 +93,7 @@ public sealed class AddOfficeMarkdownTableCommand : PSCmdlet
 
     private void AddInput(object? value)
     {
-        if (value is IEnumerable enumerable and not string and not IDictionary)
-        {
-            foreach (var entry in enumerable)
-            {
-                _items.Add(NormalizeItem(entry));
-            }
-            return;
-        }
-
-        _items.Add(NormalizeItem(value));
+        TableInputCollector.AddInput(_items, value);
     }
 
     private static object? NormalizeItem(object? item)

--- a/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableCommand.cs
@@ -30,16 +30,19 @@ public sealed class AddOfficeMarkdownTableCommand : PSCmdlet
 {
     private const string ParameterSetContext = "Context";
     private const string ParameterSetDocument = "Document";
+    private const string ParameterSetPipelineDocument = "PipelineDocument";
     private readonly List<object?> _items = new();
     private MarkdownDoc? _document;
 
     /// <summary>Markdown document to update outside the DSL context.</summary>
-    [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = ParameterSetDocument)]
+    [Parameter(Mandatory = true, ParameterSetName = ParameterSetDocument)]
+    [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = ParameterSetPipelineDocument)]
     public MarkdownDoc Document { get; set; } = null!;
 
     /// <summary>Objects to convert into a Markdown table.</summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = ParameterSetContext)]
-    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetDocument)]
+    [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = ParameterSetDocument)]
+    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetPipelineDocument)]
     public object? InputObject { get; set; }
 
     /// <summary>Projection to apply before writing the table.</summary>
@@ -66,14 +69,38 @@ public sealed class AddOfficeMarkdownTableCommand : PSCmdlet
     /// <inheritdoc />
     protected override void ProcessRecord()
     {
+        if (ParameterSetName == ParameterSetPipelineDocument)
+        {
+            RenderTable(Document, BuildRows(InputObject));
+            if (PassThru.IsPresent)
+            {
+                WriteObject(Document);
+            }
+
+            return;
+        }
+
         AddInput(InputObject);
     }
 
     /// <inheritdoc />
     protected override void EndProcessing()
     {
+        if (ParameterSetName == ParameterSetPipelineDocument)
+        {
+            return;
+        }
+
         var doc = _document ?? ResolveDocument();
-        var rows = TableInputCollector.RequireRows(_items, nameof(InputObject));
+        RenderTable(doc, TableInputCollector.RequireRows(_items, nameof(InputObject)));
+        if (PassThru.IsPresent)
+        {
+            WriteObject(doc);
+        }
+    }
+
+    private void RenderTable(MarkdownDoc doc, object[] rows)
+    {
         var projectedRows = TableViewProjection.Project(rows, View);
         var normalizedRows = projectedRows.Select(NormalizeItem).ToArray();
         if (DisableAutoAlign.IsPresent)
@@ -84,16 +111,18 @@ public sealed class AddOfficeMarkdownTableCommand : PSCmdlet
         {
             doc.TableFromAuto(normalizedRows);
         }
-
-        if (PassThru.IsPresent)
-        {
-            WriteObject(doc);
-        }
     }
 
     private void AddInput(object? value)
     {
         TableInputCollector.AddInput(_items, value);
+    }
+
+    private static object[] BuildRows(object? value)
+    {
+        var items = new List<object?>();
+        TableInputCollector.AddInput(items, value);
+        return TableInputCollector.RequireRows(items, nameof(InputObject));
     }
 
     private static object? NormalizeItem(object? item)

--- a/Sources/PSWriteOffice/Cmdlets/Pdf/AddOfficePdfTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Pdf/AddOfficePdfTableCommand.cs
@@ -1,8 +1,10 @@
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 using OfficeIMO.Pdf;
 using PSWriteOffice.Services.Pdf;
+using PSWriteOffice.Services.Table;
 
 namespace PSWriteOffice.Cmdlets.Pdf;
 
@@ -27,14 +29,16 @@ public sealed class AddOfficePdfTableCommand : PSCmdlet
 {
     private const string ParameterSetContext = "Context";
     private const string ParameterSetDocument = "Document";
+    private readonly List<object?> _items = new();
 
     /// <summary>PDF document to update outside the DSL context.</summary>
     [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = ParameterSetDocument)]
     public PdfDocument Document { get; set; } = null!;
 
     /// <summary>Objects or row arrays to render as a table.</summary>
-    [Parameter(Mandatory = true, Position = 0)]
-    public object[] InputObject { get; set; } = System.Array.Empty<object>();
+    [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = ParameterSetContext)]
+    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetDocument)]
+    public object? InputObject { get; set; }
 
     /// <summary>Specific object properties to include.</summary>
     [Parameter]
@@ -43,6 +47,10 @@ public sealed class AddOfficePdfTableCommand : PSCmdlet
     /// <summary>Header labels. Defaults to property names.</summary>
     [Parameter]
     public string[]? Header { get; set; }
+
+    /// <summary>Projection to apply before writing the table.</summary>
+    [Parameter]
+    public OfficeTableView View { get; set; } = OfficeTableView.Normal;
 
     /// <summary>Table alignment.</summary>
     [Parameter]
@@ -55,13 +63,21 @@ public sealed class AddOfficePdfTableCommand : PSCmdlet
     /// <inheritdoc />
     protected override void ProcessRecord()
     {
+        TableInputCollector.AddInput(_items, InputObject);
+    }
+
+    /// <inheritdoc />
+    protected override void EndProcessing()
+    {
         var document = PdfCommandUtilities.ResolveDocument(this, Document, ParameterSetName, ParameterSetDocument);
-        var rowArrayInput = InputObject.All(item => item is IEnumerable && item is not string && item is not IDictionary);
+        var inputRows = TableInputCollector.RequireRows(_items, nameof(InputObject));
+        var projectedRows = TableViewProjection.Project(inputRows, View);
+        var rowArrayInput = projectedRows.All(item => item is IEnumerable && item is not string && item is not IDictionary);
         string[][] rows = rowArrayInput
-            ? PdfCommandUtilities.ConvertDataRows(InputObject, Header)
-            : InputObject.Length == 1 && InputObject[0] is IEnumerable enumerable && InputObject[0] is not string && InputObject[0] is not IDictionary
+            ? PdfCommandUtilities.ConvertDataRows(projectedRows, Header)
+            : projectedRows.Length == 1 && projectedRows[0] is IEnumerable enumerable && projectedRows[0] is not string && projectedRows[0] is not IDictionary
             ? PdfCommandUtilities.ConvertDataRows(enumerable, Header)
-            : PdfCommandUtilities.ConvertToTableRows(InputObject, Property, Header);
+            : PdfCommandUtilities.ConvertToTableRows(projectedRows, Property, Header);
 
         document.Table(rows, Align);
         if (PassThru.IsPresent)

--- a/Sources/PSWriteOffice/Cmdlets/Pdf/AddOfficePdfTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Pdf/AddOfficePdfTableCommand.cs
@@ -29,15 +29,18 @@ public sealed class AddOfficePdfTableCommand : PSCmdlet
 {
     private const string ParameterSetContext = "Context";
     private const string ParameterSetDocument = "Document";
+    private const string ParameterSetPipelineDocument = "PipelineDocument";
     private readonly List<object?> _items = new();
 
     /// <summary>PDF document to update outside the DSL context.</summary>
-    [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = ParameterSetDocument)]
+    [Parameter(Mandatory = true, ParameterSetName = ParameterSetDocument)]
+    [Parameter(Mandatory = true, ValueFromPipeline = true, ParameterSetName = ParameterSetPipelineDocument)]
     public PdfDocument Document { get; set; } = null!;
 
     /// <summary>Objects or row arrays to render as a table.</summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = ParameterSetContext)]
-    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetDocument)]
+    [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ParameterSetName = ParameterSetDocument)]
+    [Parameter(Mandatory = true, Position = 0, ParameterSetName = ParameterSetPipelineDocument)]
     public object? InputObject { get; set; }
 
     /// <summary>Specific object properties to include.</summary>
@@ -63,14 +66,38 @@ public sealed class AddOfficePdfTableCommand : PSCmdlet
     /// <inheritdoc />
     protected override void ProcessRecord()
     {
+        if (ParameterSetName == ParameterSetPipelineDocument)
+        {
+            RenderTable(Document, BuildRows(InputObject));
+            if (PassThru.IsPresent)
+            {
+                WriteObject(Document);
+            }
+
+            return;
+        }
+
         TableInputCollector.AddInput(_items, InputObject);
     }
 
     /// <inheritdoc />
     protected override void EndProcessing()
     {
+        if (ParameterSetName == ParameterSetPipelineDocument)
+        {
+            return;
+        }
+
         var document = PdfCommandUtilities.ResolveDocument(this, Document, ParameterSetName, ParameterSetDocument);
-        var inputRows = TableInputCollector.RequireRows(_items, nameof(InputObject));
+        RenderTable(document, TableInputCollector.RequireRows(_items, nameof(InputObject)));
+        if (PassThru.IsPresent)
+        {
+            WriteObject(document);
+        }
+    }
+
+    private void RenderTable(PdfDocument document, object[] inputRows)
+    {
         var projectedRows = TableViewProjection.Project(inputRows, View);
         var rowArrayInput = projectedRows.All(item => item is IEnumerable && item is not string && item is not IDictionary);
         string[][] rows = rowArrayInput
@@ -80,9 +107,12 @@ public sealed class AddOfficePdfTableCommand : PSCmdlet
             : PdfCommandUtilities.ConvertToTableRows(projectedRows, Property, Header);
 
         document.Table(rows, Align);
-        if (PassThru.IsPresent)
-        {
-            WriteObject(document);
-        }
+    }
+
+    private static object[] BuildRows(object? value)
+    {
+        var items = new List<object?>();
+        TableInputCollector.AddInput(items, value);
+        return TableInputCollector.RequireRows(items, nameof(InputObject));
     }
 }

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointChartCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointChartCommand.cs
@@ -35,7 +35,7 @@ public enum PowerPointChartType
 /// )
 /// New-OfficePowerPoint -Path .\Examples\Documents\PowerPointChart.pptx {
 ///     $slide = Add-OfficePowerPointSlide -Layout 1
-///     Add-OfficePowerPointChart -Slide $slide -Data $rows -CategoryProperty Month -SeriesProperty Sales,Profit -Title 'Monthly performance'
+///     Add-OfficePowerPointChart -Slide $slide -InputObject $rows -CategoryProperty Month -SeriesProperty Sales,Profit -Title 'Monthly performance'
 /// }</code>
 ///   <para>Creates a clustered column chart using Month for categories and Sales/Profit as series.</para>
 /// </example>
@@ -48,7 +48,7 @@ public enum PowerPointChartType
 /// )
 /// New-OfficePowerPoint -Path .\Examples\Documents\PowerPointScatter.pptx {
 ///     $slide = Add-OfficePowerPointSlide -Layout 1
-///     Add-OfficePowerPointChart -Slide $slide -Type Scatter -Data $rows -XProperty Quarter -YProperty Revenue -Title 'Revenue trend'
+///     Add-OfficePowerPointChart -Slide $slide -Type Scatter -InputObject $rows -XProperty Quarter -YProperty Revenue -Title 'Revenue trend'
 /// }</code>
 ///   <para>Creates a scatter chart using Quarter on the X axis and Revenue on the Y axis.</para>
 /// </example>
@@ -72,7 +72,7 @@ public sealed class AddOfficePowerPointChartCommand : PSCmdlet
     /// <summary>Source objects used to build chart data.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetCategorical)]
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetScatter)]
-    public object[] Data { get; set; } = Array.Empty<object>();
+    public object[] InputObject { get; set; } = Array.Empty<object>();
 
     /// <summary>Property name used for category labels on standard charts.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetCategorical)]
@@ -228,12 +228,12 @@ public sealed class AddOfficePowerPointChartCommand : PSCmdlet
 
     private object[] EnsureData()
     {
-        if (Data == null || Data.Length == 0)
+        if (InputObject == null || InputObject.Length == 0)
         {
-            throw new PSArgumentException("Provide at least one data item.", nameof(Data));
+            throw new PSArgumentException("Provide at least one data item.", nameof(InputObject));
         }
 
-        return Data;
+        return InputObject;
     }
 
     private static object? GetPropertyValue(object item, string propertyName)

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointChartCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointChartCommand.cs
@@ -72,6 +72,7 @@ public sealed class AddOfficePowerPointChartCommand : PSCmdlet
     /// <summary>Source objects used to build chart data.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetCategorical)]
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetScatter)]
+    [Alias("Data")]
     public object[] InputObject { get; set; } = Array.Empty<object>();
 
     /// <summary>Property name used for category labels on standard charts.</summary>

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTableCommand.cs
@@ -37,6 +37,7 @@ public sealed class AddOfficePowerPointTableCommand : PSCmdlet
 
     /// <summary>Optional header order to apply to the table.</summary>
     [Parameter(ParameterSetName = ParameterSetInputObject)]
+    [Alias("Headers")]
     public string[]? Header { get; set; }
 
     /// <summary>Skip writing header row.</summary>

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTableCommand.cs
@@ -33,6 +33,7 @@ public sealed class AddOfficePowerPointTableCommand : PSCmdlet
 
     /// <summary>Source objects to convert into table rows.</summary>
     [Parameter(Mandatory = true, Position = 1, ParameterSetName = ParameterSetInputObject)]
+    [Alias("Data")]
     public object? InputObject { get; set; }
 
     /// <summary>Optional header order to apply to the table.</summary>

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTableCommand.cs
@@ -7,6 +7,7 @@ using System.Management.Automation;
 using OfficeIMO.PowerPoint;
 using PSWriteOffice.Services;
 using PSWriteOffice.Services.PowerPoint;
+using PSWriteOffice.Services.Table;
 
 namespace PSWriteOffice.Cmdlets.PowerPoint;
 
@@ -16,14 +17,14 @@ namespace PSWriteOffice.Cmdlets.PowerPoint;
 ///   <summary>Create a table from objects.</summary>
 ///   <prefix>PS&gt; </prefix>
 ///   <code>$rows = @([pscustomobject]@{ Item='Alpha'; Qty=2 }, [pscustomobject]@{ Item='Beta'; Qty=4 })
-///   Add-OfficePowerPointTable -Slide $slide -Data $rows -X 60 -Y 140 -Width 420 -Height 200</code>
+///   Add-OfficePowerPointTable -Slide $slide -InputObject $rows -X 60 -Y 140 -Width 420 -Height 200</code>
 ///   <para>Creates a table with headers and two data rows.</para>
 /// </example>
-[Cmdlet(VerbsCommon.Add, "OfficePowerPointTable", DefaultParameterSetName = ParameterSetData)]
+[Cmdlet(VerbsCommon.Add, "OfficePowerPointTable", DefaultParameterSetName = ParameterSetInputObject)]
 [Alias("PptTable")]
 public sealed class AddOfficePowerPointTableCommand : PSCmdlet
 {
-    private const string ParameterSetData = "Data";
+    private const string ParameterSetInputObject = "InputObject";
     private const string ParameterSetSize = "Size";
 
     /// <summary>Target slide that will receive the table (optional inside DSL).</summary>
@@ -31,16 +32,20 @@ public sealed class AddOfficePowerPointTableCommand : PSCmdlet
     public PowerPointSlide? Slide { get; set; }
 
     /// <summary>Source objects to convert into table rows.</summary>
-    [Parameter(Mandatory = true, ParameterSetName = ParameterSetData)]
-    public object[] Data { get; set; } = Array.Empty<object>();
+    [Parameter(Mandatory = true, Position = 1, ParameterSetName = ParameterSetInputObject)]
+    public object? InputObject { get; set; }
 
     /// <summary>Optional header order to apply to the table.</summary>
-    [Parameter(ParameterSetName = ParameterSetData)]
-    public string[]? Headers { get; set; }
+    [Parameter(ParameterSetName = ParameterSetInputObject)]
+    public string[]? Header { get; set; }
 
     /// <summary>Skip writing header row.</summary>
-    [Parameter(ParameterSetName = ParameterSetData)]
+    [Parameter(ParameterSetName = ParameterSetInputObject)]
     public SwitchParameter NoHeader { get; set; }
+
+    /// <summary>Projection to apply before writing the table.</summary>
+    [Parameter(ParameterSetName = ParameterSetInputObject)]
+    public OfficeTableView View { get; set; } = OfficeTableView.Normal;
 
     /// <summary>Row count for an empty table.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetSize)]
@@ -113,12 +118,11 @@ public sealed class AddOfficePowerPointTableCommand : PSCmdlet
 
     private PowerPointTable CreateDataTable(PowerPointSlide slide)
     {
-        if (Data == null || Data.Length == 0)
-        {
-            throw new PSArgumentException("Provide at least one data row.", nameof(Data));
-        }
-
-        var normalized = PowerShellObjectNormalizer.NormalizeItems(Data);
+        var items = new List<object?>();
+        TableInputCollector.AddInput(items, InputObject);
+        var inputRows = TableInputCollector.RequireRows(items, nameof(InputObject));
+        var projectedRows = TableViewProjection.Project(inputRows, View);
+        var normalized = PowerShellObjectNormalizer.NormalizeItems(projectedRows);
         var rows = NormalizeRows(normalized);
         var headers = ResolveHeaders(rows);
 
@@ -188,16 +192,16 @@ public sealed class AddOfficePowerPointTableCommand : PSCmdlet
 
     private List<string> ResolveHeaders(IReadOnlyList<Dictionary<string, object?>> rows)
     {
-        if (Headers != null && Headers.Length > 0)
+        if (Header != null && Header.Length > 0)
         {
-            var explicitHeaders = Headers
+            var explicitHeaders = Header
                 .Where(h => !string.IsNullOrWhiteSpace(h))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
             if (explicitHeaders.Count == 0)
             {
-                throw new PSArgumentException("Headers cannot be empty.", nameof(Headers));
+                throw new PSArgumentException("Header cannot be empty.", nameof(Header));
             }
 
             return explicitHeaders;

--- a/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordChartCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordChartCommand.cs
@@ -36,8 +36,8 @@ public enum WordChartType
 /// )
 /// New-OfficeWord -Path .\RegionalReport.docx {
 ///     Add-OfficeWordParagraph -Text 'Regional revenue'
-///     Add-OfficeWordChart -Type Pie -Data $rows -CategoryProperty Region -SeriesProperty Revenue -Title 'Revenue mix' -FitToPageWidth -WidthFraction 0.75
-///     Add-OfficeWordChart -Type Bar -Data $rows -CategoryProperty Region -SeriesProperty Revenue, Profit -Legend -XAxisTitle 'Region' -YAxisTitle 'Amount'
+///     Add-OfficeWordChart -Type Pie -InputObject $rows -CategoryProperty Region -SeriesProperty Revenue -Title 'Revenue mix' -FitToPageWidth -WidthFraction 0.75
+///     Add-OfficeWordChart -Type Bar -InputObject $rows -CategoryProperty Region -SeriesProperty Revenue, Profit -Legend -XAxisTitle 'Region' -YAxisTitle 'Amount'
 /// }</code>
 ///   <para>Creates a report with a pie chart and a multi-series bar chart from PowerShell objects.</para>
 /// </example>
@@ -50,7 +50,7 @@ public enum WordChartType
 ///     [pscustomobject]@{ Month = 'Mar'; Sales = 15; Profit = 7 }
 /// )
 /// $doc = New-OfficeWord -Path .\Trend.docx -PassThru
-/// Add-OfficeWordChart -Document $doc -Type Line -Data $trend -CategoryProperty Month -SeriesProperty Sales, Profit -Legend -Title 'Quarter trend'
+/// Add-OfficeWordChart -Document $doc -Type Line -InputObject $trend -CategoryProperty Month -SeriesProperty Sales, Profit -Legend -Title 'Quarter trend'
 /// Save-OfficeWord -Document $doc</code>
 ///   <para>Creates a multi-series line chart on the document and shows a legend.</para>
 /// </example>
@@ -87,7 +87,7 @@ public sealed class AddOfficeWordChartCommand : PSCmdlet
 
     /// <summary>Source objects used to build chart data.</summary>
     [Parameter(Mandatory = true)]
-    public object[] Data { get; set; } = Array.Empty<object>();
+    public object[] InputObject { get; set; } = Array.Empty<object>();
 
     /// <summary>Property name used for category labels.</summary>
     [Parameter(Mandatory = true)]
@@ -145,9 +145,9 @@ public sealed class AddOfficeWordChartCommand : PSCmdlet
     /// <inheritdoc />
     protected override void ProcessRecord()
     {
-        if (Data == null || Data.Length == 0)
+        if (InputObject == null || InputObject.Length == 0)
         {
-            throw new PSArgumentException("Provide at least one data item.", nameof(Data));
+            throw new PSArgumentException("Provide at least one data item.", nameof(InputObject));
         }
 
         if (SeriesProperty == null || SeriesProperty.Length == 0)
@@ -175,10 +175,10 @@ public sealed class AddOfficeWordChartCommand : PSCmdlet
             throw new ArgumentOutOfRangeException(nameof(WidthFraction), "WidthFraction must be between 0 and 1 when FitToPageWidth is used.");
         }
 
-        var items = Data.Where(item => item != null).ToArray();
+        var items = InputObject.Where(item => item != null).ToArray();
         if (items.Length == 0)
         {
-            throw new PSArgumentException("Chart data items cannot all be null.", nameof(Data));
+            throw new PSArgumentException("Chart data items cannot all be null.", nameof(InputObject));
         }
 
         var chart = CreateChartTarget();

--- a/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordChartCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordChartCommand.cs
@@ -87,6 +87,7 @@ public sealed class AddOfficeWordChartCommand : PSCmdlet
 
     /// <summary>Source objects used to build chart data.</summary>
     [Parameter(Mandatory = true)]
+    [Alias("Data")]
     public object[] InputObject { get; set; } = Array.Empty<object>();
 
     /// <summary>Property name used for category labels.</summary>

--- a/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCellCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCellCommand.cs
@@ -10,7 +10,7 @@ namespace PSWriteOffice.Cmdlets.Word;
 /// <example>
 ///   <summary>Add nested content to a table cell.</summary>
 ///   <prefix>PS&gt; </prefix>
-///   <code>WordTable -Data $Rows { WordTableCell -Row 1 -Column 0 { WordParagraph { WordText 'Details' } } }</code>
+///   <code>WordTable -InputObject $Rows { WordTableCell -Row 1 -Column 0 { WordParagraph { WordText 'Details' } } }</code>
 ///   <para>Targets the data cell at row 1, column 0 and writes text inside it.</para>
 /// </example>
 [Cmdlet(VerbsCommon.Add, "OfficeWordTableCell", DefaultParameterSetName = ParameterSetContext)]

--- a/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCommand.cs
@@ -7,6 +7,7 @@ using System.Management.Automation;
 using DocumentFormat.OpenXml.Wordprocessing;
 using OfficeIMO.Word;
 using PSWriteOffice.Services;
+using PSWriteOffice.Services.Table;
 using PSWriteOffice.Services.Word;
 
 namespace PSWriteOffice.Cmdlets.Word;
@@ -23,9 +24,10 @@ namespace PSWriteOffice.Cmdlets.Word;
 [Alias("WordTable")]
 public sealed class AddOfficeWordTableCommand : PSCmdlet
 {
+    private readonly List<object?> _items = new();
+
     /// <summary>Input data (array, list, DataTable, etc.).</summary>
-    [Parameter(Mandatory = true, Position = 0)]
-    [Alias("Data")]
+    [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
     public object? InputObject { get; set; }
 
     /// <summary>Built-in table style.</summary>
@@ -39,11 +41,11 @@ public sealed class AddOfficeWordTableCommand : PSCmdlet
 
     /// <summary>Skip writing header row.</summary>
     [Parameter]
-    public SwitchParameter SkipHeader { get; set; }
+    public SwitchParameter NoHeader { get; set; }
 
-    /// <summary>Transpose rows into property-oriented output.</summary>
+    /// <summary>Projection to apply before writing the table.</summary>
     [Parameter]
-    public SwitchParameter Transpose { get; set; }
+    public OfficeTableView View { get; set; } = OfficeTableView.Normal;
 
     /// <summary>DSL content executed inside the table.</summary>
     [Parameter(Position = 1)]
@@ -56,7 +58,13 @@ public sealed class AddOfficeWordTableCommand : PSCmdlet
     /// <inheritdoc />
     protected override void ProcessRecord()
     {
-        var rows = NormalizeRows(InputObject);
+        TableInputCollector.AddInput(_items, InputObject);
+    }
+
+    /// <inheritdoc />
+    protected override void EndProcessing()
+    {
+        var rows = TableInputCollector.RequireRows(_items, nameof(InputObject));
         if (rows.Length == 0)
         {
             ThrowTerminatingError(new ErrorRecord(
@@ -68,10 +76,10 @@ public sealed class AddOfficeWordTableCommand : PSCmdlet
         }
 
         var context = WordDslContext.Require(this);
-        var tableRows = Transpose.IsPresent ? TransposeRows(rows) : rows;
+        var tableRows = TableViewProjection.Project(rows, View);
         var normalizedRows = PowerShellObjectNormalizer.NormalizeItems(tableRows);
         var legacyLayout = ResolveLegacyLayout(Layout);
-        var table = CreateTable(context, normalizedRows, Style, includeHeader: !SkipHeader.IsPresent, layout: legacyLayout);
+        var table = CreateTable(context, normalizedRows, Style, includeHeader: !NoHeader.IsPresent, layout: legacyLayout);
         ApplyLayout(table, Layout);
         context.RegisterTableSource(table, tableRows);
 
@@ -83,7 +91,7 @@ public sealed class AddOfficeWordTableCommand : PSCmdlet
         var conditions = context.ConsumeTableConditions(table);
         if (conditions.Count > 0)
         {
-            ApplyConditions(table, tableRows, conditions, SkipHeader.IsPresent);
+            ApplyConditions(table, tableRows, conditions, NoHeader.IsPresent);
         }
 
         context.ClearTableSource(table);
@@ -92,109 +100,6 @@ public sealed class AddOfficeWordTableCommand : PSCmdlet
         {
             WriteObject(table);
         }
-    }
-
-    private static object[] NormalizeRows(object? data)
-    {
-        switch (data)
-        {
-            case null:
-                return Array.Empty<object>();
-            case Array array:
-                return array.Cast<object?>().Where(o => o != null).Select(o => o!).ToArray();
-            case IEnumerable enumerable when data is not string:
-                var list = new List<object>();
-                foreach (var item in enumerable)
-                {
-                    if (item != null)
-                    {
-                        list.Add(item);
-                    }
-                }
-                return list.ToArray();
-            default:
-                return new[] { data };
-        }
-    }
-
-    private static object[] TransposeRows(IReadOnlyList<object> rows)
-    {
-        var maps = rows.Select(BuildPropertyMap).ToList();
-        var columnNames = new List<string>();
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var map in maps)
-        {
-            foreach (var key in map.Keys)
-            {
-                if (seen.Add(key))
-                {
-                    columnNames.Add(key);
-                }
-            }
-        }
-
-        if (columnNames.Count == 0)
-        {
-            return Array.Empty<object>();
-        }
-
-        var transposed = new object[columnNames.Count];
-        for (var columnIndex = 0; columnIndex < columnNames.Count; columnIndex++)
-        {
-            var propertyName = columnNames[columnIndex];
-            var transposedRow = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
-            {
-                ["Property"] = propertyName
-            };
-
-            for (var rowIndex = 0; rowIndex < maps.Count; rowIndex++)
-            {
-                var header = $"Row{rowIndex + 1}";
-                transposedRow[header] = maps[rowIndex].TryGetValue(propertyName, out var value)
-                    ? value
-                    : null;
-            }
-
-            transposed[columnIndex] = transposedRow;
-        }
-
-        return transposed;
-    }
-
-    private static Dictionary<string, object?> BuildPropertyMap(object row)
-    {
-        var normalized = PowerShellObjectNormalizer.NormalizeItem(row);
-        if (normalized is IDictionary dictionary)
-        {
-            var mapped = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-            foreach (DictionaryEntry entry in dictionary)
-            {
-                var key = entry.Key?.ToString();
-                if (string.IsNullOrWhiteSpace(key))
-                {
-                    continue;
-                }
-
-                var propertyName = key!;
-                if (mapped.ContainsKey(propertyName))
-                {
-                    continue;
-                }
-
-                mapped[propertyName] = entry.Value;
-            }
-
-            if (mapped.Count > 0)
-            {
-                return mapped;
-            }
-        }
-
-        return new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["Value"] = normalized
-        };
     }
 
     private void ApplyConditions(WordTable table, IReadOnlyList<object> rows, IReadOnlyList<WordTableConditionModel> conditions, bool skipHeader)

--- a/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCommand.cs
@@ -47,6 +47,10 @@ public sealed class AddOfficeWordTableCommand : PSCmdlet
     [Parameter]
     public OfficeTableView View { get; set; } = OfficeTableView.Normal;
 
+    /// <summary>Legacy switch that maps to <see cref="OfficeTableView.Transpose"/>.</summary>
+    [Parameter]
+    public SwitchParameter Transpose { get; set; }
+
     /// <summary>DSL content executed inside the table.</summary>
     [Parameter(Position = 1)]
     public ScriptBlock? Content { get; set; }
@@ -76,7 +80,8 @@ public sealed class AddOfficeWordTableCommand : PSCmdlet
         }
 
         var context = WordDslContext.Require(this);
-        var tableRows = TableViewProjection.Project(rows, View);
+        var effectiveView = Transpose.IsPresent ? OfficeTableView.Transpose : View;
+        var tableRows = TableViewProjection.Project(rows, effectiveView);
         var normalizedRows = PowerShellObjectNormalizer.NormalizeItems(tableRows);
         var legacyLayout = ResolveLegacyLayout(Layout);
         var table = CreateTable(context, normalizedRows, Style, includeHeader: !NoHeader.IsPresent, layout: legacyLayout);

--- a/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCommand.cs
@@ -28,6 +28,7 @@ public sealed class AddOfficeWordTableCommand : PSCmdlet
 
     /// <summary>Input data (array, list, DataTable, etc.).</summary>
     [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
+    [Alias("Data")]
     public object? InputObject { get; set; }
 
     /// <summary>Built-in table style.</summary>
@@ -41,6 +42,7 @@ public sealed class AddOfficeWordTableCommand : PSCmdlet
 
     /// <summary>Skip writing header row.</summary>
     [Parameter]
+    [Alias("SkipHeader")]
     public SwitchParameter NoHeader { get; set; }
 
     /// <summary>Projection to apply before writing the table.</summary>

--- a/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordMarkdownCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordMarkdownCommand.cs
@@ -24,6 +24,12 @@ namespace PSWriteOffice.Cmdlets.Word;
 ///   <code>Get-OfficeMarkdown -Path .\README.md | ConvertFrom-OfficeWordMarkdown</code>
 ///   <para>Returns a Word document instance for further edits.</para>
 /// </example>
+/// <example>
+///   <summary>Insert Markdown into a Word template bookmark.</summary>
+///   <prefix>PS&gt; </prefix>
+///   <code>ConvertFrom-OfficeWordMarkdown -Path .\SOP.md -TemplatePath .\Template.docx -BookmarkName MainContent -OutputPath .\SOP.docx</code>
+///   <para>Copies the template and replaces the bookmark paragraph with generated Markdown content.</para>
+/// </example>
 [Cmdlet(VerbsData.ConvertFrom, "OfficeWordMarkdown", DefaultParameterSetName = ParameterSetMarkdown)]
 [Alias("ConvertFrom-WordMarkdown")]
 [OutputType(typeof(WordDocument), typeof(FileInfo))]
@@ -50,6 +56,31 @@ public sealed class ConvertFromOfficeWordMarkdownCommand : PSCmdlet
     [Parameter]
     [Alias("OutPath")]
     public string? OutputPath { get; set; }
+
+    /// <summary>Optional Word template document to copy before inserting Markdown content.</summary>
+    [Parameter]
+    [Alias("Template")]
+    public string? TemplatePath { get; set; }
+
+    /// <summary>Bookmark name that marks where Markdown content should be inserted in the template.</summary>
+    [Parameter]
+    public string? BookmarkName { get; set; }
+
+    /// <summary>Block content control tag that marks where Markdown content should be inserted in the template.</summary>
+    [Parameter]
+    public string? ContentControlTag { get; set; }
+
+    /// <summary>Block content control alias that marks where Markdown content should be inserted in the template.</summary>
+    [Parameter]
+    public string? ContentControlAlias { get; set; }
+
+    /// <summary>Keep the target bookmark or content-control placeholder after inserting Markdown content.</summary>
+    [Parameter]
+    public SwitchParameter KeepPlaceholder { get; set; }
+
+    /// <summary>Render YAML front matter as visible Word content. Template conversions hide front matter by default.</summary>
+    [Parameter]
+    public SwitchParameter RenderFrontMatter { get; set; }
 
     /// <summary>Optional font family applied during conversion.</summary>
     [Parameter]
@@ -116,6 +147,7 @@ public sealed class ConvertFromOfficeWordMarkdownCommand : PSCmdlet
                 throw new ArgumentException("Use either -FitImagesToPageContentWidth or -FitImagesToContextWidth, not both.");
             }
 
+            ValidateTemplateParameters();
             var options = BuildOptions();
 
             switch (ParameterSetName)
@@ -133,11 +165,19 @@ public sealed class ConvertFromOfficeWordMarkdownCommand : PSCmdlet
                         options.BaseUri = BuildDirectoryUri(Path.GetDirectoryName(resolvedPath) ?? Directory.GetCurrentDirectory());
                     }
 
-                    document = WordMarkdownConverterExtensions.LoadFromMarkdown(resolvedPath, options);
+                    if (options is MarkdownToWordTemplateOptions templateOptions)
+                    {
+                        var markdown = File.ReadAllText(resolvedPath);
+                        document = markdown.LoadFromMarkdownTemplate(ResolveTemplatePath(), templateOptions);
+                    }
+                    else
+                    {
+                        document = WordMarkdownConverterExtensions.LoadFromMarkdown(resolvedPath, options);
+                    }
                     break;
                 }
                 case ParameterSetDocument:
-                    document = WordMarkdownConverterExtensions.LoadFromMarkdown(Document.ToMarkdown(), options);
+                    document = ConvertMarkdownText(Document.ToMarkdown(), options);
                     break;
                 default:
                     if (string.IsNullOrWhiteSpace(Markdown))
@@ -145,7 +185,7 @@ public sealed class ConvertFromOfficeWordMarkdownCommand : PSCmdlet
                         throw new ArgumentException("Markdown content cannot be empty.", nameof(Markdown));
                     }
 
-                    document = Markdown.LoadFromMarkdown(options);
+                    document = ConvertMarkdownText(Markdown, options);
                     break;
             }
 
@@ -201,11 +241,22 @@ public sealed class ConvertFromOfficeWordMarkdownCommand : PSCmdlet
 
     private MarkdownToWordOptions BuildOptions()
     {
-        var options = new MarkdownToWordOptions
+        var options = CreateOptions();
+        options.AllowLocalImages = AllowLocalImages.IsPresent;
+        options.AllowRemoteImages = AllowRemoteImages.IsPresent;
+
+        if (RenderFrontMatter.IsPresent)
         {
-            AllowLocalImages = AllowLocalImages.IsPresent,
-            AllowRemoteImages = AllowRemoteImages.IsPresent
-        };
+            options.RenderFrontMatter = true;
+        }
+
+        if (options is MarkdownToWordTemplateOptions templateOptions)
+        {
+            templateOptions.BookmarkName = NormalizeOptionalText(BookmarkName);
+            templateOptions.ContentControlTag = NormalizeOptionalText(ContentControlTag);
+            templateOptions.ContentControlAlias = NormalizeOptionalText(ContentControlAlias);
+            templateOptions.ReplacePlaceholder = !KeepPlaceholder.IsPresent;
+        }
 
         if (!string.IsNullOrWhiteSpace(FontFamily))
         {
@@ -238,6 +289,54 @@ public sealed class ConvertFromOfficeWordMarkdownCommand : PSCmdlet
         }
 
         return options;
+    }
+
+    private MarkdownToWordOptions CreateOptions()
+    {
+        return string.IsNullOrWhiteSpace(TemplatePath)
+            ? new MarkdownToWordOptions()
+            : new MarkdownToWordTemplateOptions();
+    }
+
+    private WordDocument ConvertMarkdownText(string markdown, MarkdownToWordOptions options)
+    {
+        return options is MarkdownToWordTemplateOptions templateOptions
+            ? markdown.LoadFromMarkdownTemplate(ResolveTemplatePath(), templateOptions)
+            : markdown.LoadFromMarkdown(options);
+    }
+
+    private void ValidateTemplateParameters()
+    {
+        var hasTemplateTarget = !string.IsNullOrWhiteSpace(BookmarkName)
+            || !string.IsNullOrWhiteSpace(ContentControlTag)
+            || !string.IsNullOrWhiteSpace(ContentControlAlias)
+            || KeepPlaceholder.IsPresent;
+
+        if (hasTemplateTarget && string.IsNullOrWhiteSpace(TemplatePath))
+        {
+            throw new ArgumentException("Template insertion parameters require -TemplatePath.", nameof(TemplatePath));
+        }
+    }
+
+    private string ResolveTemplatePath()
+    {
+        if (string.IsNullOrWhiteSpace(TemplatePath))
+        {
+            throw new ArgumentException("Template path cannot be empty.", nameof(TemplatePath));
+        }
+
+        var resolvedPath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(TemplatePath);
+        if (!File.Exists(resolvedPath))
+        {
+            throw new FileNotFoundException($"Template file '{resolvedPath}' was not found.", resolvedPath);
+        }
+
+        return resolvedPath;
+    }
+
+    private static string? NormalizeOptionalText(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value;
     }
 
     private static void TrySetOptionProperty(object target, string propertyName, object? value)

--- a/Sources/PSWriteOffice/Cmdlets/Word/InvokeOfficeWordMailMergeCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/InvokeOfficeWordMailMergeCommand.cs
@@ -13,7 +13,7 @@ namespace PSWriteOffice.Cmdlets.Word;
 /// <example>
 ///   <summary>Replace merge fields from a hashtable.</summary>
 ///   <prefix>PS&gt; </prefix>
-///   <code>Invoke-OfficeWordMailMerge -Data @{ FirstName = 'John'; OrderId = 12345 }</code>
+///   <code>Invoke-OfficeWordMailMerge -InputObject @{ FirstName = 'John'; OrderId = 12345 }</code>
 ///   <para>Updates MERGEFIELD values in the active Word document.</para>
 /// </example>
 [Cmdlet(VerbsLifecycle.Invoke, "OfficeWordMailMerge")]
@@ -26,8 +26,7 @@ public sealed class InvokeOfficeWordMailMergeCommand : PSCmdlet
 
     /// <summary>Hashtable or object whose properties map to MERGEFIELD names.</summary>
     [Parameter(Mandatory = true, Position = 0)]
-    [Alias("Values")]
-    public object Data { get; set; } = null!;
+    public object InputObject { get; set; } = null!;
 
     /// <summary>Preserve field codes and only update displayed field text.</summary>
     [Parameter]
@@ -46,10 +45,10 @@ public sealed class InvokeOfficeWordMailMergeCommand : PSCmdlet
             throw new InvalidOperationException("Word document was not provided.");
         }
 
-        var values = NormalizeData(Data);
+        var values = NormalizeInputObject(InputObject);
         if (values.Count == 0)
         {
-            throw new PSArgumentException("Provide at least one mail-merge value.", nameof(Data));
+            throw new PSArgumentException("Provide at least one mail-merge value.", nameof(InputObject));
         }
 
         WordMailMerge.Execute(document, values, removeFields: !PreserveFields.IsPresent);
@@ -60,11 +59,11 @@ public sealed class InvokeOfficeWordMailMergeCommand : PSCmdlet
         }
     }
 
-    private static Dictionary<string, string> NormalizeData(object? value)
+    private static Dictionary<string, string> NormalizeInputObject(object? value)
     {
         if (value == null)
         {
-            throw new PSArgumentNullException(nameof(Data));
+            throw new PSArgumentNullException(nameof(InputObject));
         }
 
         if (value is IDictionary dictionary)
@@ -80,7 +79,7 @@ public sealed class InvokeOfficeWordMailMergeCommand : PSCmdlet
 
         if (properties.Count == 0)
         {
-            throw new PSArgumentException("Mail-merge data must be a hashtable or an object with readable properties.", nameof(Data));
+            throw new PSArgumentException("Mail-merge input must be a hashtable or an object with readable properties.", nameof(InputObject));
         }
 
         var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/Sources/PSWriteOffice/Cmdlets/Word/InvokeOfficeWordMailMergeCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/InvokeOfficeWordMailMergeCommand.cs
@@ -26,6 +26,7 @@ public sealed class InvokeOfficeWordMailMergeCommand : PSCmdlet
 
     /// <summary>Hashtable or object whose properties map to MERGEFIELD names.</summary>
     [Parameter(Mandatory = true, Position = 0)]
+    [Alias("Data", "Values")]
     public object InputObject { get; set; } = null!;
 
     /// <summary>Preserve field codes and only update displayed field text.</summary>

--- a/Sources/PSWriteOffice/PSWriteOffice.csproj
+++ b/Sources/PSWriteOffice/PSWriteOffice.csproj
@@ -10,6 +10,7 @@
         <Copyright>(c) 2011 - 2022 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -76,8 +77,8 @@
     </ItemGroup>
     <ItemGroup Condition="'$(UseOfficeIMOProjectReferences)' != 'true'">
         <PackageReference Include="OfficeIMO.Drawing" Version="1.0.14" />
-        <PackageReference Include="OfficeIMO.Word" Version="1.0.60" />
-        <PackageReference Include="OfficeIMO.Word.Markdown" Version="1.0.33" />
+        <PackageReference Include="OfficeIMO.Word" Version="1.0.61" />
+        <PackageReference Include="OfficeIMO.Word.Markdown" Version="1.0.36" />
         <PackageReference Include="OfficeIMO.Excel" Version="0.6.40" />
         <PackageReference Include="OfficeIMO.PowerPoint" Version="1.0.35" />
         <PackageReference Include="OfficeIMO.Markdown" Version="0.6.27" />
@@ -88,6 +89,6 @@
         <PackageReference Include="OfficeIMO.Markdown.Pdf" Version="1.0.0" />
         <PackageReference Include="OfficeIMO.PowerPoint.Pdf" Version="1.0.0" />
         <PackageReference Include="OfficeIMO.CSV" Version="0.1.39" />
-        <PackageReference Include="OfficeIMO.Word.Html" Version="1.0.33" />
+        <PackageReference Include="OfficeIMO.Word.Html" Version="1.0.34" />
     </ItemGroup>
 </Project>

--- a/Sources/PSWriteOffice/Services/Table/OfficeTableView.cs
+++ b/Sources/PSWriteOffice/Services/Table/OfficeTableView.cs
@@ -1,0 +1,13 @@
+namespace PSWriteOffice.Services.Table;
+
+/// <summary>
+/// Describes how tabular input should be projected before it is rendered.
+/// </summary>
+public enum OfficeTableView
+{
+    /// <summary>Keep input objects as rows and object properties as columns.</summary>
+    Normal,
+
+    /// <summary>Turn object properties into rows and input rows into columns.</summary>
+    Transpose
+}

--- a/Sources/PSWriteOffice/Services/Table/TableInputCollector.cs
+++ b/Sources/PSWriteOffice/Services/Table/TableInputCollector.cs
@@ -1,0 +1,67 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+
+namespace PSWriteOffice.Services.Table;
+
+internal static class TableInputCollector
+{
+    public static void AddInput(ICollection<object?> items, object? value, bool preserveTabularInput = false)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        if (ShouldExpand(value, preserveTabularInput))
+        {
+            foreach (var entry in (IEnumerable)value)
+            {
+                if (entry is not null)
+                {
+                    items.Add(entry);
+                }
+            }
+
+            return;
+        }
+
+        items.Add(value);
+    }
+
+    public static object[] RequireRows(IReadOnlyCollection<object?> items, string parameterName)
+    {
+        if (items.Count == 0)
+        {
+            throw new System.Management.Automation.PSArgumentException("Provide at least one data row.", parameterName);
+        }
+
+        var rows = new object[items.Count];
+        var index = 0;
+        foreach (var item in items)
+        {
+            if (item is not null)
+            {
+                rows[index++] = item;
+            }
+        }
+
+        if (index == rows.Length)
+        {
+            return rows;
+        }
+
+        System.Array.Resize(ref rows, index);
+        return rows;
+    }
+
+    private static bool ShouldExpand(object value, bool preserveTabularInput)
+    {
+        return value is IEnumerable
+            and not string
+            and not IDictionary
+            and not IDataReader
+            and not DataSet
+            && (!preserveTabularInput || value is not DataTable && value is not DataView);
+    }
+}

--- a/Sources/PSWriteOffice/Services/Table/TableViewProjection.cs
+++ b/Sources/PSWriteOffice/Services/Table/TableViewProjection.cs
@@ -32,8 +32,53 @@ internal static class TableViewProjection
         {
             DataTable table => table.Rows.Cast<DataRow>().Cast<object>().ToArray(),
             DataView view => view.Cast<DataRowView>().Cast<object>().ToArray(),
+            IDataReader reader => ReadDataReaderRows(reader),
             _ => rows
         };
+    }
+
+    private static IReadOnlyList<object> ReadDataReaderRows(IDataReader reader)
+    {
+        var rows = new List<object>();
+        var columnNames = ResolveDataReaderColumnNames(reader);
+        while (reader.Read())
+        {
+            var row = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+            for (var index = 0; index < reader.FieldCount; index++)
+            {
+                row[columnNames[index]] = reader.IsDBNull(index) ? null : reader.GetValue(index);
+            }
+
+            rows.Add(row);
+        }
+
+        return rows;
+    }
+
+    private static string[] ResolveDataReaderColumnNames(IDataReader reader)
+    {
+        var columnNames = new string[reader.FieldCount];
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var index = 0; index < reader.FieldCount; index++)
+        {
+            var columnName = reader.GetName(index);
+            if (string.IsNullOrWhiteSpace(columnName))
+            {
+                columnName = "Column" + (index + 1).ToString(CultureInfo.InvariantCulture);
+            }
+
+            var candidate = columnName;
+            var suffix = 2;
+            while (!seen.Add(candidate))
+            {
+                candidate = columnName + suffix.ToString(CultureInfo.InvariantCulture);
+                suffix++;
+            }
+
+            columnNames[index] = candidate;
+        }
+
+        return columnNames;
     }
 
     private static object[] TransposeRows(IReadOnlyList<object> rows)

--- a/Sources/PSWriteOffice/Services/Table/TableViewProjection.cs
+++ b/Sources/PSWriteOffice/Services/Table/TableViewProjection.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Globalization;
+using System.Linq;
+using System.Management.Automation;
+using PSWriteOffice.Services;
+
+namespace PSWriteOffice.Services.Table;
+
+internal static class TableViewProjection
+{
+    public static object[] Project(IReadOnlyList<object> rows, OfficeTableView view)
+    {
+        return view switch
+        {
+            OfficeTableView.Normal => rows.ToArray(),
+            OfficeTableView.Transpose => TransposeRows(ExpandSingleTabularInput(rows)),
+            _ => throw new PSArgumentException($"Unsupported table view '{view}'.", nameof(view))
+        };
+    }
+
+    private static IReadOnlyList<object> ExpandSingleTabularInput(IReadOnlyList<object> rows)
+    {
+        if (rows.Count != 1)
+        {
+            return rows;
+        }
+
+        return rows[0] switch
+        {
+            DataTable table => table.Rows.Cast<DataRow>().Cast<object>().ToArray(),
+            DataView view => view.Cast<DataRowView>().Cast<object>().ToArray(),
+            _ => rows
+        };
+    }
+
+    private static object[] TransposeRows(IReadOnlyList<object> rows)
+    {
+        var maps = rows.Select(BuildPropertyMap).ToList();
+        var columnNames = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var map in maps)
+        {
+            foreach (var key in map.Keys)
+            {
+                if (seen.Add(key))
+                {
+                    columnNames.Add(key);
+                }
+            }
+        }
+
+        if (columnNames.Count == 0)
+        {
+            return Array.Empty<object>();
+        }
+
+        var transposed = new object[columnNames.Count];
+        for (var columnIndex = 0; columnIndex < columnNames.Count; columnIndex++)
+        {
+            var propertyName = columnNames[columnIndex];
+            var transposedRow = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Property"] = propertyName
+            };
+
+            for (var rowIndex = 0; rowIndex < maps.Count; rowIndex++)
+            {
+                var header = "Row" + (rowIndex + 1).ToString(CultureInfo.InvariantCulture);
+                transposedRow[header] = maps[rowIndex].TryGetValue(propertyName, out var value)
+                    ? value
+                    : null;
+            }
+
+            transposed[columnIndex] = transposedRow;
+        }
+
+        return transposed;
+    }
+
+    private static Dictionary<string, object?> BuildPropertyMap(object row)
+    {
+        if (row is DataRow dataRow)
+        {
+            return BuildDataRowMap(dataRow);
+        }
+
+        if (row is DataRowView rowView)
+        {
+            return BuildDataRowMap(rowView.Row);
+        }
+
+        var normalized = PowerShellObjectNormalizer.NormalizeItem(row);
+        if (normalized is IDictionary dictionary)
+        {
+            var mapped = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+            foreach (DictionaryEntry entry in dictionary)
+            {
+                var key = Convert.ToString(entry.Key, CultureInfo.InvariantCulture);
+                if (string.IsNullOrWhiteSpace(key) || mapped.ContainsKey(key!))
+                {
+                    continue;
+                }
+
+                mapped[key!] = entry.Value;
+            }
+
+            if (mapped.Count > 0)
+            {
+                return mapped;
+            }
+        }
+
+        var psObject = PSObject.AsPSObject(normalized);
+        var properties = psObject.Properties
+            .Where(property => property.MemberType is PSMemberTypes.NoteProperty or PSMemberTypes.Property)
+            .Where(property => !string.IsNullOrWhiteSpace(property.Name))
+            .ToList();
+
+        if (properties.Count == 0)
+        {
+            return new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Value"] = normalized
+            };
+        }
+
+        var result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var property in properties)
+        {
+            if (!result.ContainsKey(property.Name))
+            {
+                result[property.Name] = property.Value;
+            }
+        }
+
+        return result;
+    }
+
+    private static Dictionary<string, object?> BuildDataRowMap(DataRow row)
+    {
+        var result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (DataColumn column in row.Table.Columns)
+        {
+            result[column.ColumnName] = row.IsNull(column) ? null : row[column];
+        }
+
+        return result;
+    }
+}

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -87,6 +87,30 @@ Describe 'Excel DSL surface' {
         $imported[1].Row2 | Should -Be 8774099
     }
 
+    It 'supports transposed Excel tables from IDataReader input' {
+        $path = Join-Path $TestDrive 'TransposedExcelReaderTable.xlsx'
+        $table = [System.Data.DataTable]::new('SqlRows')
+        [void] $table.Columns.Add('Name', [string])
+        [void] $table.Columns.Add('Value', [int])
+        [void] $table.Rows.Add('One', 1)
+        [void] $table.Rows.Add('Two', 2)
+        $reader = $table.CreateDataReader()
+
+        New-OfficeExcel -Path $path {
+            Add-OfficeExcelSheet -Name 'Data' -Content {
+                Add-OfficeExcelTable -InputObject $reader -View Transpose -TableName 'TransposedReader'
+            }
+        }
+
+        $imported = @(Import-OfficeExcel -Path $path -WorksheetName 'Data' -Range 'A1:C3')
+        $imported[0].Property | Should -Be 'Name'
+        $imported[0].Row1 | Should -Be 'One'
+        $imported[0].Row2 | Should -Be 'Two'
+        $imported[1].Property | Should -Be 'Value'
+        $imported[1].Row1 | Should -Be 1
+        $imported[1].Row2 | Should -Be 2
+    }
+
     It 'round-trips encrypted workbooks through lifecycle cmdlets' {
         if (-not (Test-OfficeLoadedMethod -TypeName 'OfficeIMO.Excel.ExcelDocument' -MethodName 'LoadEncrypted')) {
             (Get-Command New-OfficeExcel).Parameters.Keys | Should -Contain 'Password'
@@ -155,6 +179,35 @@ Describe 'Excel DSL surface' {
         }
 
         Test-Path $path | Should -BeTrue
+    }
+
+    It 'preserves legacy Excel table data parameter aliases' {
+        $path = Join-Path $TestDrive 'DslExcelTableDataAliases.xlsx'
+        $rows = @(
+            [PSCustomObject]@{ Item = 'Laptop'; Qty = 5 }
+            [PSCustomObject]@{ Item = 'Tablet'; Qty = 12 }
+        )
+
+        $table = [System.Data.DataTable]::new('Stock')
+        [void] $table.Columns.Add('Item', [string])
+        [void] $table.Columns.Add('Qty', [int])
+        [void] $table.Rows.Add('Dock', 3)
+
+        New-OfficeExcel -Path $path {
+            Add-OfficeExcelSheet -Name 'DataAlias' -Content {
+                ExcelTable -Data $rows -TableName 'RowsAlias'
+            }
+            Add-OfficeExcelSheet -Name 'DataTableAlias' -Content {
+                ExcelTable -DataTable $table -TableName 'TableAlias'
+            }
+        }
+
+        $rowsAlias = @(Import-OfficeExcel -Path $path -WorksheetName 'DataAlias' -Range 'A1:B3')
+        $tableAlias = @(Import-OfficeExcel -Path $path -WorksheetName 'DataTableAlias' -Range 'A1:B2')
+        $rowsAlias[0].Item | Should -Be 'Laptop'
+        $rowsAlias[1].Qty | Should -Be 12
+        $tableAlias[0].Item | Should -Be 'Dock'
+        $tableAlias[0].Qty | Should -Be 3
     }
 
     It 'writes a DataTable directly as an Excel table' {

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -1,4 +1,4 @@
-﻿BeforeAll {
+BeforeAll {
     $ModuleManifest = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
         $env:PSWRITEOFFICE_MODULE_MANIFEST
     } else {
@@ -51,7 +51,7 @@ Describe 'Excel DSL surface' {
             Add-OfficeExcelSheet -Name 'Data' -Content {
                 Set-OfficeExcelCell -Address 'A1' -Value 'Region'
                 Set-OfficeExcelCell -Address 'B1' -Value 'Revenue'
-                Add-OfficeExcelTable -Data $rows -TableName 'Sales'
+                Add-OfficeExcelTable -InputObject $rows -TableName 'Sales'
             }
         }
 
@@ -63,6 +63,28 @@ Describe 'Excel DSL surface' {
         } finally {
             Close-OfficeExcel -Document $doc
         }
+    }
+
+    It 'supports transposed Excel tables' {
+        $path = Join-Path $TestDrive 'TransposedExcelTable.xlsx'
+        $rows = @(
+            [PSCustomObject]@{ Region = 'Europe'; Revenue = 21704714 }
+            [PSCustomObject]@{ Region = 'Asia'; Revenue = 8774099 }
+        )
+
+        New-OfficeExcel -Path $path {
+            Add-OfficeExcelSheet -Name 'Data' -Content {
+                Add-OfficeExcelTable -InputObject $rows -View Transpose -TableName 'TransposedSales'
+            }
+        }
+
+        $imported = @(Import-OfficeExcel -Path $path -WorksheetName 'Data' -Range 'A1:C3')
+        $imported[0].Property | Should -Be 'Region'
+        $imported[0].Row1 | Should -Be 'Europe'
+        $imported[0].Row2 | Should -Be 'Asia'
+        $imported[1].Property | Should -Be 'Revenue'
+        $imported[1].Row1 | Should -Be 21704714
+        $imported[1].Row2 | Should -Be 8774099
     }
 
     It 'round-trips encrypted workbooks through lifecycle cmdlets' {
@@ -128,7 +150,7 @@ Describe 'Excel DSL surface' {
             Add-OfficeExcelSheet -Name 'Orders' -Content {
                 ExcelCell -Address 'A1' -Value 'Item'
                 ExcelCell -Address 'B1' -Value 'Qty'
-                ExcelTable -Data $rows -TableName 'OrdersTable'
+                ExcelTable -InputObject $rows -TableName 'OrdersTable'
             }
         }
 
@@ -145,7 +167,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Data' -Content {
-                Add-OfficeExcelTable -DataTable $table -TableName 'PeopleTable' -AutoFit
+                Add-OfficeExcelTable -InputObject $table -TableName 'PeopleTable' -AutoFit
             }
         }
 
@@ -679,7 +701,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Data' -Content {
-                Add-OfficeExcelTable -Data $table -TableName 'Items' -AutoFit
+                Add-OfficeExcelTable -InputObject $table -TableName 'Items' -AutoFit
             }
         }
 
@@ -697,10 +719,10 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'First' -Content {
-                Add-OfficeExcelTable -Data $rows
+                Add-OfficeExcelTable -InputObject $rows
             }
             Add-OfficeExcelSheet -Name 'Second' -Content {
-                Add-OfficeExcelTable -Data $rows
+                Add-OfficeExcelTable -InputObject $rows
             }
         }
 
@@ -737,7 +759,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Data' -Content {
-                Add-OfficeExcelTable -Data $rows -TableName 'Items' -AutoFit
+                Add-OfficeExcelTable -InputObject $rows -TableName 'Items' -AutoFit
                 Add-OfficeExcelValidationList -Range 'C2:C3' -Values 'New','In Progress','Done'
                 Invoke-OfficeExcelAutoFit -Columns
             }
@@ -759,7 +781,7 @@ Describe 'Excel DSL surface' {
                 Set-OfficeExcelColumn -Column 1 -StartRow 2 -Values 'Alpha', 'Beta'
                 Set-OfficeExcelColumn -Column 2 -StartRow 2 -Values 10, 20
                 Set-OfficeExcelNamedRange -Name 'ManualRange' -Range 'A1:B3'
-                Add-OfficeExcelTable -Data $rows -TableName 'Sales' -StartRow 5
+                Add-OfficeExcelTable -InputObject $rows -TableName 'Sales' -StartRow 5
             }
         } | Out-Null
 
@@ -878,7 +900,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Data' -Content {
-                Add-OfficeExcelTable -Data $rows -TableName 'Sales' -AutoFit
+                Add-OfficeExcelTable -InputObject $rows -TableName 'Sales' -AutoFit
                 Add-OfficeExcelAutoFilter -Range 'A1:F4'
                 Invoke-OfficeExcelSort -Header 'Region'
                 Set-OfficeExcelFreeze -TopRows 1
@@ -942,7 +964,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Data' -Content {
-                Add-OfficeExcelTable -Data $rows -TableName 'Sales' -AutoFit
+                Add-OfficeExcelTable -InputObject $rows -TableName 'Sales' -AutoFit
                 Add-OfficeExcelPivotTable -SourceRange 'A1:F4' -DestinationCell 'J1' -RowField 'Region' -DataField 'Sales' -DataDisplayName 'Total Sales'
                 Add-OfficeExcelValidationWholeNumber -Range 'B2:B4' -Operator Between -Formula1 1 -Formula2 1000 -AllowBlank:$false
                 Add-OfficeExcelValidationDecimal -Range 'C2:C4' -Operator Between -Formula1 0.0 -Formula2 1.0
@@ -988,7 +1010,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Data' -Content {
-                Add-OfficeExcelTable -Data $rows -TableName 'Sales'
+                Add-OfficeExcelTable -InputObject $rows -TableName 'Sales'
                 Add-OfficeExcelPivotTable -SourceRange 'A1:C4' -DestinationCell 'E1' -RowField 'Region' -PageField 'Product' -DataField 'Sales' -DataNumberFormat '#,##0' -GrandTotalCaption 'Overall' -FieldSort @{ Region = 'Ascending' } -FieldHiddenItems @{ Region = @('APAC') } -PageFieldSelection @{ Product = 'Standard' }
             }
         }
@@ -1006,7 +1028,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Data' -Content {
-                Add-OfficeExcelTable -Data $rows -TableName 'Sales' -AutoFit
+                Add-OfficeExcelTable -InputObject $rows -TableName 'Sales' -AutoFit
                 Set-OfficeExcelPageSetup -FitToWidth 1 -FitToHeight 0
                 Set-OfficeExcelMargins -Preset Narrow
                 Set-OfficeExcelOrientation -Orientation Landscape
@@ -1053,10 +1075,10 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Data' -Content {
-                Add-OfficeExcelTable -Data $rows -TableName 'Sales'
+                Add-OfficeExcelTable -InputObject $rows -TableName 'Sales'
             }
             Add-OfficeExcelSheet -Name 'More' -Content {
-                Add-OfficeExcelTable -Data $moreRows -TableName 'MoreSales'
+                Add-OfficeExcelTable -InputObject $moreRows -TableName 'MoreSales'
             }
         }
         New-OfficeExcel -Path $sourcePath {
@@ -1105,7 +1127,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Data' -Content {
-                Add-OfficeExcelTable -Data $rows -TableName 'People'
+                Add-OfficeExcelTable -InputObject $rows -TableName 'People'
             }
         }
 
@@ -1132,7 +1154,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Data' -Content {
-                Add-OfficeExcelTable -Data $rows -TableName 'Sales'
+                Add-OfficeExcelTable -InputObject $rows -TableName 'Sales'
             }
         }
 
@@ -1179,7 +1201,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Data' -Content {
-                Add-OfficeExcelTable -Data $rows -TableName 'Sales' -AutoFit
+                Add-OfficeExcelTable -InputObject $rows -TableName 'Sales' -AutoFit
                 Set-OfficeExcelNamedRange -Name 'SalesData' -Range 'A1:B3'
             }
             Add-OfficeExcelSheet -Name 'Notes' -Content {
@@ -1365,7 +1387,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Data' -Content {
-                Add-OfficeExcelTable -Data $rows -TableName 'Sales' -AutoFit
+                Add-OfficeExcelTable -InputObject $rows -TableName 'Sales' -AutoFit
                 $chart = Add-OfficeExcelChart -TableName 'Sales' -Row 6 -Column 1 -Type Pie -Title 'Revenue Mix' -PassThru
                 $formattedChart = $chart |
                     Set-OfficeExcelChartLegend -Position Right |
@@ -1406,7 +1428,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Data' -Content {
-                Add-OfficeExcelTable -Data $rows -TableName 'Sales' -AutoFit
+                Add-OfficeExcelTable -InputObject $rows -TableName 'Sales' -AutoFit
                 $chart = Add-OfficeExcelChart -TableName 'Sales' -Row 6 -Column 1 -Type Line -Title 'Revenue Trend' -PassThru
                 { $chart | Set-OfficeExcelChartSeries -SeriesIndex 0 -LineWidthPoints 1.5 -ErrorAction Stop } |
                     Should -Throw '*LineColor is required*'
@@ -1491,7 +1513,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Summary' -Content {
-                Add-OfficeExcelTable -Data $rows -TableName 'SummaryTable' -AutoFit
+                Add-OfficeExcelTable -InputObject $rows -TableName 'SummaryTable' -AutoFit
                 Set-OfficeExcelCell -Address 'D1' -Value 'Sheet'
                 Set-OfficeExcelCell -Address 'D2' -Value 'Alpha'
                 Set-OfficeExcelCell -Address 'D3' -Value 'Beta'
@@ -1539,7 +1561,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Summary' -Content {
-                Add-OfficeExcelTable -Data $rows -TableName 'LinksTable' -AutoFit
+                Add-OfficeExcelTable -InputObject $rows -TableName 'LinksTable' -AutoFit
                 Set-OfficeExcelCell -Address 'D1' -Value 'Spec'
                 Set-OfficeExcelCell -Address 'D2' -Value 'rfc5321'
                 Set-OfficeExcelCell -Address 'D3' -Value 'rfc1035'
@@ -1582,7 +1604,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Data' -Content {
-                Add-OfficeExcelTable -Data $rows -TableName 'ReportRows'
+                Add-OfficeExcelTable -InputObject $rows -TableName 'ReportRows'
                 Set-OfficeExcelColumnStyleByHeader -Header Revenue -Style Currency -CultureName en-US -AutoFit
                 Set-OfficeExcelColumnStyleByHeader -Header Rate -Style Percent -Decimals 1
                 Set-OfficeExcelColumnStyleByHeader -Header Status -BackgroundByText @{ Ready = '#D4EDDA'; Blocked = '#F8D7DA' } -BoldByText Blocked
@@ -1611,7 +1633,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelSheet -Name 'Data' -Content {
-                Add-OfficeExcelTable -Data $rows -TableName 'ReportRows'
+                Add-OfficeExcelTable -InputObject $rows -TableName 'ReportRows'
                 Set-OfficeExcelColumnStyleByHeader -Header Status -BackgroundByText $statusColors -CaseSensitive
             }
         }
@@ -1635,10 +1657,10 @@ Describe 'Excel DSL surface' {
         New-OfficeExcel -Path $path {
             Add-OfficeExcelReportSheet -Name 'Summary' {
                 Add-OfficeExcelReportTitle -Title 'Operational Summary' -Subtitle 'Current view'
-                Add-OfficeExcelReportKpiRow -Data ([ordered] @{ Ready = 1; Blocked = 1 }) -PerRow 2
+                Add-OfficeExcelReportKpiRow -InputObject ([ordered] @{ Ready = 1; Blocked = 1 }) -PerRow 2
                 Add-OfficeExcelReportCallout -Kind Warning -Title 'Attention' -Body 'One item needs review.'
-                Add-OfficeExcelReportTable -Data $rows -Title 'Rows'
-                Add-OfficeExcelReportLegend -Title 'Legend' -Headers 'Status','Meaning' -Rows @(
+                Add-OfficeExcelReportTable -InputObject $rows -Title 'Rows'
+                Add-OfficeExcelReportLegend -Title 'Legend' -Header 'Status','Meaning' -InputObject @(
                     @('Ready', 'No action'),
                     @('Blocked', 'Needs owner')
                 ) -FirstColumnFillByValue @{ Ready = '#D4EDDA'; Blocked = '#F8D7DA' }
@@ -1675,7 +1697,7 @@ Describe 'Excel DSL surface' {
 
         New-OfficeExcel -Path $path {
             Add-OfficeExcelReportSheet -Name 'Legend' {
-                Add-OfficeExcelReportLegend -Headers 'Status','Meaning' -Rows @(
+                Add-OfficeExcelReportLegend -Header 'Status','Meaning' -InputObject @(
                     @('Ready', 'Upper'),
                     @('ready', 'Lower')
                 ) -FirstColumnFillByValue $statusColors -CaseSensitive

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -1710,10 +1710,10 @@ Describe 'Excel DSL surface' {
         New-OfficeExcel -Path $path {
             Add-OfficeExcelReportSheet -Name 'Summary' {
                 Add-OfficeExcelReportTitle -Title 'Operational Summary' -Subtitle 'Current view'
-                Add-OfficeExcelReportKpiRow -InputObject ([ordered] @{ Ready = 1; Blocked = 1 }) -PerRow 2
+                Add-OfficeExcelReportKpiRow -Data ([ordered] @{ Ready = 1; Blocked = 1 }) -PerRow 2
                 Add-OfficeExcelReportCallout -Kind Warning -Title 'Attention' -Body 'One item needs review.'
-                Add-OfficeExcelReportTable -InputObject $rows -Title 'Rows'
-                Add-OfficeExcelReportLegend -Title 'Legend' -Header 'Status','Meaning' -InputObject @(
+                Add-OfficeExcelReportTable -Data $rows -Title 'Rows'
+                Add-OfficeExcelReportLegend -Title 'Legend' -Headers 'Status','Meaning' -Rows @(
                     @('Ready', 'No action'),
                     @('Blocked', 'Needs owner')
                 ) -FirstColumnFillByValue @{ Ready = '#D4EDDA'; Blocked = '#F8D7DA' }

--- a/Tests/Markdown.Tests.ps1
+++ b/Tests/Markdown.Tests.ps1
@@ -223,7 +223,7 @@ Describe 'Markdown cmdlets' {
         $path = Join-Path $TestDrive 'MarkdownAdvancedDsl.md'
 
         New-OfficeMarkdown -Path $path {
-            MarkdownFrontMatter -InputObject @{
+            MarkdownFrontMatter -Data @{
                 title = 'Operations Report'
                 tags  = @('ops', 'weekly')
             }

--- a/Tests/Markdown.Tests.ps1
+++ b/Tests/Markdown.Tests.ps1
@@ -1,4 +1,4 @@
-﻿BeforeAll {
+BeforeAll {
     $ModuleManifest = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
         $env:PSWRITEOFFICE_MODULE_MANIFEST
     } else {
@@ -141,6 +141,40 @@ Describe 'Markdown cmdlets' {
         $content | Should -Match 'Value'
     }
 
+    It 'supports transposed Markdown tables' {
+        $path = Join-Path $TestDrive 'MarkdownTransposedTable.md'
+        $rows = @(
+            [pscustomobject]@{ Name = 'Alpha'; Value = 1 }
+            [pscustomobject]@{ Name = 'Beta'; Value = 2 }
+        )
+
+        New-OfficeMarkdown -Path $path {
+            MarkdownTable -InputObject $rows -View Transpose
+        } | Out-Null
+
+        $content = Get-Content -Path $path -Raw
+        $content | Should -Match 'Property'
+        $content | Should -Match 'Row1'
+        $content | Should -Match 'Row2'
+        $content | Should -Match 'Alpha'
+        $content | Should -Match 'Beta'
+    }
+
+    It 'adds Markdown tables to piped document objects' {
+        $doc = Get-OfficeMarkdown -Text '# Seed'
+        $rows = @(
+            [pscustomobject]@{ Name = 'Alpha'; Value = 1 }
+            [pscustomobject]@{ Name = 'Beta'; Value = 2 }
+        )
+
+        $updated = $doc | MarkdownTable -InputObject $rows -PassThru
+        $markdown = $updated.ToMarkdown()
+
+        $updated | Should -Be $doc
+        $markdown | Should -Match 'Name'
+        $markdown | Should -Match 'Alpha'
+    }
+
     It 'does not save Markdown or PDF sidecars when NoSave is used' {
         $path = Join-Path $TestDrive 'NoSave.md'
         $pdfPath = Join-Path $TestDrive 'NoSave.pdf'
@@ -157,7 +191,7 @@ Describe 'Markdown cmdlets' {
         $path = Join-Path $TestDrive 'MarkdownAdvancedDsl.md'
 
         New-OfficeMarkdown -Path $path {
-            MarkdownFrontMatter -Data @{
+            MarkdownFrontMatter -InputObject @{
                 title = 'Operations Report'
                 tags  = @('ops', 'weekly')
             }
@@ -189,7 +223,7 @@ Describe 'Markdown cmdlets' {
         $doc = Get-OfficeMarkdown -Text '# Seed'
 
         $doc |
-            Add-OfficeMarkdownFrontMatter -Data @{ title = 'Doc pipeline' } -PassThru |
+            Add-OfficeMarkdownFrontMatter -InputObject @{ title = 'Doc pipeline' } -PassThru |
             Add-OfficeMarkdownHeading -Level 1 -Text 'Doc pipeline' -PassThru |
             Add-OfficeMarkdownTaskList -Items 'Alpha', 'Beta' -Completed 0 -PassThru |
             Add-OfficeMarkdownDefinitionList -Definition @{ API = 'Application programming interface' } -PassThru |

--- a/Tests/Markdown.Tests.ps1
+++ b/Tests/Markdown.Tests.ps1
@@ -175,6 +175,38 @@ Describe 'Markdown cmdlets' {
         $markdown | Should -Match 'Alpha'
     }
 
+    It 'adds piped Markdown table rows to a supplied document' {
+        $doc = Get-OfficeMarkdown -Text '# Seed'
+        $rows = @(
+            [pscustomobject]@{ Name = 'Alpha'; Value = 1 }
+            [pscustomobject]@{ Name = 'Beta'; Value = 2 }
+        )
+
+        $updated = $rows | MarkdownTable -Document $doc -PassThru
+        $markdown = $updated.ToMarkdown()
+
+        $updated | Should -Be $doc
+        $markdown | Should -Match 'Alpha'
+        $markdown | Should -Match 'Beta'
+    }
+
+    It 'adds explicit Markdown table rows to each piped document' {
+        $doc1 = Get-OfficeMarkdown -Text '# First'
+        $doc2 = Get-OfficeMarkdown -Text '# Second'
+        $rows = @(
+            [pscustomobject]@{ Name = 'Alpha'; Value = 1 }
+            [pscustomobject]@{ Name = 'Beta'; Value = 2 }
+        )
+
+        $updated = @($doc1, $doc2) | MarkdownTable -InputObject $rows -PassThru
+
+        $updated.Count | Should -Be 2
+        $updated[0] | Should -Be $doc1
+        $updated[1] | Should -Be $doc2
+        ($doc1.ToMarkdown() | Select-String -Pattern 'Alpha' -AllMatches).Matches.Count | Should -Be 1
+        ($doc2.ToMarkdown() | Select-String -Pattern 'Alpha' -AllMatches).Matches.Count | Should -Be 1
+    }
+
     It 'does not save Markdown or PDF sidecars when NoSave is used' {
         $path = Join-Path $TestDrive 'NoSave.md'
         $pdfPath = Join-Path $TestDrive 'NoSave.pdf'

--- a/Tests/Pdf.Tests.ps1
+++ b/Tests/Pdf.Tests.ps1
@@ -96,6 +96,24 @@ Describe 'PDF cmdlets' {
         $text | Should -Match 'Beta'
     }
 
+    It 'supports transposed table views' {
+        $path = Join-Path $TestDrive 'transposed-table.pdf'
+        $rows = @(
+            [pscustomobject]@{ Name = 'Alpha'; Value = 1 }
+            [pscustomobject]@{ Name = 'Beta'; Value = 2 }
+        )
+
+        New-OfficePdf -Path $path {
+            PdfTable -InputObject $rows -View Transpose
+        } | Out-Null
+
+        $text = Get-OfficePdfText -Path $path
+        $text | Should -Match 'Property'
+        $text | Should -Match 'Row1'
+        $text | Should -Match 'Alpha'
+        $text | Should -Match 'Beta'
+    }
+
     It 'keeps the current page size when only margins are updated' {
         $path = Join-Path $TestDrive 'page-size-margin.pdf'
 

--- a/Tests/Pdf.Tests.ps1
+++ b/Tests/Pdf.Tests.ps1
@@ -114,6 +114,50 @@ Describe 'PDF cmdlets' {
         $text | Should -Match 'Beta'
     }
 
+    It 'adds piped PDF table rows to a supplied document' {
+        $path = Join-Path $TestDrive 'piped-rows-supplied-document.pdf'
+        $doc = New-OfficePdf {
+            PdfHeading 'Pipeline rows'
+        }
+        $rows = @(
+            [pscustomobject]@{ Name = 'Alpha'; Value = 1 }
+            [pscustomobject]@{ Name = 'Beta'; Value = 2 }
+        )
+
+        $updated = $rows | PdfTable -Document $doc -PassThru
+        $updated | Save-OfficePdf -Path $path | Out-Null
+
+        $updated | Should -Be $doc
+        $text = Get-OfficePdfText -Path $path
+        $text | Should -Match 'Alpha'
+        $text | Should -Match 'Beta'
+    }
+
+    It 'adds explicit PDF table rows to each piped document' {
+        $path1 = Join-Path $TestDrive 'piped-document-one.pdf'
+        $path2 = Join-Path $TestDrive 'piped-document-two.pdf'
+        $doc1 = New-OfficePdf {
+            PdfHeading 'First document'
+        }
+        $doc2 = New-OfficePdf {
+            PdfHeading 'Second document'
+        }
+        $rows = @(
+            [pscustomobject]@{ Name = 'Alpha'; Value = 1 }
+            [pscustomobject]@{ Name = 'Beta'; Value = 2 }
+        )
+
+        $updated = @($doc1, $doc2) | PdfTable -InputObject $rows -PassThru
+        $updated[0] | Save-OfficePdf -Path $path1 | Out-Null
+        $updated[1] | Save-OfficePdf -Path $path2 | Out-Null
+
+        $updated.Count | Should -Be 2
+        $updated[0] | Should -Be $doc1
+        $updated[1] | Should -Be $doc2
+        (Get-OfficePdfText -Path $path1) | Should -Match 'Alpha'
+        (Get-OfficePdfText -Path $path2) | Should -Match 'Alpha'
+    }
+
     It 'keeps the current page size when only margins are updated' {
         $path = Join-Path $TestDrive 'page-size-margin.pdf'
 

--- a/Tests/PowerPoint.Tests.ps1
+++ b/Tests/PowerPoint.Tests.ps1
@@ -201,6 +201,26 @@ Describe 'PowerPoint cmdlets' {
         }
     }
 
+    It 'preserves the legacy PowerPoint table headers alias' {
+        $path = Join-Path $TestDrive 'PowerPointHeadersAlias.pptx'
+        $presentation = New-OfficePowerPoint -FilePath $path
+        try {
+            $slide = Add-OfficePowerPointSlide -Presentation $presentation -Layout 1
+            $rows = @(
+                [PSCustomObject]@{ Item = 'Alpha'; Qty = 10 }
+                [PSCustomObject]@{ Item = 'Beta'; Qty = 20 }
+            )
+
+            Add-OfficePowerPointTable -Slide $slide -InputObject $rows -Headers Qty, Item -X 40 -Y 120 -Width 420 -Height 160 | Out-Null
+
+            $shapeInfo = @(Get-OfficePowerPointShape -Slide $slide | Where-Object Kind -eq 'Table')[0]
+            $shapeInfo.RowCount | Should -Be 3
+            $shapeInfo.ColumnCount | Should -Be 2
+        } finally {
+            Close-OfficePowerPoint -Presentation $presentation
+        }
+    }
+
     It 'reads notes without creating empty notes parts' {
         $path = Join-Path $TestDrive 'PowerPointNotesRead.pptx'
         $presentation = New-OfficePowerPoint -FilePath $path

--- a/Tests/PowerPoint.Tests.ps1
+++ b/Tests/PowerPoint.Tests.ps1
@@ -211,7 +211,7 @@ Describe 'PowerPoint cmdlets' {
                 [PSCustomObject]@{ Item = 'Beta'; Qty = 20 }
             )
 
-            Add-OfficePowerPointTable -Slide $slide -InputObject $rows -Headers Qty, Item -X 40 -Y 120 -Width 420 -Height 160 | Out-Null
+            Add-OfficePowerPointTable -Slide $slide -Data $rows -Headers Qty, Item -X 40 -Y 120 -Width 420 -Height 160 | Out-Null
 
             $shapeInfo = @(Get-OfficePowerPointShape -Slide $slide | Where-Object Kind -eq 'Table')[0]
             $shapeInfo.RowCount | Should -Be 3
@@ -806,7 +806,7 @@ Describe 'PowerPoint cmdlets' {
 
             $slide1 = Add-OfficePowerPointSlide -Presentation $presentation -Layout 1
             Set-OfficePowerPointSlideTitle -Slide $slide1 -Title 'Column Chart' | Out-Null
-            $columnChart = Add-OfficePowerPointChart -Slide $slide1 -InputObject $rows -CategoryProperty Month -SeriesProperty Sales, Profit -Title 'Sales vs Profit' -X 40 -Y 120 -Width 360 -Height 220
+            $columnChart = Add-OfficePowerPointChart -Slide $slide1 -Data $rows -CategoryProperty Month -SeriesProperty Sales, Profit -Title 'Sales vs Profit' -X 40 -Y 120 -Width 360 -Height 220
             $columnChart | Should -Not -BeNullOrEmpty
             @($slide1.Charts).Count | Should -Be 1
 
@@ -818,7 +818,7 @@ Describe 'PowerPoint cmdlets' {
 
             $slide3 = Add-OfficePowerPointSlide -Presentation $presentation -Layout 1
             Set-OfficePowerPointSlideTitle -Slide $slide3 -Title 'Scatter Chart' | Out-Null
-            $scatterChart = Add-OfficePowerPointChart -Slide $slide3 -Type Scatter -InputObject $rows -XProperty MonthNumber -YProperty Sales, Profit -Title 'Trend Scatter' -X 40 -Y 120 -Width 360 -Height 220
+            $scatterChart = Add-OfficePowerPointChart -Slide $slide3 -Type Scatter -Data $rows -XProperty MonthNumber -YProperty Sales, Profit -Title 'Trend Scatter' -X 40 -Y 120 -Width 360 -Height 220
             $scatterChart | Should -Not -BeNullOrEmpty
             @($slide3.Charts).Count | Should -Be 1
 

--- a/Tests/PowerPoint.Tests.ps1
+++ b/Tests/PowerPoint.Tests.ps1
@@ -101,7 +101,7 @@ Describe 'PowerPoint cmdlets' {
             [PSCustomObject]@{ Item = 'Alpha'; Qty = 10 }
             [PSCustomObject]@{ Item = 'Beta'; Qty = 20 }
         )
-        $table = Add-OfficePowerPointTable -Slide $slide -Data $rows -X 40 -Y 140 -Width 360 -Height 200
+        $table = Add-OfficePowerPointTable -Slide $slide -InputObject $rows -X 40 -Y 140 -Width 360 -Height 200
         $image = Add-OfficePowerPointImage -Slide $slide -Path $imagePath -X 420 -Y 40 -Width 120 -Height 90
         $bullets = Add-OfficePowerPointBullets -Slide $slide -Bullets 'Wins','Risks','Next Steps' -X 420 -Y 150 -Width 250 -Height 200
         Set-OfficePowerPointNotes -Slide $slide -Text 'Keep this under five minutes.'
@@ -178,6 +178,26 @@ Describe 'PowerPoint cmdlets' {
             if ($reloaded) {
                 $reloaded.Dispose()
             }
+        }
+    }
+
+    It 'supports transposed PowerPoint tables' {
+        $path = Join-Path $TestDrive 'PowerPointTransposedTable.pptx'
+        $presentation = New-OfficePowerPoint -FilePath $path
+        try {
+            $slide = Add-OfficePowerPointSlide -Presentation $presentation -Layout 1
+            $rows = @(
+                [PSCustomObject]@{ Region = 'Europe'; Revenue = 21704714 }
+                [PSCustomObject]@{ Region = 'Asia'; Revenue = 8774099 }
+            )
+
+            Add-OfficePowerPointTable -Slide $slide -InputObject $rows -View Transpose -X 40 -Y 120 -Width 420 -Height 160 | Out-Null
+
+            $shapeInfo = @(Get-OfficePowerPointShape -Slide $slide | Where-Object Kind -eq 'Table')[0]
+            $shapeInfo.RowCount | Should -Be 3
+            $shapeInfo.ColumnCount | Should -Be 3
+        } finally {
+            Close-OfficePowerPoint -Presentation $presentation
         }
     }
 
@@ -766,19 +786,19 @@ Describe 'PowerPoint cmdlets' {
 
             $slide1 = Add-OfficePowerPointSlide -Presentation $presentation -Layout 1
             Set-OfficePowerPointSlideTitle -Slide $slide1 -Title 'Column Chart' | Out-Null
-            $columnChart = Add-OfficePowerPointChart -Slide $slide1 -Data $rows -CategoryProperty Month -SeriesProperty Sales, Profit -Title 'Sales vs Profit' -X 40 -Y 120 -Width 360 -Height 220
+            $columnChart = Add-OfficePowerPointChart -Slide $slide1 -InputObject $rows -CategoryProperty Month -SeriesProperty Sales, Profit -Title 'Sales vs Profit' -X 40 -Y 120 -Width 360 -Height 220
             $columnChart | Should -Not -BeNullOrEmpty
             @($slide1.Charts).Count | Should -Be 1
 
             $slide2 = Add-OfficePowerPointSlide -Presentation $presentation -Layout 1
             Set-OfficePowerPointSlideTitle -Slide $slide2 -Title 'Pie Chart' | Out-Null
-            $pieChart = Add-OfficePowerPointChart -Slide $slide2 -Type Pie -Data $rows -CategoryProperty Month -SeriesProperty Sales -Title 'Sales Mix' -X 40 -Y 120 -Width 320 -Height 220
+            $pieChart = Add-OfficePowerPointChart -Slide $slide2 -Type Pie -InputObject $rows -CategoryProperty Month -SeriesProperty Sales -Title 'Sales Mix' -X 40 -Y 120 -Width 320 -Height 220
             $pieChart | Should -Not -BeNullOrEmpty
             @($slide2.Charts).Count | Should -Be 1
 
             $slide3 = Add-OfficePowerPointSlide -Presentation $presentation -Layout 1
             Set-OfficePowerPointSlideTitle -Slide $slide3 -Title 'Scatter Chart' | Out-Null
-            $scatterChart = Add-OfficePowerPointChart -Slide $slide3 -Type Scatter -Data $rows -XProperty MonthNumber -YProperty Sales, Profit -Title 'Trend Scatter' -X 40 -Y 120 -Width 360 -Height 220
+            $scatterChart = Add-OfficePowerPointChart -Slide $slide3 -Type Scatter -InputObject $rows -XProperty MonthNumber -YProperty Sales, Profit -Title 'Trend Scatter' -X 40 -Y 120 -Width 360 -Height 220
             $scatterChart | Should -Not -BeNullOrEmpty
             @($slide3.Charts).Count | Should -Be 1
 

--- a/Tests/WordDsl.Tests.ps1
+++ b/Tests/WordDsl.Tests.ps1
@@ -254,7 +254,7 @@ Describe 'Word DSL surface' {
 
         New-OfficeWord -Path $path {
             Add-OfficeWordParagraph -Text 'Revenue mix'
-            Add-OfficeWordChart -Type Pie -InputObject $rows -CategoryProperty Region -SeriesProperty Revenue -Title 'Regional Revenue Mix'
+            Add-OfficeWordChart -Type Pie -Data $rows -CategoryProperty Region -SeriesProperty Revenue -Title 'Regional Revenue Mix'
         } | Out-Null
 
         $document = Get-OfficeWord -Path $path -ReadOnly
@@ -303,16 +303,16 @@ Describe 'Word DSL surface' {
         )
 
         New-OfficeWord -Path $path {
-            Add-OfficeWordTable -InputObject $rows -Transpose -Style TableGrid
+            Add-OfficeWordTable -Data $rows -SkipHeader -Transpose -Style TableGrid
         } | Out-Null
 
         $document = Get-OfficeWord -Path $path -ReadOnly
         try {
             $table = $document.Tables[0]
-            $table.RowsCount | Should -Be 3
-            $table.Rows[1].Cells[0].Paragraphs[0].Text | Should -Be 'Name'
-            $table.Rows[1].Cells[1].Paragraphs[0].Text | Should -Be 'One'
-            $table.Rows[1].Cells[2].Paragraphs[0].Text | Should -Be 'Two'
+            $table.RowsCount | Should -Be 2
+            $table.Rows[0].Cells[0].Paragraphs[0].Text | Should -Be 'Name'
+            $table.Rows[0].Cells[1].Paragraphs[0].Text | Should -Be 'One'
+            $table.Rows[0].Cells[2].Paragraphs[0].Text | Should -Be 'Two'
         } finally {
             $document.Dispose()
         }

--- a/Tests/WordDsl.Tests.ps1
+++ b/Tests/WordDsl.Tests.ps1
@@ -94,7 +94,7 @@ Describe 'Word DSL surface' {
                     WordListItem 'One'
                     WordListItem 'Two'
                 }
-                WordTable -Data $rows -Style 'GridTable1LightAccent1' {
+                WordTable -InputObject $rows -Style 'GridTable1LightAccent1' {
                     WordTableCondition -FilterScript { $_.Qty -gt 2 } -BackgroundColor '#ffeeee'
                 }
             }
@@ -121,7 +121,7 @@ Describe 'Word DSL surface' {
         Copy-Item -LiteralPath $fixturePath -Destination $imagePath -Force
 
         New-OfficeWord -Path $path {
-            WordTable -Data $rows -Style 'GridTable1LightAccent1' {
+            WordTable -InputObject $rows -Style 'GridTable1LightAccent1' {
                 WordTableCell -Row 1 -Column 0 {
                     WordParagraph { WordText 'Checklist' }
                     WordImage -Path $imagePath -Width 24 -Height 24
@@ -132,7 +132,7 @@ Describe 'Word DSL surface' {
                 }
 
                 WordTableCell -Row 1 -Column 1 {
-                    WordTable -Data $nestedRows -SkipHeader -Style 'TableGrid' {
+                    WordTable -InputObject $nestedRows -NoHeader -Style 'TableGrid' {
                         WordTableCell -Row 0 -Column 0 {
                             WordParagraph { WordText 'Nested detail' }
                         }
@@ -254,7 +254,7 @@ Describe 'Word DSL surface' {
 
         New-OfficeWord -Path $path {
             Add-OfficeWordParagraph -Text 'Revenue mix'
-            Add-OfficeWordChart -Type Pie -Data $rows -CategoryProperty Region -SeriesProperty Revenue -Title 'Regional Revenue Mix'
+            Add-OfficeWordChart -Type Pie -InputObject $rows -CategoryProperty Region -SeriesProperty Revenue -Title 'Regional Revenue Mix'
         } | Out-Null
 
         $document = Get-OfficeWord -Path $path -ReadOnly
@@ -274,7 +274,7 @@ Describe 'Word DSL surface' {
         )
 
         New-OfficeWord -Path $path {
-            Add-OfficeWordTable -InputObject $rows -Transpose -Style TableGrid
+            Add-OfficeWordTable -InputObject $rows -View Transpose -Style TableGrid
         } | Out-Null
 
         $document = Get-OfficeWord -Path $path -ReadOnly
@@ -305,7 +305,7 @@ Describe 'Word DSL surface' {
 
         $document = New-OfficeWord -Path $path
         try {
-            $chart = Add-OfficeWordChart -Document $document -Type Line -Data $rows -CategoryProperty Month -SeriesProperty Sales, Profit -Legend -XAxisTitle 'Month' -YAxisTitle 'Value' -Title 'Monthly Trend' -PassThru
+            $chart = Add-OfficeWordChart -Document $document -Type Line -InputObject $rows -CategoryProperty Month -SeriesProperty Sales, Profit -Legend -XAxisTitle 'Month' -YAxisTitle 'Value' -Title 'Monthly Trend' -PassThru
             $chart.Title | Should -Be 'Monthly Trend'
             Save-OfficeWord -Document $document | Out-Null
         } finally {
@@ -397,7 +397,7 @@ Describe 'Word DSL surface' {
             $table = Add-OfficeWordTable -InputObject $tableRows -Style 'GridTable1LightAccent1' -PassThru
             $paragraph = $table.Rows[1].Cells[1].AddParagraph()
 
-            Add-OfficeWordChart -Paragraph $paragraph -Type Pie -Data $chartRows -CategoryProperty Region -SeriesProperty Revenue -Title 'Regional Revenue Mix'
+            Add-OfficeWordChart -Paragraph $paragraph -Type Pie -InputObject $chartRows -CategoryProperty Region -SeriesProperty Revenue -Title 'Regional Revenue Mix'
         } | Out-Null
 
         $document = Get-OfficeWord -Path $path -ReadOnly
@@ -561,7 +561,7 @@ Describe 'Word DSL surface' {
                 Add-OfficeWordText -Text ' is ready.'
             }
 
-            Invoke-OfficeWordMailMerge -Data @{
+            Invoke-OfficeWordMailMerge -InputObject @{
                 FirstName = 'Jane'
                 OrderId   = 77
             }
@@ -755,7 +755,7 @@ Describe 'Word DSL surface' {
         )
 
         New-OfficeWord -Path $path {
-            $table = WordTable -Data $rows -Style TableGrid -PassThru
+            $table = WordTable -InputObject $rows -Style TableGrid -PassThru
             $cell = $table |
                 Get-OfficeWordTableCell -Row 1 -Column 1 |
                 Set-OfficeWordTableCell -ShadingFillColor '#DDEEFF' -Width 2400 -WidthType Dxa -WrapText $false -FitText $true -PassThru

--- a/Tests/WordDsl.Tests.ps1
+++ b/Tests/WordDsl.Tests.ps1
@@ -295,6 +295,29 @@ Describe 'Word DSL surface' {
         }
     }
 
+    It 'preserves the legacy Word table transpose switch' {
+        $path = Join-Path $TestDrive 'DslTableLegacyTranspose.docx'
+        $rows = @(
+            [PSCustomObject]@{ Name = 'One'; Value = 1 }
+            [PSCustomObject]@{ Name = 'Two'; Value = 2 }
+        )
+
+        New-OfficeWord -Path $path {
+            Add-OfficeWordTable -InputObject $rows -Transpose -Style TableGrid
+        } | Out-Null
+
+        $document = Get-OfficeWord -Path $path -ReadOnly
+        try {
+            $table = $document.Tables[0]
+            $table.RowsCount | Should -Be 3
+            $table.Rows[1].Cells[0].Paragraphs[0].Text | Should -Be 'Name'
+            $table.Rows[1].Cells[1].Paragraphs[0].Text | Should -Be 'One'
+            $table.Rows[1].Cells[2].Paragraphs[0].Text | Should -Be 'Two'
+        } finally {
+            $document.Dispose()
+        }
+    }
+
     It 'adds Word line charts to an open document' {
         $path = Join-Path $TestDrive 'DslWordLineChart.docx'
         $rows = @(
@@ -561,7 +584,7 @@ Describe 'Word DSL surface' {
                 Add-OfficeWordText -Text ' is ready.'
             }
 
-            Invoke-OfficeWordMailMerge -InputObject @{
+            Invoke-OfficeWordMailMerge -Values @{
                 FirstName = 'Jane'
                 OrderId   = 77
             }
@@ -577,6 +600,22 @@ Describe 'Word DSL surface' {
 
         (Find-OfficeWord -Path $path -Text 'Jane').Count | Should -BeGreaterThan 0
         (Find-OfficeWord -Path $path -Text '77').Count | Should -BeGreaterThan 0
+    }
+
+    It 'preserves the legacy Word mail merge data alias' {
+        $path = Join-Path $TestDrive 'DslMailMergeDataAlias.docx'
+
+        New-OfficeWord -Path $path {
+            Add-OfficeWordParagraph {
+                Add-OfficeWordField -Type MergeField -Parameters '"FirstName"'
+            }
+
+            Invoke-OfficeWordMailMerge -Data @{
+                FirstName = 'Ada'
+            }
+        } | Out-Null
+
+        (Find-OfficeWord -Path $path -Text 'Ada').Count | Should -BeGreaterThan 0
     }
 
     It 'updates Word text and hyperlink metadata from a path' {

--- a/Tests/WordMarkdown.Tests.ps1
+++ b/Tests/WordMarkdown.Tests.ps1
@@ -46,4 +46,47 @@ Describe 'Word Markdown conversions' {
             $document.Dispose()
         }
     }
+
+    It 'inserts Markdown into a Word template bookmark' {
+        $templatePath = Join-Path $TestDrive 'Template.docx'
+        $docPath = Join-Path $TestDrive 'TemplateOutput.docx'
+
+        New-OfficeWord -Path $templatePath {
+            Add-OfficeWordParagraph -Text 'Before template content'
+            Add-OfficeWordParagraph {
+                Add-OfficeWordText -Text 'PLACEHOLDER'
+                Add-OfficeWordBookmark -Name 'MainContent'
+            }
+            Add-OfficeWordParagraph -Text 'After template content'
+        } | Out-Null
+
+        $markdown = @'
+---
+title: Hidden metadata
+---
+# Inserted heading
+
+Inserted body.
+'@
+
+        $file = ConvertFrom-OfficeWordMarkdown -Markdown $markdown -TemplatePath $templatePath -BookmarkName 'MainContent' -OutputPath $docPath -PassThru
+        $file | Should -BeOfType System.IO.FileInfo
+
+        $paragraphs = @(Get-OfficeWordParagraph -Path $docPath)
+        $texts = @($paragraphs.Text | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+
+        $texts | Should -Contain 'Before template content'
+        $texts | Should -Contain 'Inserted heading'
+        $texts | Should -Contain 'Inserted body.'
+        $texts | Should -Contain 'After template content'
+        $texts | Should -Not -Contain 'PLACEHOLDER'
+        ($texts -join "`n") | Should -Not -Match 'Hidden metadata'
+        [Array]::IndexOf($texts, 'Inserted heading') | Should -BeGreaterThan ([Array]::IndexOf($texts, 'Before template content'))
+        [Array]::IndexOf($texts, 'After template content') | Should -BeGreaterThan ([Array]::IndexOf($texts, 'Inserted body.'))
+    }
+
+    It 'rejects template insertion selectors without a template path' {
+        { ConvertFrom-OfficeWordMarkdown -Markdown '# Missing template' -BookmarkName 'MainContent' -ErrorAction Stop } |
+            Should -Throw '*Template insertion parameters require -TemplatePath*'
+    }
 }

--- a/Tests/WordReader.Tests.ps1
+++ b/Tests/WordReader.Tests.ps1
@@ -1,4 +1,4 @@
-﻿BeforeAll {
+BeforeAll {
     $ModuleManifest = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
         $env:PSWRITEOFFICE_MODULE_MANIFEST
     } else {
@@ -142,7 +142,7 @@ Describe 'Word reader helpers' {
                 Add-OfficeWordField -Type MergeField -Parameters '"FirstName"'
             }
 
-            Invoke-OfficeWordMailMerge -Data ([pscustomobject]@{
+            Invoke-OfficeWordMailMerge -InputObject ([pscustomobject]@{
                 FirstName = 'Morgan'
             }) -PreserveFields
         } | Out-Null


### PR DESCRIPTION
## Summary
- adds shared table input collection/projection helpers with `OfficeTableView` and transposed table support across Excel, Markdown, PDF, PowerPoint, and Word surfaces
- normalizes table/chart cmdlet API naming toward `-InputObject` and `-View`, with docs/tests updated for the 2.0 API cleanup
- extends `ConvertFrom-OfficeWordMarkdown` with Word template insertion parameters backed by OfficeIMO.Word.Markdown
- enables `TreatWarningsAsErrors` and updates OfficeIMO package refs to the published template-capable packages

## Validation
- `dotnet build .\Sources\PSWriteOffice.sln -c Debug /p:BuildInParallel=false /m:1 /nr:false` -> 0 warnings, 0 errors
- source-backed Pester: `Invoke-Pester -Path .\Tests -Output Detailed` with `PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES=true` -> 150 passed, 1 skipped
- `Build\Validate-PackagedArtefact.ps1` after clearing NuGet HTTP/cache entries -> package build/import passed using public OfficeIMO.Word 1.0.61 and OfficeIMO.Word.Markdown 1.0.36
- packaged smoke: `ConvertFrom-OfficeWordMarkdown -TemplatePath ... -BookmarkName MainContent` passed against installed PSWriteOffice 1.0.3.41
- `git diff --cached --check` passed

## Notes
- OfficeIMO.Word 1.0.61 and OfficeIMO.Word.Markdown 1.0.36 were published because the first Markdown-only package publish exposed a runtime dependency on the matching OfficeIMO.Word friend assembly.
- Companion OfficeIMO version-record PR: EvotecIT/OfficeIMO#1899