### PR TITLE
Route clean Excel object exports through OfficeIMO

### DIFF
--- a/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
@@ -202,14 +202,33 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
             }
 
             var sheet = PrepareSheet(document);
+            var dataStartRow = ResolveDataStartRow(sheet, isAppendingToExistingSheet);
+            var includeHeaders = !NoHeader.IsPresent && !isAppendingToExistingSheet;
+
+            if (TryExportObjectsThroughOfficeImoObjectPath(
+                sheet,
+                isAppendingToExistingSheet,
+                preserveWorkbook,
+                dataStartRow,
+                includeHeaders,
+                style,
+                out var objectRange))
+            {
+                if (!string.IsNullOrWhiteSpace(objectRange))
+                {
+                    WriteVerbose($"Exported data to {sheet.Name}!{objectRange}.");
+                }
+
+                ExcelDocumentService.SaveDocument(document, Open.IsPresent, resolvedPath);
+                WritePassThru(resolvedPath);
+                return;
+            }
+
             var data = BuildDataTable();
             if (data.Columns.Count == 0)
             {
                 throw new InvalidOperationException("Unable to infer columns from the supplied data.");
             }
-
-            var dataStartRow = ResolveDataStartRow(sheet, isAppendingToExistingSheet);
-            var includeHeaders = !NoHeader.IsPresent && !isAppendingToExistingSheet;
 
             if (!string.IsNullOrWhiteSpace(Title) && !isAppendingToExistingSheet)
             {
@@ -260,6 +279,81 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
     private bool CanExportReaderDirectly(bool isAppendingToExistingSheet)
     {
         return !isAppendingToExistingSheet && ExcludeProperty is not { Length: > 0 };
+    }
+
+    private bool TryExportObjectsThroughOfficeImoObjectPath(
+        ExcelSheet sheet,
+        bool isAppendingToExistingSheet,
+        bool preserveWorkbook,
+        int dataStartRow,
+        bool includeHeaders,
+        TableStyle style,
+        out string range)
+    {
+        range = string.Empty;
+        if (!CanExportObjectsThroughOfficeImoObjectPath(isAppendingToExistingSheet, preserveWorkbook, dataStartRow, includeHeaders))
+        {
+            return false;
+        }
+
+        var items = _input.Where(static item => item != null).ToList();
+        if (items.Count == 0)
+        {
+            return false;
+        }
+
+        if (!CanUseOfficeImoObjectPathInput(items))
+        {
+            return false;
+        }
+
+        sheet.InsertObjects<object?>(items, includeHeaders, dataStartRow);
+        range = sheet.GetUsedRangeA1();
+        if (string.IsNullOrWhiteSpace(range))
+        {
+            return false;
+        }
+
+        if (!NoTable.IsPresent)
+        {
+            sheet.AddTable(range, includeHeaders, TableName ?? string.Empty, style, includeAutoFilter: !NoAutoFilter.IsPresent);
+        }
+
+        return true;
+    }
+
+    private bool CanExportObjectsThroughOfficeImoObjectPath(bool isAppendingToExistingSheet, bool preserveWorkbook, int dataStartRow, bool includeHeaders)
+    {
+        return !isAppendingToExistingSheet &&
+            !preserveWorkbook &&
+            includeHeaders &&
+            dataStartRow == 1 &&
+            StartColumn == 1 &&
+            string.IsNullOrWhiteSpace(Title) &&
+            ExcludeProperty is not { Length: > 0 } &&
+            !AutoFit.IsPresent &&
+            !BoldTopRow.IsPresent &&
+            !FreezeTopRow.IsPresent &&
+            !FreezeFirstColumn.IsPresent;
+    }
+
+    private static bool CanUseOfficeImoObjectPathInput(IReadOnlyList<object?> items)
+    {
+        foreach (var item in items)
+        {
+            if (item is PSObject ||
+                item is Dictionary<string, object?> ||
+                item is IReadOnlyDictionary<string, object?> ||
+                item is IDictionary<string, object?> ||
+                item is IDictionary)
+            {
+                continue;
+            }
+
+            return false;
+        }
+
+        return items.Count > 0;
     }
 
     private string ExportDataReader(ExcelSheet sheet, IDataReader reader, TableStyle style)

--- a/Sources/PSWriteOffice/PSWriteOffice.csproj
+++ b/Sources/PSWriteOffice/PSWriteOffice.csproj
@@ -81,23 +81,23 @@
         <ProjectReference Include="$(OfficeIMORoot)\OfficeIMO.Visio\OfficeIMO.Visio.csproj" />
     </ItemGroup>
     <ItemGroup Condition="'$(UseOfficeIMOProjectReferences)' != 'true'">
-        <PackageReference Include="OfficeIMO.Drawing" Version="1.0.16" />
-        <PackageReference Include="OfficeIMO.Word" Version="1.0.63" />
-        <PackageReference Include="OfficeIMO.Word.Markdown" Version="1.0.38" />
-        <PackageReference Include="OfficeIMO.Excel" Version="0.6.42" />
-        <PackageReference Include="OfficeIMO.PowerPoint" Version="1.0.37" />
-        <PackageReference Include="OfficeIMO.Markdown" Version="0.6.29" />
-        <PackageReference Include="OfficeIMO.Markdown.Html" Version="0.1.29" />
-        <PackageReference Include="OfficeIMO.Pdf" Version="0.1.37" />
-        <PackageReference Include="OfficeIMO.Word.Pdf" Version="1.0.36" />
-        <PackageReference Include="OfficeIMO.Excel.Pdf" Version="1.0.2" />
-        <PackageReference Include="OfficeIMO.Markdown.Pdf" Version="1.0.2" />
-        <PackageReference Include="OfficeIMO.Html.Pdf" Version="1.0.0" />
-        <PackageReference Include="OfficeIMO.PowerPoint.Pdf" Version="1.0.2" />
-        <PackageReference Include="OfficeIMO.CSV" Version="0.1.42" />
-        <PackageReference Include="OfficeIMO.Word.Html" Version="1.0.36" />
-        <PackageReference Include="OfficeIMO.Reader" Version="0.1.37" />
-        <PackageReference Include="OfficeIMO.Reader.Pdf" Version="0.0.1" />
-        <PackageReference Include="OfficeIMO.Visio" Version="1.0.2" />
+        <PackageReference Include="OfficeIMO.Drawing" Version="1.0.17" />
+        <PackageReference Include="OfficeIMO.Word" Version="1.0.64" />
+        <PackageReference Include="OfficeIMO.Word.Markdown" Version="1.0.39" />
+        <PackageReference Include="OfficeIMO.Excel" Version="0.6.43" />
+        <PackageReference Include="OfficeIMO.PowerPoint" Version="1.0.38" />
+        <PackageReference Include="OfficeIMO.Markdown" Version="0.6.30" />
+        <PackageReference Include="OfficeIMO.Markdown.Html" Version="0.1.30" />
+        <PackageReference Include="OfficeIMO.Pdf" Version="0.1.38" />
+        <PackageReference Include="OfficeIMO.Word.Pdf" Version="1.0.37" />
+        <PackageReference Include="OfficeIMO.Excel.Pdf" Version="1.0.3" />
+        <PackageReference Include="OfficeIMO.Markdown.Pdf" Version="1.0.3" />
+        <PackageReference Include="OfficeIMO.Html.Pdf" Version="1.0.1" />
+        <PackageReference Include="OfficeIMO.PowerPoint.Pdf" Version="1.0.3" />
+        <PackageReference Include="OfficeIMO.CSV" Version="0.1.43" />
+        <PackageReference Include="OfficeIMO.Word.Html" Version="1.0.37" />
+        <PackageReference Include="OfficeIMO.Reader" Version="0.1.38" />
+        <PackageReference Include="OfficeIMO.Reader.Pdf" Version="0.0.2" />
+        <PackageReference Include="OfficeIMO.Visio" Version="1.0.3" />
     </ItemGroup>
 </Project>

--- a/Sources/PSWriteOffice/Services/Excel/ExcelTabularInputService.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelTabularInputService.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using System.Management.Automation;
 using OfficeIMO.Excel;
 using PSWriteOffice.Services;
 
@@ -97,11 +96,6 @@ internal static class ExcelTabularInputService
             }
         }
 
