### PR TITLE
Fix implicit Word paragraph section reuse

### DIFF
--- a/Sources/PSWriteOffice/Services/Word/WordDslContext.cs
+++ b/Sources/PSWriteOffice/Services/Word/WordDslContext.cs
@@ -128,7 +128,15 @@ internal sealed class WordDslContext : IDisposable
 
     public WordSection RequireSection()
     {
-        return CurrentSection ?? AcquireSection();
+        return CurrentSection ?? RequireImplicitSection();
+    }
+
+    private WordSection RequireImplicitSection()
+    {
+        _initialSectionConsumed = true;
+        return Document.Sections.Count > 0
+            ? Document.Sections.Last()
+            : Document.AddSection();
     }
 
     public object RequireParagraphHost()

--- a/Tests/WordDsl.Tests.ps1
+++ b/Tests/WordDsl.Tests.ps1
@@ -172,6 +172,26 @@ Describe 'Word DSL surface' {
         )
     }
 
+    It 'keeps top-level paragraphs in the implicit section' {
+        $path = Join-Path $TestDrive 'DslImplicitSectionParagraphs.docx'
+
+        New-OfficeWord -Path $path {
+            Add-OfficeWordParagraph -Text 'Hello World'
+            Add-OfficeWordParagraph -Text 'Hello Again'
+        }
+
+        @(Get-TestWordBodyOrder -Path $path) | Should -Be @(
+            'p:Hello World'
+            'p:Hello Again'
+        )
+
+        $documentXml = Get-ZipXmlDocumentLocal -Path $path -Entry 'word/document.xml'
+        $namespaceManager = New-Object System.Xml.XmlNamespaceManager($documentXml.NameTable)
+        $namespaceManager.AddNamespace('w', 'http://schemas.openxmlformats.org/wordprocessingml/2006/main')
+
+        $documentXml.SelectNodes('/w:document/w:body/w:p[w:pPr/w:sectPr and not(.//w:t[normalize-space()])]', $namespaceManager).Count | Should -Be 0
+    }
+
     It 'preserves OfficeIMO insertion order when editing paragraphs returned by Find-OfficeWord' {
         $path = Join-Path $TestDrive 'ExistingWordInlineInsertion.docx'
 


### PR DESCRIPTION
## Summary
- Reuse the existing implicit Word section for top-level Word DSL content instead of acquiring a new section for every top-level paragraph.
- Add a regression test that generates a `.docx` and asserts two top-level paragraphs remain consecutive without an empty `sectPr` paragraph between them.

## Root cause
`RequireParagraphHost()` fell through to `RequireSection()`, and `RequireSection()` called `AcquireSection()` after the initial section had already been consumed. That made the second top-level paragraph create a new section, which Word can display as a page or section jump.

## Validation
- `dotnet build .\Sources\PSWriteOffice.sln -c Debug`
- `.\PSWriteOffice.Tests.ps1 -TestsPath .\Tests\WordDsl.Tests.ps1 -SkipDependencyInstall`
