### PR TITLE
Restore Windows PowerShell 5.1 CI

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -80,7 +80,6 @@ jobs:
           path: WebsiteArtifacts/**
 
   test-windows-ps5:
-    if: false # Temporarily disabled
     needs: refresh-psd1
     name: 'Windows PowerShell 5.1'
     runs-on: windows-latest

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -1301,7 +1301,7 @@ Describe 'Excel DSL surface' {
 
             $backLink = $null
             $doc['Data'].TryGetCellText(5, 1, [ref] $backLink) | Should -BeTrue
-            $backLink | Should -Be '← TOC'
+            $backLink | Should -Be "$([char]0x2190) TOC"
         } finally {
             Close-OfficeExcel -Document $doc
         }


### PR DESCRIPTION
## Summary
- restore the Windows PowerShell 5.1 GitHub Actions lane
- make the Excel TOC backlink assertion encoding-safe for Windows PowerShell 5.1

## Validation
- powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command '& { $ErrorActionPreference = "Stop"; Import-Module Pester -ErrorAction Stop; Import-Module .\PSWriteOffice.psd1 -Force -ErrorAction Stop; Invoke-Pester -Path .\Tests\ExcelDsl.Tests.ps1 -Output Detailed }'
- powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\PSWriteOffice.Tests.ps1
- pwsh -NoLogo -NoProfile -File .\PSWriteOffice.Tests.ps1
- git diff --check