-        if (TryBuildFromPowerShellObjects(items, tableName, out var powerShellObjectTable))
-        {
-            return powerShellObjectTable;
-        }
-
         var normalized = PowerShellObjectNormalizer.NormalizeItems(items);
         return ObjectDataTableBuilder.FromObjects(normalized, tableName ?? string.Empty);
     }
@@ -182,126 +176,6 @@ internal static class ExcelTabularInputService
         }
 
         return result;
-    }
-
-    private static bool TryBuildFromPowerShellObjects(IReadOnlyList<object?> items, string? tableName, out DataTable table)
-    {
-        table = new DataTable();
-        var result = string.IsNullOrWhiteSpace(tableName)
-            ? new DataTable()
-            : new DataTable(tableName);
-
-        if (items.Count == 0)
-        {
-            return false;
-        }
-
-        if (items[0] is not PSObject firstObject)
-        {
-            return false;
-        }
-
-        var columns = GetPowerShellPropertyNames(firstObject);
-        if (columns.Count == 0)
-        {
-            return false;
-        }
-
-        foreach (var column in columns)
-        {
-            result.Columns.Add(column, typeof(object));
-        }
-
-        var columnIndexes = CreateColumnIndexMap(columns);
-
-        var values = new object?[columns.Count];
-        result.BeginLoadData();
-        try
-        {
-            foreach (var item in items)
-            {
-                if (item is not PSObject psObject)
-                {
-                    return false;
-                }
-
-                if (!TryReadPowerShellObjectRow(psObject, columns.Count, columnIndexes, values))
-                {
-                    return false;
-                }
-
-                result.Rows.Add(values);
-            }
-        }
-        finally
-        {
-            result.EndLoadData();
-        }
-
-        table = result;
-        return true;
-    }
-
-    private static List<string> GetPowerShellPropertyNames(PSObject psObject)
-    {
-        var names = new List<string>();
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var property in psObject.Properties)
-        {
-            if (!IsExportablePowerShellProperty(property))
-            {
-                continue;
-            }
-
-            var name = property.Name;
-            if (string.IsNullOrWhiteSpace(name) || !seen.Add(name))
-            {
-                continue;
-            }
-
-            names.Add(name);
-        }
-
-        return names;
-    }
-
-    private static bool TryReadPowerShellObjectRow(PSObject psObject, int columnCount, IReadOnlyDictionary<string, int> columnIndexes, object?[] values)
-    {
-        Array.Clear(values, 0, values.Length);
-        var matched = 0;
-        foreach (var property in psObject.Properties)
-        {
-            if (!IsExportablePowerShellProperty(property))
-            {
-                continue;
-            }
-
-            if (!columnIndexes.TryGetValue(property.Name, out var columnIndex))
-            {
-                return false;
-            }
-
-            values[columnIndex] = property.Value ?? DBNull.Value;
-            matched++;
-        }
-
-        return matched == columnCount;
-    }
-
-    private static Dictionary<string, int> CreateColumnIndexMap(IReadOnlyList<string> columns)
-    {
-        var columnIndexes = new Dictionary<string, int>(columns.Count, StringComparer.OrdinalIgnoreCase);
-        for (var columnIndex = 0; columnIndex < columns.Count; columnIndex++)
-        {
-            columnIndexes[columns[columnIndex]] = columnIndex;
-        }
-
-        return columnIndexes;
-    }
-
-    private static bool IsExportablePowerShellProperty(PSPropertyInfo property)
-    {
-        return property.MemberType is PSMemberTypes.NoteProperty or PSMemberTypes.Property;
     }
 
     private static object? Unwrap(object? item)

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -295,6 +295,28 @@ Describe 'Excel DSL surface' {
             Should -Throw '*StartColumn must be less than or equal to EndColumn*'
     }
 
+    It 'exports plain objects through the default table path' {
+        $path = Join-Path $TestDrive 'ExportOfficeExcelDefaultObjects.xlsx'
+        $rows = @(
+            [PSCustomObject]@{ Region = 'NA'; Revenue = 100; Created = [DateTime] '2026-01-01'; Enabled = $true }
+            [PSCustomObject]@{ Region = 'EMEA'; Revenue = 200; Created = [DateTime] '2026-01-02'; Enabled = $false }
+        )
+
+        $rows | Export-OfficeExcel -Path $path -WorksheetName 'Data' -TableName 'Sales'
+
+        $tables = @(Get-OfficeExcelTable -Path $path | Where-Object Name -eq 'Sales')
+        $tables.Count | Should -Be 1
+        $tables[0].Range | Should -Be 'A1:D3'
+
+        $imported = @(Import-OfficeExcel -Path $path -WorksheetName 'Data' -Range 'A1:D3')
+        $imported.Count | Should -Be 2
+        $imported[0].Region | Should -Be 'NA'
+        $imported[0].Revenue | Should -Be 100
+        $imported[1].Region | Should -Be 'EMEA'
+        $imported[1].Revenue | Should -Be 200
+        $imported[1].Enabled | Should -BeFalse
+    }
+
     It 'appends rows without rewriting headers' {
         $path = Join-Path $TestDrive 'ExportOfficeExcelAppend.xlsx'
         $rows = @(


### PR DESCRIPTION
## Summary
- Route clean default object/dictionary Excel exports through OfficeIMO's existing object insertion path.
- Use the normal `InsertObjects` -> `GetUsedRangeA1` -> `AddTable` flow, so PSWriteOffice stays a thin surface and does not own a custom benchmark writer.
- Remove the previous wrapper-side PowerShell-object DataTable shortcut and cover the default object table export path in Pester.

## Why
The matching OfficeIMO PR makes pending direct-tabular ranges visible through the existing API. PSWriteOffice can then use normal OfficeIMO calls for the common object export path and pick up the reusable engine performance improvement without changing the public PowerShell API.

Upstream dependency: EvotecIT/OfficeIMO#1905

## Validation
- `dotnet build C:\Support\GitHub\PSWriteOffice\Sources\PSWriteOffice.sln -c Debug --no-restore`
- `Invoke-Pester -Path C:\Support\GitHub\PSWriteOffice\Tests\ExcelDsl.Tests.ps1 -Output Detailed` with `OfficeIMORoot=C:\Support\GitHub\OfficeIMO` and `PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES=true`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File C:\Support\GitHub\PSWriteOffice\Build\Validate-PackagedArtefact.ps1`
- `git diff --check`

## Benchmark Evidence
Large 100k run: `C:\Support\GitHub\PSWriteOffice\Ignore\Benchmarks\ExcelPerformance\Run-20260612-204610-660060`

- `objects-default`: PSWriteOffice 618 ms vs ExcelFast 748 ms.
- `wide-objects-default`: PSWriteOffice 1667 ms vs ExcelFast 3389 ms.
- `objects-table`: PSWriteOffice 578 ms, fastest.
- `objects-no-table`: PSWriteOffice 611 ms, fastest.
- `objects-table-autofit`: PSWriteOffice 839 ms, fastest.
- `datatable-default`: PSWriteOffice 157 ms, fastest.
- `report-workbook`: PSWriteOffice 13934 ms, fastest.
- `dataset-worksheets`: PSWriteOffice 3606 ms, fastest.
