### PR TITLE
Improve OfficeIMO-backed surfaces and Excel benchmarks

### DIFF
--- a/Benchmarks/Compare-ExcelPerformance.ps1
+++ b/Benchmarks/Compare-ExcelPerformance.ps1
@@ -16,6 +16,8 @@ param(
 
     [switch] $SkipFollowUps,
 
+    [switch] $SkipWorkbookValidation,
+
     [switch] $SkipImportExcelInstall,
 
     [switch] $SkipExcelFastInstall
@@ -306,6 +308,61 @@ function ConvertTo-ExcelColumnName {
     $name
 }
 
+function Get-BenchmarkRegionGroups {
+    param([object[]] $Rows)
+
+    foreach ($region in @('NA', 'EU', 'APAC', 'LATAM')) {
+        [pscustomobject]@{
+            Name = $region
+            TableName = 'Data_' + $region
+            Data = @($Rows | Where-Object { $_.Region -eq $region })
+        }
+    }
+}
+
+function Get-BenchmarkSummaryRows {
+    param([int] $Rows)
+
+    @(
+        [pscustomobject]@{ Metric = 'Rows'; Formula = 'COUNTA(Data!A2:A{0})' -f ($Rows + 1); NumberFormat = '#,##0' }
+        [pscustomobject]@{ Metric = 'Average score'; Formula = 'AVERAGE(Data!G2:G{0})' -f ($Rows + 1); NumberFormat = '#,##0.00' }
+        [pscustomobject]@{ Metric = 'Tickets'; Formula = 'SUM(Data!I2:I{0})' -f ($Rows + 1); NumberFormat = '#,##0' }
+        [pscustomobject]@{ Metric = 'Enabled'; Formula = 'COUNTIF(Data!E2:E{0},TRUE)' -f ($Rows + 1); NumberFormat = '#,##0' }
+    )
+}
+
+function Get-BenchmarkAppendSplit {
+    param([object[]] $Rows)
+
+    $initialCount = [math]::Max(1, [math]::Floor($Rows.Count * 0.8))
+    [pscustomobject]@{
+        Initial = @($Rows | Select-Object -First $initialCount)
+        Append = @($Rows | Select-Object -Skip $initialCount)
+    }
+}
+
+function Get-BenchmarkSmallSheetGroups {
+    param(
+        [object[]] $Rows,
+        [int] $SheetCount = 20
+    )
+
+    $safeSheetCount = [math]::Max(1, [math]::Min($SheetCount, [math]::Max(1, $Rows.Count)))
+    $rowsPerSheet = [math]::Max(1, [math]::Ceiling($Rows.Count / $safeSheetCount))
+    for ($sheetIndex = 0; $sheetIndex -lt $safeSheetCount; $sheetIndex++) {
+        $sheetRows = @($Rows | Select-Object -Skip ($sheetIndex * $rowsPerSheet) -First $rowsPerSheet)
+        if ($sheetRows.Count -eq 0) {
+            continue
+        }
+
+        [pscustomobject]@{
+            Name = 'Sheet{0:00}' -f ($sheetIndex + 1)
+            TableName = 'Data{0:00}' -f ($sheetIndex + 1)
+            Data = $sheetRows
+        }
+    }
+}
+
 function Get-RowCount {
     param([object] $Rows)
 
@@ -328,7 +385,8 @@ function New-FollowUpScenario {
         [string] $Key,
         [string] $Name,
         [string[]] $Suites,
-        [scriptblock] $Script
+        [scriptblock] $Script,
+        [string[]] $Engines = @('PSWriteOffice', 'ImportExcel', 'ExcelFast')
     )
 
     [pscustomobject]@{
@@ -336,6 +394,7 @@ function New-FollowUpScenario {
         Name = $Name
         Suites = $Suites
         Script = $Script
+        Engines = $Engines
     }
 }
 
@@ -370,6 +429,7 @@ function Get-ExcelBenchmarkScenarios {
     $scaleSuites = @('Standard', 'Large', 'Full', 'SuperLarge')
     $dataSetSuites = @('Large', 'Full')
     $reportSuites = @('Smoke', 'Standard', 'Large', 'Full')
+    $workflowSuites = @('Standard', 'Large', 'Full')
 
     $defaultImport = New-FollowUpScenario -Key 'import-default-full' -Name 'Import full sheet from default export' -Suites $basicSuites -Script {
         param($Context)
@@ -401,6 +461,34 @@ function Get-ExcelBenchmarkScenarios {
         }
     }
 
+    $noHeaderRangeImport = New-FollowUpScenario -Key 'read-no-header-range' -Name 'Read selected range without headers' -Suites $standardSuites -Script {
+        param($Context)
+
+        switch ($Context.Engine) {
+            'PSWriteOffice' { Import-OfficeExcel -Path $Context.Path -WorksheetName $Context.WorksheetName -Range $Context.Range -NoHeader }
+            'ImportExcel' { Import-Excel -Path $Context.Path -WorksheetName $Context.WorksheetName -StartRow 1 -EndRow ($Context.Rows + 1) -StartColumn 1 -EndColumn $Context.ColumnCount -NoHeader }
+            'ExcelFast' { Import-Workbook -Path $Context.Path -SheetName $Context.WorksheetName -StartCell 'A1' -EndCell $Context.RangeEndCell -NoHeaders }
+        }
+    }
+
+    $usedRangeAsDataTable = New-FollowUpScenario -Key 'read-used-range-datatable' -Name 'Read used range as DataTable' -Suites $standardSuites -Engines @('PSWriteOffice') -Script {
+        param($Context)
+
+        Get-OfficeExcelUsedRange -Path $Context.Path -Sheet $Context.WorksheetName -AsDataTable
+    }
+
+    $tableMetadataRead = New-FollowUpScenario -Key 'read-table-metadata' -Name 'Read workbook table metadata' -Suites $standardSuites -Engines @('PSWriteOffice') -Script {
+        param($Context)
+
+        Get-OfficeExcelTable -Path $Context.Path -Sheet $Context.WorksheetName
+    }
+
+    $namedRangeRead = New-FollowUpScenario -Key 'read-named-range-metadata' -Name 'Read workbook named range metadata' -Suites $standardSuites -Engines @('PSWriteOffice') -Script {
+        param($Context)
+
+        Get-OfficeExcelNamedRange -Path $Context.Path -Sheet $Context.WorksheetName
+    }
+
     @(
         New-ExportScenario -Key 'objects-table' -Name 'Export objects as table' -Suites $tableSuites -Engine 'PSWriteOffice' -Profile 'MixedObjects' -FileStem 'pswriteoffice-objects-table' -FollowUps @($tableImport) -Script {
             param($Context)
@@ -410,15 +498,15 @@ function Get-ExcelBenchmarkScenarios {
             param($Context)
             $Context.Data | Export-Excel -Path $Context.Path -WorksheetName $Context.WorksheetName -TableName Data -AutoFilter
         }
-        New-ExportScenario -Key 'objects-default' -Name 'Export objects default' -Suites $basicSuites -Engine 'PSWriteOffice' -Profile 'MixedObjects' -FileStem 'pswriteoffice-objects-default' -FollowUps @($defaultImport, $defaultRangeImport) -Script {
+        New-ExportScenario -Key 'objects-default' -Name 'Export objects default' -Suites $basicSuites -Engine 'PSWriteOffice' -Profile 'MixedObjects' -FileStem 'pswriteoffice-objects-default' -FollowUps @($defaultImport, $defaultRangeImport, $noHeaderRangeImport, $usedRangeAsDataTable, $tableMetadataRead) -Script {
             param($Context)
             $Context.Data | Export-OfficeExcel -Path $Context.Path -WorksheetName $Context.WorksheetName
         }
-        New-ExportScenario -Key 'objects-default' -Name 'Export objects default' -Suites $basicSuites -Engine 'ImportExcel' -Profile 'MixedObjects' -FileStem 'importexcel-objects-default' -FollowUps @($defaultImport, $defaultRangeImport) -Script {
+        New-ExportScenario -Key 'objects-default' -Name 'Export objects default' -Suites $basicSuites -Engine 'ImportExcel' -Profile 'MixedObjects' -FileStem 'importexcel-objects-default' -FollowUps @($defaultImport, $defaultRangeImport, $noHeaderRangeImport, $usedRangeAsDataTable, $tableMetadataRead) -Script {
             param($Context)
             $Context.Data | Export-Excel -Path $Context.Path -WorksheetName $Context.WorksheetName
         }
-        New-ExportScenario -Key 'objects-default' -Name 'Export objects default' -Suites $basicSuites -Engine 'ExcelFast' -Profile 'MixedObjects' -FileStem 'excelfast-objects-default' -FollowUps @($defaultImport, $defaultRangeImport) -Script {
+        New-ExportScenario -Key 'objects-default' -Name 'Export objects default' -Suites $basicSuites -Engine 'ExcelFast' -Profile 'MixedObjects' -FileStem 'excelfast-objects-default' -FollowUps @($defaultImport, $defaultRangeImport, $noHeaderRangeImport, $usedRangeAsDataTable, $tableMetadataRead) -Script {
             param($Context)
             Export-Workbook -Destination $Context.Path -InputObject $Context.Data -SheetName $Context.WorksheetName -Force
         }
@@ -438,15 +526,23 @@ function Get-ExcelBenchmarkScenarios {
             param($Context)
             $Context.Data | Export-Excel -Path $Context.Path -WorksheetName $Context.WorksheetName -TableName Data -AutoFilter -AutoSize
         }
-        New-ExportScenario -Key 'wide-objects-default' -Name 'Export wide objects default' -Suites $scaleSuites -Engine 'PSWriteOffice' -Profile 'WideObjects' -FileStem 'pswriteoffice-wide-objects-default' -FollowUps @($defaultImport, $defaultRangeImport) -Script {
+        New-ExportScenario -Key 'objects-title-freeze' -Name 'Export objects with title, offset header, and frozen top row' -Suites $workflowSuites -Engine 'PSWriteOffice' -Profile 'MixedObjects' -FileStem 'pswriteoffice-objects-title-freeze' -Script {
+            param($Context)
+            $Context.Data | Export-OfficeExcel -Path $Context.Path -WorksheetName $Context.WorksheetName -TableName Data -Title 'Operational export' -StartRow 3 -FreezeTopRow -BoldTopRow
+        }
+        New-ExportScenario -Key 'objects-title-freeze' -Name 'Export objects with title, offset header, and frozen top row' -Suites $workflowSuites -Engine 'ImportExcel' -Profile 'MixedObjects' -FileStem 'importexcel-objects-title-freeze' -Script {
+            param($Context)
+            $Context.Data | Export-Excel -Path $Context.Path -WorksheetName $Context.WorksheetName -TableName Data -AutoFilter -Title 'Operational export' -StartRow 3 -FreezeTopRow -BoldTopRow
+        }
+        New-ExportScenario -Key 'wide-objects-default' -Name 'Export wide objects default' -Suites $scaleSuites -Engine 'PSWriteOffice' -Profile 'WideObjects' -FileStem 'pswriteoffice-wide-objects-default' -FollowUps @($defaultImport, $defaultRangeImport, $noHeaderRangeImport, $usedRangeAsDataTable, $tableMetadataRead) -Script {
             param($Context)
             $Context.Data | Export-OfficeExcel -Path $Context.Path -WorksheetName $Context.WorksheetName
         }
-        New-ExportScenario -Key 'wide-objects-default' -Name 'Export wide objects default' -Suites $scaleSuites -Engine 'ImportExcel' -Profile 'WideObjects' -FileStem 'importexcel-wide-objects-default' -FollowUps @($defaultImport, $defaultRangeImport) -Script {
+        New-ExportScenario -Key 'wide-objects-default' -Name 'Export wide objects default' -Suites $scaleSuites -Engine 'ImportExcel' -Profile 'WideObjects' -FileStem 'importexcel-wide-objects-default' -FollowUps @($defaultImport, $defaultRangeImport, $noHeaderRangeImport, $usedRangeAsDataTable, $tableMetadataRead) -Script {
             param($Context)
             $Context.Data | Export-Excel -Path $Context.Path -WorksheetName $Context.WorksheetName
         }
-        New-ExportScenario -Key 'wide-objects-default' -Name 'Export wide objects default' -Suites $scaleSuites -Engine 'ExcelFast' -Profile 'WideObjects' -FileStem 'excelfast-wide-objects-default' -FollowUps @($defaultImport, $defaultRangeImport) -Script {
+        New-ExportScenario -Key 'wide-objects-default' -Name 'Export wide objects default' -Suites $scaleSuites -Engine 'ExcelFast' -Profile 'WideObjects' -FileStem 'excelfast-wide-objects-default' -FollowUps @($defaultImport, $defaultRangeImport, $noHeaderRangeImport, $usedRangeAsDataTable, $tableMetadataRead) -Script {
             param($Context)
             Export-Workbook -Destination $Context.Path -InputObject $Context.Data -SheetName $Context.WorksheetName -Force
         }
@@ -457,6 +553,233 @@ function Get-ExcelBenchmarkScenarios {
         New-ExportScenario -Key 'datatable-default' -Name 'Export DataTable default' -Suites $scaleSuites -Engine 'ImportExcel' -Profile 'DataTable' -FileStem 'importexcel-datatable-default' -FollowUps @($defaultImport, $defaultRangeImport) -Script {
             param($Context)
             $Context.Data | Export-Excel -Path $Context.Path -WorksheetName $Context.WorksheetName
+        }
+        New-ExportScenario -Key 'multi-sheet-regions' -Name 'Export regional workbook with one table per sheet' -Suites $workflowSuites -Engine 'PSWriteOffice' -Profile 'MixedObjects' -FileStem 'pswriteoffice-multi-sheet-regions' -Script {
+            param($Context)
+
+            New-OfficeExcel -Path $Context.Path {
+                foreach ($group in (Get-BenchmarkRegionGroups -Rows $Context.Data)) {
+                    Add-OfficeExcelSheet -Name $group.Name -Content {
+                        Add-OfficeExcelTable -Data $group.Data -TableName $group.TableName
+                        Set-OfficeExcelFreeze -TopRows 1
+                    }
+                }
+            } | Out-Null
+        }
+        New-ExportScenario -Key 'multi-sheet-regions' -Name 'Export regional workbook with one table per sheet' -Suites $workflowSuites -Engine 'ImportExcel' -Profile 'MixedObjects' -FileStem 'importexcel-multi-sheet-regions' -Script {
+            param($Context)
+
+            $excel = $null
+            try {
+                foreach ($group in (Get-BenchmarkRegionGroups -Rows $Context.Data)) {
+                    if ($excel) {
+                        $excel = $group.Data | Export-Excel -ExcelPackage $excel -WorksheetName $group.Name -TableName $group.TableName -AutoFilter -FreezeTopRow -BoldTopRow -PassThru
+                    } else {
+                        $excel = $group.Data | Export-Excel -Path $Context.Path -WorksheetName $group.Name -TableName $group.TableName -AutoFilter -FreezeTopRow -BoldTopRow -PassThru
+                    }
+                }
+            } finally {
+                if ($excel) {
+                    Close-ExcelPackage -ExcelPackage $excel
+                }
+            }
+        }
+        New-ExportScenario -Key 'summary-formulas' -Name 'Export data workbook with summary formulas' -Suites $workflowSuites -Engine 'PSWriteOffice' -Profile 'MixedObjects' -FileStem 'pswriteoffice-summary-formulas' -Script {
+            param($Context)
+
+            $summaryRows = Get-BenchmarkSummaryRows -Rows $Context.Rows
+            New-OfficeExcel -Path $Context.Path {
+                Add-OfficeExcelSheet -Name $Context.WorksheetName -Content {
+                    Add-OfficeExcelTable -Data $Context.Data -TableName Data
+                    Set-OfficeExcelFreeze -TopRows 1
+                }
+                Add-OfficeExcelSheet -Name 'Summary' -Content {
+                    Set-OfficeExcelCell -Address 'A1' -Value 'Metric'
+                    Set-OfficeExcelCell -Address 'B1' -Value 'Value'
+                    $row = 2
+                    foreach ($summaryRow in $summaryRows) {
+                        Set-OfficeExcelCell -Row $row -Column 1 -Value $summaryRow.Metric
+                        Set-OfficeExcelFormula -Address ('B{0}' -f $row) -Formula $summaryRow.Formula
+                        Set-OfficeExcelCell -Row $row -Column 2 -NumberFormat $summaryRow.NumberFormat
+                        $row++
+                    }
+                }
+            } | Out-Null
+        }
+        New-ExportScenario -Key 'summary-formulas' -Name 'Export data workbook with summary formulas' -Suites $workflowSuites -Engine 'ImportExcel' -Profile 'MixedObjects' -FileStem 'importexcel-summary-formulas' -Script {
+            param($Context)
+
+            $summaryRows = Get-BenchmarkSummaryRows -Rows $Context.Rows
+            $excel = $Context.Data | Export-Excel -Path $Context.Path -WorksheetName $Context.WorksheetName -TableName Data -AutoFilter -FreezeTopRow -BoldTopRow -PassThru
+            try {
+                $summary = $excel.Workbook.Worksheets.Add('Summary')
+                $summary.Cells['A1'].Value = 'Metric'
+                $summary.Cells['B1'].Value = 'Value'
+                $row = 2
+                foreach ($summaryRow in $summaryRows) {
+                    $summary.Cells[$row, 1].Value = $summaryRow.Metric
+                    $summary.Cells[$row, 2].Formula = $summaryRow.Formula
+                    $summary.Cells[$row, 2].Style.Numberformat.Format = $summaryRow.NumberFormat
+                    $row++
+                }
+            } finally {
+                Close-ExcelPackage -ExcelPackage $excel
+            }
+        }
+        New-ExportScenario -Key 'append-existing-table' -Name 'Append rows to an existing workbook table' -Suites $workflowSuites -Engine 'PSWriteOffice' -Profile 'MixedObjects' -FileStem 'pswriteoffice-append-existing-table' -FollowUps @($defaultImport, $tableMetadataRead) -Script {
+            param($Context)
+
+            $split = Get-BenchmarkAppendSplit -Rows $Context.Data
+            $split.Initial | Export-OfficeExcel -Path $Context.Path -WorksheetName $Context.WorksheetName -TableName Data
+            if ($split.Append.Count -gt 0) {
+                Add-OfficeExcelTableRow -InputPath $Context.Path -Sheet $Context.WorksheetName -TableName Data -InputObject $split.Append | Out-Null
+            }
+        }
+        New-ExportScenario -Key 'append-existing-table' -Name 'Append rows to an existing workbook table' -Suites $workflowSuites -Engine 'ImportExcel' -Profile 'MixedObjects' -FileStem 'importexcel-append-existing-table' -FollowUps @($defaultImport, $tableMetadataRead) -Script {
+            param($Context)
+
+            $split = Get-BenchmarkAppendSplit -Rows $Context.Data
+            $split.Initial | Export-Excel -Path $Context.Path -WorksheetName $Context.WorksheetName -TableName Data -AutoFilter
+            if ($split.Append.Count -gt 0) {
+                $split.Append | Export-Excel -Path $Context.Path -WorksheetName $Context.WorksheetName -Append
+            }
+        }
+        New-ExportScenario -Key 'update-existing-workbook' -Name 'Update cells and formulas in an existing workbook' -Suites $workflowSuites -Engine 'PSWriteOffice' -Profile 'MixedObjects' -FileStem 'pswriteoffice-update-existing-workbook' -FollowUps @($defaultImport, $defaultRangeImport) -Script {
+            param($Context)
+
+            $Context.Data | Export-OfficeExcel -Path $Context.Path -WorksheetName $Context.WorksheetName -TableName Data
+            Edit-OfficeExcelRow -InputPath $Context.Path -Sheet $Context.WorksheetName -ScriptBlock {
+                param($row)
+
+                $row.Set('TicketCount', ([int]$row.Get[int]('TicketCount') + 1))
+                if ($row.Get[bool]('IsEnabled')) {
+                    $row.Set('Notes', 'Reviewed')
+                }
+            } | Out-Null
+
+            $document = Get-OfficeExcel -Path $Context.Path
+            try {
+                $sheet = $document.Sheets | Where-Object { $_.Name -eq $Context.WorksheetName } | Select-Object -First 1
+                $formulaColumn = $Context.ColumnCount + 1
+                $sheet.Cell(1, $formulaColumn, 'ScoreDouble', $null, $null)
+                $sheet.Cell(2, $formulaColumn, $null, 'G2*2', '#,##0.00')
+                $document | Save-OfficeExcel
+            } finally {
+                $document | Close-OfficeExcel
+            }
+        }
+        New-ExportScenario -Key 'update-existing-workbook' -Name 'Update cells and formulas in an existing workbook' -Suites $workflowSuites -Engine 'ImportExcel' -Profile 'MixedObjects' -FileStem 'importexcel-update-existing-workbook' -FollowUps @($defaultImport, $defaultRangeImport) -Script {
+            param($Context)
+
+            $Context.Data | Export-Excel -Path $Context.Path -WorksheetName $Context.WorksheetName -TableName Data -AutoFilter
+            $excel = Open-ExcelPackage -Path $Context.Path
+            try {
+                $sheet = $excel.Workbook.Worksheets[$Context.WorksheetName]
+                for ($row = 2; $row -le ($Context.Rows + 1); $row++) {
+                    $sheet.Cells[$row, 9].Value = [int]$sheet.Cells[$row, 9].Value + 1
+                    if ([bool]$sheet.Cells[$row, 5].Value) {
+                        $sheet.Cells[$row, 10].Value = 'Reviewed'
+                    }
+                }
+
+                $formulaColumn = $Context.ColumnCount + 1
+                $sheet.Cells[1, $formulaColumn].Value = 'ScoreDouble'
+                $sheet.Cells[2, $formulaColumn].Formula = 'G2*2'
+                $sheet.Cells[2, $formulaColumn].Style.Numberformat.Format = '#,##0.00'
+            } finally {
+                Close-ExcelPackage -ExcelPackage $excel
+            }
+        }
+        New-ExportScenario -Key 'many-small-sheets' -Name 'Export many small worksheets' -Suites $workflowSuites -Engine 'PSWriteOffice' -Profile 'MixedObjects' -FileStem 'pswriteoffice-many-small-sheets' -Script {
+            param($Context)
+
+            New-OfficeExcel -Path $Context.Path {
+                foreach ($group in (Get-BenchmarkSmallSheetGroups -Rows $Context.Data -SheetCount 20)) {
+                    Add-OfficeExcelSheet -Name $group.Name -Content {
+                        Add-OfficeExcelTable -Data $group.Data -TableName $group.TableName
+                        Set-OfficeExcelFreeze -TopRows 1
+                    }
+                }
+            } | Out-Null
+        }
+        New-ExportScenario -Key 'many-small-sheets' -Name 'Export many small worksheets' -Suites $workflowSuites -Engine 'ImportExcel' -Profile 'MixedObjects' -FileStem 'importexcel-many-small-sheets' -Script {
+            param($Context)
+
+            $excel = $null
+            try {
+                foreach ($group in (Get-BenchmarkSmallSheetGroups -Rows $Context.Data -SheetCount 20)) {
+                    if ($excel) {
+                        $excel = $group.Data | Export-Excel -ExcelPackage $excel -WorksheetName $group.Name -TableName $group.TableName -AutoFilter -FreezeTopRow -BoldTopRow -PassThru
+                    } else {
+                        $excel = $group.Data | Export-Excel -Path $Context.Path -WorksheetName $group.Name -TableName $group.TableName -AutoFilter -FreezeTopRow -BoldTopRow -PassThru
+                    }
+                }
+            } finally {
+                if ($excel) {
+                    Close-ExcelPackage -ExcelPackage $excel
+                }
+            }
+        }
+        New-ExportScenario -Key 'named-range-workbook' -Name 'Export workbook with named data range' -Suites $workflowSuites -Engine 'PSWriteOffice' -Profile 'MixedObjects' -FileStem 'pswriteoffice-named-range-workbook' -FollowUps @($defaultImport, $namedRangeRead) -Script {
+            param($Context)
+
+            $sourceRange = 'A1:{0}{1}' -f (ConvertTo-ExcelColumnName -ColumnNumber $Context.ColumnCount), ($Context.Rows + 1)
+            New-OfficeExcel -Path $Context.Path {
+                Add-OfficeExcelSheet -Name $Context.WorksheetName -Content {
+                    Add-OfficeExcelTable -Data $Context.Data -TableName Data
+                    Set-OfficeExcelNamedRange -Name SalesData -Range $sourceRange
+                }
+            } | Out-Null
+        }
+        New-ExportScenario -Key 'named-range-workbook' -Name 'Export workbook with named data range' -Suites $workflowSuites -Engine 'ImportExcel' -Profile 'MixedObjects' -FileStem 'importexcel-named-range-workbook' -FollowUps @($defaultImport, $namedRangeRead) -Script {
+            param($Context)
+
+            $Context.Data | Export-Excel -Path $Context.Path -WorksheetName $Context.WorksheetName -TableName Data -AutoFilter -RangeName SalesData
+        }
+        New-ExportScenario -Key 'chart-only-workbook' -Name 'Export workbook with table and chart' -Suites $workflowSuites -Engine 'PSWriteOffice' -Profile 'MixedObjects' -FileStem 'pswriteoffice-chart-only-workbook' -Script {
+            param($Context)
+
+            New-OfficeExcel -Path $Context.Path {
+                Add-OfficeExcelSheet -Name $Context.WorksheetName -Content {
+                    Add-OfficeExcelTable -Data $Context.Data -TableName Data
+                    Add-OfficeExcelChart -TableName Data -Row 2 -Column 12 -Type ColumnClustered -Title 'Score by region'
+                }
+            } | Out-Null
+        }
+        New-ExportScenario -Key 'chart-only-workbook' -Name 'Export workbook with table and chart' -Suites $workflowSuites -Engine 'ImportExcel' -Profile 'MixedObjects' -FileStem 'importexcel-chart-only-workbook' -Script {
+            param($Context)
+
+            $lastRow = $Context.Rows + 1
+            $excel = $Context.Data | Export-Excel -Path $Context.Path -WorksheetName $Context.WorksheetName -TableName Data -AutoFilter -PassThru
+            try {
+                $worksheet = $excel.Workbook.Worksheets[$Context.WorksheetName]
+                Add-ExcelChart -Worksheet $worksheet -ChartType ColumnClustered -Title 'Score by region' -XRange "D2:D$lastRow" -YRange "G2:G$lastRow" -Row 2 -Column 12 -Width 640 -Height 360
+            } finally {
+                Close-ExcelPackage -ExcelPackage $excel
+            }
+        }
+        New-ExportScenario -Key 'pivot-only-workbook' -Name 'Export workbook with table and pivot' -Suites $workflowSuites -Engine 'PSWriteOffice' -Profile 'MixedObjects' -FileStem 'pswriteoffice-pivot-only-workbook' -Script {
+            param($Context)
+
+            $lastRow = $Context.Rows + 1
+            $sourceRange = 'A1:{0}{1}' -f (ConvertTo-ExcelColumnName -ColumnNumber $Context.ColumnCount), $lastRow
+            New-OfficeExcel -Path $Context.Path {
+                Add-OfficeExcelSheet -Name $Context.WorksheetName -Content {
+                    Add-OfficeExcelTable -Data $Context.Data -TableName Data
+                    Add-OfficeExcelPivotTable -SourceRange $sourceRange -DestinationCell 'L4' -Name 'SummaryPivot' -RowField Region -ColumnField Department -DataField Score, TicketCount -DataFunction Average, Sum -DataDisplayName 'Average Score', 'Tickets' -DataNumberFormat '#,##0.00', '#,##0'
+                }
+            } | Out-Null
+        }
+        New-ExportScenario -Key 'pivot-only-workbook' -Name 'Export workbook with table and pivot' -Suites $workflowSuites -Engine 'ImportExcel' -Profile 'MixedObjects' -FileStem 'importexcel-pivot-only-workbook' -Script {
+            param($Context)
+
+            $excel = $Context.Data | Export-Excel -Path $Context.Path -WorksheetName $Context.WorksheetName -TableName Data -AutoFilter -PassThru
+            try {
+                $worksheet = $excel.Workbook.Worksheets[$Context.WorksheetName]
+                Add-PivotTable -ExcelPackage $excel -Address $worksheet.Cells['L4'] -SourceWorksheet $worksheet -SourceRange $worksheet.Tables[0].Address -PivotTableName SummaryPivot -PivotRows Region -PivotColumns Department -PivotData @{ Score = 'Average'; TicketCount = 'Sum' } -PivotNumberFormat '#,##0.00'
+            } finally {
+                Close-ExcelPackage -ExcelPackage $excel
+            }
         }
         New-ExportScenario -Key 'report-workbook' -Name 'Export report workbook with table chart pivot formatting' -Suites $reportSuites -Engine 'PSWriteOffice' -Profile 'MixedObjects' -FileStem 'pswriteoffice-report-workbook' -FollowUps @($defaultImport, $defaultRangeImport) -Script {
             param($Context)
@@ -527,7 +850,11 @@ function Test-ScenarioFilter {
 function Get-SelectedFollowUps {
     param([object] $ScenarioObject)
 
-    $followUps = @($ScenarioObject.FollowUps | Where-Object { $_.Suites -contains $Suite })
+    $followUps = @(
+        $ScenarioObject.FollowUps |
+            Where-Object { $_.Suites -contains $Suite } |
+            Where-Object { -not $_.PSObject.Properties['Engines'] -or $_.Engines -contains $ScenarioObject.Engine }
+    )
     if (-not $Scenario -or $Scenario.Count -eq 0) {
         return $followUps
     }
@@ -539,19 +866,111 @@ function Get-SelectedFollowUps {
     @($followUps | Where-Object { Test-ScenarioFilter -ScenarioObject $_ -Patterns $Scenario })
 }
 
+function Get-BenchmarkLoadedType {
+    param([string] $FullName)
+
+    foreach ($assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {
+        $type = $assembly.GetType($FullName, $false, $false)
+        if ($type) {
+            return $type
+        }
+    }
+
+    $null
+}
+
+function Test-BenchmarkWorkbook {
+    param([string] $Path)
+
+    $stopwatch = [Diagnostics.Stopwatch]::StartNew()
+    $openStatus = 'Skipped'
+    $openXmlStatus = 'Skipped'
+    $errorMessage = $null
+
+    if ([string]::IsNullOrWhiteSpace($Path) -or -not (Test-Path $Path)) {
+        $stopwatch.Stop()
+        return [pscustomobject]@{
+            Status = 'Skipped'
+            OpenStatus = $openStatus
+            OpenXmlStatus = $openXmlStatus
+            Milliseconds = [math]::Round($stopwatch.Elapsed.TotalMilliseconds, 3)
+            Error = 'Workbook file was not created.'
+        }
+    }
+
+    try {
+        $document = Get-OfficeExcel -Path $Path -ReadOnly
+        if ($document) {
+            Close-OfficeExcel -Document $document
+        }
+        $openStatus = 'Passed'
+    } catch {
+        $openStatus = 'Failed'
+        $errorMessage = $_.Exception.Message
+    }
+
+    if ($openStatus -eq 'Passed') {
+        $spreadsheetDocumentType = Get-BenchmarkLoadedType -FullName 'DocumentFormat.OpenXml.Packaging.SpreadsheetDocument'
+        $openXmlValidatorType = Get-BenchmarkLoadedType -FullName 'DocumentFormat.OpenXml.Validation.OpenXmlValidator'
+
+        if ($spreadsheetDocumentType -and $openXmlValidatorType) {
+            $spreadsheetDocument = $null
+            try {
+                $openMethod = $spreadsheetDocumentType.GetMethod('Open', [type[]]@([string], [bool]))
+                $spreadsheetDocument = $openMethod.Invoke($null, @($Path, $false))
+                $validator = [Activator]::CreateInstance($openXmlValidatorType)
+                $validationErrors = @($validator.Validate($spreadsheetDocument) | Select-Object -First 1)
+                if ($validationErrors.Count -gt 0) {
+                    $openXmlStatus = 'Failed'
+                    $errorMessage = $validationErrors[0].Description
+                } else {
+                    $openXmlStatus = 'Passed'
+                }
+            } catch {
+                $openXmlStatus = 'Failed'
+                $errorMessage = $_.Exception.Message
+            } finally {
+                if ($spreadsheetDocument) {
+                    $spreadsheetDocument.Dispose()
+                }
+            }
+        }
+    }
+
+    $stopwatch.Stop()
+    $status = if ($openStatus -eq 'Failed' -or $openXmlStatus -eq 'Failed') {
+        'Failed'
+    } elseif ($openStatus -eq 'Passed') {
+        'Passed'
+    } else {
+        'Skipped'
+    }
+
+    [pscustomobject]@{
+        Status = $status
+        OpenStatus = $openStatus
+        OpenXmlStatus = $openXmlStatus
+        Milliseconds = [math]::Round($stopwatch.Elapsed.TotalMilliseconds, 3)
+        Error = $errorMessage
+    }
+}
+
 function Invoke-BenchmarkOperation {
     param(
         [object] $Context,
         [string] $ScenarioKey,
         [string] $ScenarioName,
-        [scriptblock] $ScriptBlock
+        [scriptblock] $ScriptBlock,
+        [bool] $ValidateWorkbook = $false
     )
 
     [GC]::Collect()
     [GC]::WaitForPendingFinalizers()
     [GC]::Collect()
     $process = [Diagnostics.Process]::GetCurrentProcess()
+    $process.Refresh()
     $beforeWorkingSet = $process.WorkingSet64
+    $beforePeakWorkingSet = $process.PeakWorkingSet64
     $beforeManaged = [GC]::GetTotalMemory($false)
     $stopwatch = [Diagnostics.Stopwatch]::StartNew()
     $resultCount = 0
@@ -566,6 +985,19 @@ function Invoke-BenchmarkOperation {
     }
     $stopwatch.Stop()
     $process.Refresh()
+    $afterWorkingSet = $process.WorkingSet64
+    $afterPeakWorkingSet = $process.PeakWorkingSet64
+    $workbookValidation = if ($ValidateWorkbook -and $status -eq 'Passed') {
+        Test-BenchmarkWorkbook -Path $Context.Path
+    } else {
+        [pscustomobject]@{
+            Status = 'Skipped'
+            OpenStatus = 'Skipped'
+            OpenXmlStatus = 'Skipped'
+            Milliseconds = 0
+            Error = $null
+        }
+    }
 
     [pscustomobject]@{
         TimestampUtc      = [datetime]::UtcNow.ToString('o')
@@ -579,8 +1011,17 @@ function Invoke-BenchmarkOperation {
         Milliseconds      = [math]::Round($stopwatch.Elapsed.TotalMilliseconds, 3)
         ResultCount       = $resultCount
         FileBytes         = if (Test-Path $Context.Path) { (Get-Item $Context.Path).Length } else { 0 }
-        WorkingSetDeltaMB = [math]::Round(($process.WorkingSet64 - $beforeWorkingSet) / 1MB, 3)
+        WorkingSetBeforeMB = [math]::Round($beforeWorkingSet / 1MB, 3)
+        WorkingSetAfterMB = [math]::Round($afterWorkingSet / 1MB, 3)
+        WorkingSetDeltaMB = [math]::Round(($afterWorkingSet - $beforeWorkingSet) / 1MB, 3)
+        PeakWorkingSetMB = [math]::Round($afterPeakWorkingSet / 1MB, 3)
+        PeakWorkingSetDeltaMB = [math]::Round([math]::Max(0, $afterPeakWorkingSet - $beforePeakWorkingSet) / 1MB, 3)
         ManagedDeltaMB    = [math]::Round(([GC]::GetTotalMemory($false) - $beforeManaged) / 1MB, 3)
+        WorkbookValidationStatus = $workbookValidation.Status
+        WorkbookOpenStatus = $workbookValidation.OpenStatus
+        WorkbookOpenXmlStatus = $workbookValidation.OpenXmlStatus
+        WorkbookValidationMs = $workbookValidation.Milliseconds
+        WorkbookValidationError = $workbookValidation.Error
         Status            = $status
         Error             = $errorMessage
     }
@@ -621,6 +1062,65 @@ function Format-Ratio {
     }
 
     ('{0:0.#} x' -f $Value)
+}
+
+function Get-BenchmarkModuleDetails {
+    param([string] $Name)
+
+    $module = Get-Module $Name | Select-Object -First 1
+    if (-not $module) {
+        return $null
+    }
+
+    $prerelease = $null
+    $psData = $null
+    if ($module.PrivateData -and $module.PrivateData.PSData) {
+        $psData = $module.PrivateData.PSData
+    }
+
+    if ($psData -is [Collections.IDictionary]) {
+        if ($psData.Contains('Prerelease') -and $psData['Prerelease']) {
+            $prerelease = [string]$psData['Prerelease']
+        }
+    } elseif ($psData -and $psData.PSObject.Properties['Prerelease'] -and $psData.Prerelease) {
+        $prerelease = [string]$psData.Prerelease
+    }
+
+    $version = $module.Version.ToString()
+    [pscustomobject]@{
+        Name = $module.Name
+        Version = $version
+        Prerelease = $prerelease
+        DisplayVersion = if ($prerelease) { "$version-$prerelease" } else { $version }
+        ModuleBase = $module.ModuleBase
+        Path = $module.Path
+    }
+}
+
+function Get-BenchmarkEnvironment {
+    $processor = $null
+    $computerSystem = $null
+    if (Get-Command Get-CimInstance -ErrorAction SilentlyContinue) {
+        try {
+            $processor = Get-CimInstance Win32_Processor -ErrorAction Stop | Select-Object -First 1
+            $computerSystem = Get-CimInstance Win32_ComputerSystem -ErrorAction Stop | Select-Object -First 1
+        } catch {
+            $processor = $null
+            $computerSystem = $null
+        }
+    }
+
+    [pscustomobject]@{
+        MachineName = [Environment]::MachineName
+        OSDescription = [Runtime.InteropServices.RuntimeInformation]::OSDescription
+        OSArchitecture = [Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+        ProcessArchitecture = [Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString()
+        DotNetVersion = [Environment]::Version.ToString()
+        ProcessorName = if ($processor) { $processor.Name.Trim() } else { $null }
+        ProcessorCores = if ($processor) { [int]$processor.NumberOfCores } else { $null }
+        ProcessorLogicalProcessors = if ($processor) { [int]$processor.NumberOfLogicalProcessors } else { $null }
+        TotalPhysicalMemoryGB = if ($computerSystem) { [math]::Round([double]$computerSystem.TotalPhysicalMemory / 1GB, 2) } else { $null }
+    }
 }
 
 function Get-ComparisonRating {
@@ -705,6 +1205,23 @@ function New-BenchmarkComparison {
                         MinMs = [double]$_.MinMs
                         MaxMs = [double]$_.MaxMs
                         MedianFileKB = [double]$_.MedianFileKB
+                        MedianWorkingSetBeforeMB = [double]$_.MedianWorkingSetBeforeMB
+                        MedianWorkingSetAfterMB = [double]$_.MedianWorkingSetAfterMB
+                        MedianWorkingSetDeltaMB = [double]$_.MedianWorkingSetDeltaMB
+                        MedianPeakWorkingSetMB = [double]$_.MedianPeakWorkingSetMB
+                        MedianPeakWorkingSetDeltaMB = [double]$_.MedianPeakWorkingSetDeltaMB
+                        MedianManagedDeltaMB = [double]$_.MedianManagedDeltaMB
+                        WorkbookValidationStatus = if ([int]$_.WorkbookValidationFailed -gt 0) {
+                            'failed'
+                        } elseif ([int]$_.WorkbookValidationPassed -gt 0) {
+                            'passed'
+                        } else {
+                            'skipped'
+                        }
+                        WorkbookValidationPassed = [int]$_.WorkbookValidationPassed
+                        WorkbookValidationFailed = [int]$_.WorkbookValidationFailed
+                        WorkbookValidationSkipped = [int]$_.WorkbookValidationSkipped
+                        MedianWorkbookValidationMs = [double]$_.MedianWorkbookValidationMs
                         TimeVsFastest = $timeRatio
                         TimeVsFastestText = Format-Ratio -Value $timeRatio
                         FileVsSmallest = $fileRatio
@@ -731,10 +1248,25 @@ function New-BenchmarkComparison {
 
         foreach ($engineName in @('PSWriteOffice', 'ImportExcel', 'ExcelFast')) {
             $engineResult = @($engineResults | Where-Object Engine -eq $engineName | Select-Object -First 1)
+            $engineSummary = @($group.Group | Where-Object Engine -eq $engineName | Select-Object -First 1)
             $prefix = $engineName -replace '[^A-Za-z0-9]', ''
+            $row["${prefix}Status"] = if ($engineResult.Count -gt 0) {
+                'tested'
+            } elseif ($engineSummary.Count -gt 0) {
+                'failed'
+            } elseif ($Engine -contains $engineName) {
+                'not supported by scenario'
+            } else {
+                'not selected'
+            }
             $row["${prefix}Ms"] = if ($engineResult.Count -gt 0) { $engineResult[0].MedianMs } else { $null }
             $row["${prefix}VsFastest"] = if ($engineResult.Count -gt 0) { $engineResult[0].TimeVsFastest } else { $null }
             $row["${prefix}FileKB"] = if ($engineResult.Count -gt 0) { $engineResult[0].MedianFileKB } else { $null }
+            $row["${prefix}WorkingSetDeltaMB"] = if ($engineResult.Count -gt 0) { $engineResult[0].MedianWorkingSetDeltaMB } else { $null }
+            $row["${prefix}PeakWorkingSetDeltaMB"] = if ($engineResult.Count -gt 0) { $engineResult[0].MedianPeakWorkingSetDeltaMB } else { $null }
+            $row["${prefix}ManagedDeltaMB"] = if ($engineResult.Count -gt 0) { $engineResult[0].MedianManagedDeltaMB } else { $null }
+            $row["${prefix}WorkbookValidationStatus"] = if ($engineResult.Count -gt 0) { $engineResult[0].WorkbookValidationStatus } else { $null }
+            $row["${prefix}WorkbookValidationMs"] = if ($engineResult.Count -gt 0) { $engineResult[0].MedianWorkbookValidationMs } else { $null }
         }
 
         $comparisonRows.Add([pscustomobject]$row)
@@ -817,7 +1349,7 @@ if ($Engine -contains 'ExcelFast') {
     Ensure-ExcelFast
 }
 
-if ($Engine -contains 'PSWriteOffice') {
+if (($Engine -contains 'PSWriteOffice') -or (-not $SkipWorkbookValidation.IsPresent)) {
     $env:PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES = 'true'
     if (-not $env:OfficeIMORoot) {
         $env:OfficeIMORoot = Join-Path $repoRoot '.missing-officeimo'
@@ -860,7 +1392,7 @@ foreach ($rows in $RowCount) {
                 Remove-Item $context.Path -Force
             }
 
-            $results.Add((Invoke-BenchmarkOperation -Context $context -ScenarioKey $benchmarkScenario.Key -ScenarioName $benchmarkScenario.Name -ScriptBlock $benchmarkScenario.Script))
+            $results.Add((Invoke-BenchmarkOperation -Context $context -ScenarioKey $benchmarkScenario.Key -ScenarioName $benchmarkScenario.Name -ScriptBlock $benchmarkScenario.Script -ValidateWorkbook (-not $SkipWorkbookValidation.IsPresent)))
 
             if ((-not $SkipFollowUps.IsPresent) -and (Test-Path $context.Path)) {
                 foreach ($followUp in (Get-SelectedFollowUps -ScenarioObject $benchmarkScenario)) {
@@ -896,8 +1428,16 @@ $summary = $results |
             MinMs        = if ($passed.Count) { ($passed | Measure-Object Milliseconds -Minimum).Minimum } else { 0 }
             MaxMs        = if ($passed.Count) { ($passed | Measure-Object Milliseconds -Maximum).Maximum } else { 0 }
             MedianFileKB = if ($passed.Count) { [math]::Round((($passed | Sort-Object FileBytes)[[int][math]::Floor(($passed.Count - 1) / 2)].FileBytes) / 1KB, 1) } else { 0 }
+            MedianWorkingSetBeforeMB = if ($passed.Count) { [math]::Round((Get-MedianValue -InputObject $passed -PropertyName WorkingSetBeforeMB), 3) } else { 0 }
+            MedianWorkingSetAfterMB = if ($passed.Count) { [math]::Round((Get-MedianValue -InputObject $passed -PropertyName WorkingSetAfterMB), 3) } else { 0 }
             MedianWorkingSetDeltaMB = if ($passed.Count) { [math]::Round((Get-MedianValue -InputObject $passed -PropertyName WorkingSetDeltaMB), 3) } else { 0 }
+            MedianPeakWorkingSetMB = if ($passed.Count) { [math]::Round((Get-MedianValue -InputObject $passed -PropertyName PeakWorkingSetMB), 3) } else { 0 }
+            MedianPeakWorkingSetDeltaMB = if ($passed.Count) { [math]::Round((Get-MedianValue -InputObject $passed -PropertyName PeakWorkingSetDeltaMB), 3) } else { 0 }
             MedianManagedDeltaMB = if ($passed.Count) { [math]::Round((Get-MedianValue -InputObject $passed -PropertyName ManagedDeltaMB), 3) } else { 0 }
+            WorkbookValidationPassed = @($passed | Where-Object WorkbookValidationStatus -eq 'Passed').Count
+            WorkbookValidationFailed = @($passed | Where-Object WorkbookValidationStatus -eq 'Failed').Count
+            WorkbookValidationSkipped = @($passed | Where-Object WorkbookValidationStatus -eq 'Skipped').Count
+            MedianWorkbookValidationMs = if ($passed.Count) { [math]::Round((Get-MedianValue -InputObject $passed -PropertyName WorkbookValidationMs), 3) } else { 0 }
         }
     } |
     Sort-Object ScenarioKey, Profile, Rows, Engine
@@ -905,7 +1445,7 @@ $summary = $results |
 $summary | Export-Csv -NoTypeInformation -Path $summaryPath
 $comparison = @(New-BenchmarkComparison -Summary $summary)
 $comparison |
-    Select-Object ScenarioKey, Scenario, Profile, Rows, FastestEngine, FastestMs, PSWriteOfficeMs, PSWriteOfficeRank, PSWriteOfficeVsFastest, PSWriteOfficeVsFastestText, LeadText, Rating, ImportExcelMs, ImportExcelVsFastest, ExcelFastMs, ExcelFastVsFastest, SmallestFileEngine, PSWriteOfficeFileKB, ImportExcelFileKB, ExcelFastFileKB |
+    Select-Object ScenarioKey, Scenario, Profile, Rows, FastestEngine, FastestMs, PSWriteOfficeStatus, PSWriteOfficeMs, PSWriteOfficeRank, PSWriteOfficeVsFastest, PSWriteOfficeVsFastestText, LeadText, Rating, ImportExcelStatus, ImportExcelMs, ImportExcelVsFastest, ExcelFastStatus, ExcelFastMs, ExcelFastVsFastest, SmallestFileEngine, PSWriteOfficeFileKB, ImportExcelFileKB, ExcelFastFileKB, PSWriteOfficeWorkbookValidationStatus, ImportExcelWorkbookValidationStatus, ExcelFastWorkbookValidationStatus, PSWriteOfficeWorkbookValidationMs, ImportExcelWorkbookValidationMs, ExcelFastWorkbookValidationMs, PSWriteOfficeWorkingSetDeltaMB, ImportExcelWorkingSetDeltaMB, ExcelFastWorkingSetDeltaMB, PSWriteOfficePeakWorkingSetDeltaMB, ImportExcelPeakWorkingSetDeltaMB, ExcelFastPeakWorkingSetDeltaMB, PSWriteOfficeManagedDeltaMB, ImportExcelManagedDeltaMB, ExcelFastManagedDeltaMB |
     Export-Csv -NoTypeInformation -Path $comparisonCsvPath
 $comparison | ConvertTo-Json -Depth 8 | Set-Content -Path $comparisonJsonPath -Encoding UTF8
 $officeIMOExcelAssemblyPath = Join-Path $repoRoot 'Sources\PSWriteOffice\bin\Debug\net8.0\OfficeIMO.Excel.dll'
@@ -922,25 +1462,41 @@ $officeIMOExcelAssemblyVersion = if (Test-Path $officeIMOExcelAssemblyPath) {
     }
 }
 
+$moduleDetails = [ordered]@{
+    PSWriteOffice = Get-BenchmarkModuleDetails -Name PSWriteOffice
+    ImportExcel = Get-BenchmarkModuleDetails -Name ImportExcel
+    ExcelFast = Get-BenchmarkModuleDetails -Name ExcelFast
+}
+
 [pscustomobject]@{
     PowerShellVersion = $PSVersionTable.PSVersion.ToString()
     PSEdition = $PSEdition
+    Environment = Get-BenchmarkEnvironment
     Suite = $Suite
-    ImportExcel = if (Get-Module ImportExcel) { (Get-Module ImportExcel).Version.ToString() } else { $null }
-    ExcelFast = if (Get-Module ExcelFast) { (Get-Module ExcelFast).Version.ToString() } else { $null }
-    PSWriteOffice = if (Get-Module PSWriteOffice) { (Get-Module PSWriteOffice).Version.ToString() } else { $null }
+    ImportExcel = if ($moduleDetails.ImportExcel) { $moduleDetails.ImportExcel.DisplayVersion } else { $null }
+    ExcelFast = if ($moduleDetails.ExcelFast) { $moduleDetails.ExcelFast.DisplayVersion } else { $null }
+    PSWriteOffice = if ($moduleDetails.PSWriteOffice) { $moduleDetails.PSWriteOffice.DisplayVersion } else { $null }
+    Modules = $moduleDetails
     OfficeIMOExcelAssembly = $officeIMOExcelAssemblyVersion
+    OfficeIMOExcelAssemblyPath = if (Test-Path $officeIMOExcelAssemblyPath) { $officeIMOExcelAssemblyPath } else { $null }
     Engines = $Engine
     ScenarioFilter = $Scenario
     RowCount = $RowCount
     RepeatCount = $RepeatCount
     SkipFollowUps = $SkipFollowUps.IsPresent
+    SkipWorkbookValidation = $SkipWorkbookValidation.IsPresent
     ScenarioCount = $selectedScenarios.Count
+    RepoRoot = $repoRoot.Path
+    OutputDirectory = $OutputDirectory
+    WorkRoot = $workRoot
+    ModuleCache = $moduleRoot
+    OfficeIMORoot = $env:OfficeIMORoot
+    PSWriteOfficeUseDevelopmentBinaries = $env:PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES
     ResultsPath = $resultsPath
     SummaryPath = $summaryPath
     ComparisonCsvPath = $comparisonCsvPath
     ComparisonJsonPath = $comparisonJsonPath
-} | ConvertTo-Json -Depth 5 | Set-Content -Path $metadataPath -Encoding UTF8
+} | ConvertTo-Json -Depth 8 | Set-Content -Path $metadataPath -Encoding UTF8
 
 Write-Host "Results: $resultsPath"
 Write-Host "Summary: $summaryPath"

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -54,6 +54,18 @@ Run the richer report workbook workflow:
 pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Standard -Scenario report-workbook -RowCount 1000,10000 -RepeatCount 3 -Engine PSWriteOffice,ImportExcel
 ```
 
+Run the more operational workbook workflows:
+
+```powershell
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Standard -Scenario objects-title-freeze,multi-sheet-regions,summary-formulas -RowCount 1000,10000,25000 -RepeatCount 3 -Engine PSWriteOffice,ImportExcel
+```
+
+Run the append, update, many-sheet, read-focused, and chart/pivot split workflows:
+
+```powershell
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Standard -Scenario objects-default,append-existing-table,update-existing-workbook,many-small-sheets,named-range-workbook,chart-only-workbook,pivot-only-workbook -RowCount 1000,10000,25000 -RepeatCount 3
+```
+
 Measure export creation without import follow-up timing:
 
 ```powershell
@@ -70,7 +82,7 @@ pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-Excel
 
 `Smoke` is a quick confidence pass for default, table, and report workbook export/import paths.
 
-`Standard` covers the everyday decisions people make: default export, table export, no-table export, autofit, full-sheet import, range import, wide objects, DataTable input, and a report workbook with a table, freeze row, conditional formatting, validation, a chart, and a pivot table.
+`Standard` covers the everyday decisions people make: default export, table export, no-table export, autofit, full-sheet import, range import, no-header reads, used-range DataTable reads, table/named-range metadata reads, append-to-existing-table workflows, update-existing-workbook workflows, wide objects, DataTable input, title/start-row/frozen-header exports, regional multi-sheet workbooks, many-small-sheet workbooks, formula summary sheets, chart-only and pivot-only workbooks, and a full report workbook with a table, freeze row, conditional formatting, validation, a chart, and a pivot table.
 
 `Large` runs the broad workflow family at `25k`, `100k`, and `250k` rows, including the PSWriteOffice DataSet worksheet path.
 
@@ -82,16 +94,47 @@ pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-Excel
 
 Every run writes these files:
 
-- `excel-performance-comparison.csv`: one row per scenario/row count with fastest engine, PSWriteOffice rank, PSWriteOffice vs fastest text, competitor timings, and file sizes.
-- `excel-performance-comparison.json`: nested comparison data with per-engine rank, timing ratio, and file-size ratio.
-- `excel-performance-summary.csv`: median/min/max data grouped by engine and scenario.
-- `excel-performance-results.csv`: raw per-iteration results, including failures.
-- `metadata.json`: tool versions, selected suite, engines, filters, and output paths.
+- `excel-performance-comparison.csv`: one row per scenario/row count with fastest engine, per-engine status (`tested`, `failed`, `not selected`, or `not supported by scenario`), PSWriteOffice rank, PSWriteOffice vs fastest text, competitor timings, file sizes, and compact memory deltas.
+- `excel-performance-comparison.json`: nested comparison data with per-engine rank, timing ratio, file-size ratio, and memory fields.
+- `excel-performance-summary.csv`: median/min/max data grouped by engine and scenario, including median working-set, peak working-set, and managed-memory deltas.
+- `excel-performance-results.csv`: raw per-iteration results, including failures, file size, working-set before/after, peak working set, and managed-memory delta.
+- `metadata.json`: exact module versions including prerelease labels, machine/runtime details, selected suite, engines, filters, module cache paths, and output paths.
 
-For quick reading, start with `excel-performance-comparison.csv`.
+For quick reading, start with `excel-performance-comparison.csv`. See
+[Artifact Schema](#artifact-schema) when you need exact column meanings.
+
+## Artifact Schema
+
+`excel-performance-results.csv` is the raw evidence. Important columns:
+
+- `Status` / `Error`: whether the timed operation itself passed.
+- `WorkbookValidationStatus`: post-operation workbook validation result for export scenarios.
+- `WorkbookOpenStatus`: whether PSWriteOffice could open the generated workbook.
+- `WorkbookOpenXmlStatus`: whether Open XML validation passed, failed, or was skipped because validator types were unavailable.
+- `WorkbookValidationMs`: validation time, recorded separately from the timed operation.
+- `WorkingSetBeforeMB`, `WorkingSetAfterMB`, `WorkingSetDeltaMB`, `PeakWorkingSetDeltaMB`, `ManagedDeltaMB`: memory diagnostics for the operation.
+
+`excel-performance-summary.csv` groups raw rows by engine, scenario, profile,
+and row count. It reports median/min/max time, median file size, median memory
+deltas, and workbook-validation pass/fail/skip counts.
+
+`excel-performance-comparison.csv` is the comparison view. It includes:
+
+- `FastestEngine`, `FastestMs`, and PSWriteOffice rank/ratio text.
+- Per-engine status columns: `tested`, `failed`, `not selected`, or `not supported by scenario`.
+- Per-engine workbook validation status and validation time.
+- Per-engine median file size and memory deltas.
+
+`metadata.json` records exact module versions including prerelease labels,
+machine/runtime details, selected engines/scenarios, module cache paths,
+OfficeIMO root, and output paths.
 
 ## Notes
 
 The benchmark records failures as rows in `excel-performance-results.csv` instead of hiding them. That makes unsupported competitor scenarios visible without stopping the whole run.
 
 Install behavior is controlled by `-SkipImportExcelInstall` and `-SkipExcelFastInstall`. Without those switches, missing competitor modules are saved into the benchmark module cache under `Ignore`.
+
+Workbook validation is enabled by default for export scenarios. Use
+`-SkipWorkbookValidation` only when you need raw timing without post-export
+open/OpenXML checks.

--- a/README.MD
+++ b/README.MD
@@ -276,6 +276,56 @@ $data | Export-OfficeExcel -Path .\Report.xlsx -WorksheetName 'Data' -TableName 
 Import-OfficeExcel -Path .\Report.xlsx -WorksheetName 'Data'
 ```
 
+### Excel benchmark snapshot
+
+The benchmark harness in `Benchmarks\Compare-ExcelPerformance.ps1` compares
+`Export-OfficeExcel` / `Import-OfficeExcel` with `ImportExcel` and `ExcelFast`
+on repeatable local workloads. The table below is a local snapshot, not a
+universal performance promise: hardware, PowerShell version, data shape,
+formatting, and workbook features all matter.
+
+Run context: PowerShell 7.5.5, AMD Ryzen 9 9950X3D2 16-Core Processor
+(16 cores / 32 logical processors), 64 GB RAM, Standard suite, median of three
+runs, measured on 2026-06-22.
+
+| Scenario | Rows | Winner | PSWriteOffice 1.0.3 / OfficeIMO.Excel 0.6.47 | ImportExcel 7.8.10 | ExcelFast 0.0.1-alpha16 | Relative time (winner = 1x) |
+| --- | ---: | --- | ---: | ---: | ---: | --- |
+| Export objects default | 1k | PSWriteOffice | 16 ms | 183 ms | 126 ms | PSWriteOffice 1x; ImportExcel 11.44x; ExcelFast 7.88x |
+| Export objects default | 10k | PSWriteOffice | 84 ms | 1,287 ms | 153 ms | PSWriteOffice 1x; ImportExcel 15.32x; ExcelFast 1.82x |
+| Export objects default | 25k | PSWriteOffice | 199 ms | 3,827 ms | 233 ms | PSWriteOffice 1x; ImportExcel 19.23x; ExcelFast 1.17x |
+| Export wide objects default | 1k | PSWriteOffice | 26 ms | 166 ms | 127 ms | PSWriteOffice 1x; ImportExcel 6.38x; ExcelFast 4.88x |
+| Export wide objects default | 10k | PSWriteOffice | 256 ms | 1,231 ms | 296 ms | PSWriteOffice 1x; ImportExcel 4.81x; ExcelFast 1.16x |
+| Export wide objects default | 25k | PSWriteOffice | 679 ms | 3,832 ms | 1,134 ms | PSWriteOffice 1x; ImportExcel 5.64x; ExcelFast 1.67x |
+| Import mixed objects full sheet | 1k | PSWriteOffice | 9 ms | 52 ms | 32 ms | PSWriteOffice 1x; ImportExcel 5.78x; ExcelFast 3.56x |
+| Import mixed objects full sheet | 10k | PSWriteOffice | 98 ms | 383 ms | 311 ms | PSWriteOffice 1x; ImportExcel 3.91x; ExcelFast 3.17x |
+| Import mixed objects full sheet | 25k | PSWriteOffice | 333 ms | 3,083 ms | 881 ms | PSWriteOffice 1x; ImportExcel 9.26x; ExcelFast 2.65x |
+| Report workbook with table, chart, pivot, formatting | 1k | PSWriteOffice | 98 ms | 214 ms | n/a | PSWriteOffice 1x; ImportExcel 2.18x; ExcelFast n/a |
+| Report workbook with table, chart, pivot, formatting | 10k | PSWriteOffice | 1,134 ms | 1,560 ms | n/a | PSWriteOffice 1x; ImportExcel 1.38x; ExcelFast n/a |
+| Report workbook with table, chart, pivot, formatting | 25k | PSWriteOffice | 3,677 ms | 3,929 ms | n/a | PSWriteOffice 1x; ImportExcel 1.07x; ExcelFast n/a |
+| Export regional workbook, one table per sheet | 1k | PSWriteOffice | 105 ms | 248 ms | n/a | PSWriteOffice 1x; ImportExcel 2.36x; ExcelFast n/a |
+| Export regional workbook, one table per sheet | 10k | PSWriteOffice | 735 ms | 1,509 ms | n/a | PSWriteOffice 1x; ImportExcel 2.05x; ExcelFast n/a |
+| Export regional workbook, one table per sheet | 25k | PSWriteOffice | 2,003 ms | 3,611 ms | n/a | PSWriteOffice 1x; ImportExcel 1.8x; ExcelFast n/a |
+| Export title, offset header, frozen top row | 1k | ImportExcel | 251 ms | 222 ms | n/a | PSWriteOffice 1.13x; ImportExcel 1x; ExcelFast n/a |
+| Export title, offset header, frozen top row | 10k | PSWriteOffice | 735 ms | 1,370 ms | n/a | PSWriteOffice 1x; ImportExcel 1.86x; ExcelFast n/a |
+| Export title, offset header, frozen top row | 25k | PSWriteOffice | 1,828 ms | 3,290 ms | n/a | PSWriteOffice 1x; ImportExcel 1.8x; ExcelFast n/a |
+| Export data workbook with summary formulas | 1k | PSWriteOffice | 53 ms | 192 ms | n/a | PSWriteOffice 1x; ImportExcel 3.62x; ExcelFast n/a |
+| Export data workbook with summary formulas | 10k | PSWriteOffice | 507 ms | 1,449 ms | n/a | PSWriteOffice 1x; ImportExcel 2.86x; ExcelFast n/a |
+| Export data workbook with summary formulas | 25k | PSWriteOffice | 1,531 ms | 3,254 ms | n/a | PSWriteOffice 1x; ImportExcel 2.13x; ExcelFast n/a |
+
+To compare on your machine, run:
+
+```powershell
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Standard
+```
+
+The benchmark output also records exact module prerelease versions, machine and
+runtime metadata, per-engine support status, file sizes, and memory deltas in
+the generated CSV/JSON files. Export scenarios are also opened after generation
+and checked with Open XML validation when the validator is available. The full
+scenario list includes append, existing-workbook update, many-sheet, named
+range, chart-only, pivot-only, and read-focused workloads. See
+`Benchmarks\README.md` for the artifact schema and scenario list.
+
 ### Excel readers
 
 ```powershell

--- a/Roadmap/OfficeIMO-SupportMatrix.md
+++ b/Roadmap/OfficeIMO-SupportMatrix.md
@@ -1,6 +1,6 @@
 # PSWriteOffice and OfficeIMO Support Matrix
 
-Date: 2026-06-11
+Date: 2026-06-21
 
 This matrix is the current planning companion for `OfficeIMO-Showcase-PolishPlan.md`.
 For the ImportExcel and PSWriteWord competitive crosswalk, see
@@ -16,6 +16,284 @@ For the ImportExcel and PSWriteWord competitive crosswalk, see
 - `Engine gap`: needs OfficeIMO work first or upstream API stabilization.
 - `Deferred`: useful, but outside core scope unless approved.
 
+## Latest OfficeIMO Release Review
+
+Latest checked release: `OfficeIMO 2026.06.16-19.47.03`
+(`OfficeIMO-v20260616194703`).
+
+The newest OfficeIMO releases since the previous matrix are mostly engine
+hardening and fidelity improvements rather than brand-new PSWriteOffice command
+families:
+
+- Security/resource guardrails: chart number-format parsing, VML image reads,
+  Visio comment XML loading, Excel style table preallocation, formula range
+  materialization, and HTML table span expansion now have tighter bounds in
+  OfficeIMO.
+- PDF fidelity: document table workflows, typography/conversion diagnostics,
+  HTML PDF proof contracts, PDF page chunk action deduplication, and default
+  table-style preservation in converters improved in OfficeIMO.Pdf and related
+  converter packages.
+- Reader/ingestion: YAML, RTF, EPUB, ZIP, HTML, CSV, JSON, XML, Visio, and PDF
+  modular adapters are now part of the package set PSWriteOffice references.
+  PSWriteOffice already registers these adapters through the Reader command
+  utilities, so the next gap is examples/profiles rather than package wiring.
+- Word/Markdown/PDF: Word Markdown conversion fidelity, Word PDF conversion
+  fidelity, native Markdown projection, and Word block insertion ordering
+  improved in OfficeIMO. Existing PSWriteOffice conversion commands benefit from
+  the package bump through the normal OfficeIMO APIs.
+- Excel: direct tabular range handling improved in OfficeIMO.Excel. Existing
+  import/export/range/table commands should stay thin and use the normal
+  OfficeIMO reader/writer APIs.
+
+Exposure guidance:
+
+- Do not add PSWriteOffice-only fast paths for save/performance. Keep using the
+  standard OfficeIMO APIs and let OfficeIMO choose optimized internals.
+- Add focused Reader profiles next: folder ingest presets, deterministic JSONL
+  export, format include/exclude presets, and cookbook examples that prove
+  YAML/RTF/EPUB/ZIP ingestion in real workflows.
+- Add PDF table style depth next because OfficeIMO now preserves default table
+  styles through converters and already owns rich `PdfTableStyle` behavior.
+- Improve examples for Word Markdown/PDF and HTML/PDF conversion so users can
+  see the fidelity improvements without needing to read OfficeIMO release notes.
+- Keep Google Workspace, Markup, and MarkdownRenderer packages out of the module
+  until PSWriteOffice gets an intentional command surface for those workflows.
+
+## Latest OfficeIMO PR Assessment
+
+Checked on 2026-06-21 against the latest merged OfficeIMO PRs:
+
+- `#1984 Improve Markdown PDF visual rendering`
+- `#1983 Add shared HTML engine platform contracts`
+- `#1982 Improve Excel and PowerPoint PDF conversion fidelity`
+- `#1981 Improve native Word PDF engine parity`
+- `#1980 Add shared HTML diagnostics and gallery contracts`
+
+The Word-specific follow-up also checked `#1978 Improve Word market readiness`
+because it is the recent PR that introduced the structured Word comparison
+result shape.
+
+### PR 1984: Markdown PDF visuals
+
+OfficeIMO added richer Markdown-to-PDF rendering: shared Markdown visual themes,
+PDF-specific figure styling, chart semantic-fence rendering, image-only
+paragraph handling, captions/placeholders, front-matter theme resolution, and
+conversion warnings/reports.
+
+PSWriteOffice currently exposes `New-OfficeMarkdown -PdfPath` and
+`Save-OfficeMarkdown -PdfPath`, but both call `SaveAsPdf(path)` without
+friendly access to `MarkdownPdfSaveOptions`.
+
+Recommended PSWriteOffice work:
+
+- Add a shared Markdown PDF option builder used by both `New-OfficeMarkdown` and
+  `Save-OfficeMarkdown`.
+- Expose a compact parameter surface first: `-PdfTheme`, `-PdfOptions`,
+  `-PdfFontFamily`, `-PdfBaseDirectory`, `-PdfIncludeLocalImages`,
+  `-PdfIncludeDataUriImages`, `-PdfDefaultImageWidth`,
+  `-PdfDefaultImageHeight`, `-PdfFrontMatterRenderMode`,
+  `-PdfUseFrontMatterVisualTheme`, `-PdfUseFrontMatterMetadata`,
+  `-PdfCreateOutlineFromHeadings`, and an optional warning/report output hook.
+- Add examples proving Markdown chart fences, image captions, front matter, and
+  the built-in `Plain`, `WordLike`, `TechnicalDocument`, `GitHubLike`,
+  `Compact`, and `Report` visual themes.
+
+### PR 1983: Shared HTML engine platform
+
+OfficeIMO added shared HTML conversion profiles, logical document/resource
+manifests, computed-style support, diagnostic catalogs, round-trip scoring, and
+profile contracts. Existing PSWriteOffice HTML commands already expose basic
+HTML-to-Word, HTML-to-Markdown, and HTML-to-PDF workflows, but not the new shared
+profile and diagnostics model.
+
+Recommended PSWriteOffice work:
+
+- Add `-ConversionProfile` to HTML-backed commands where it maps cleanly:
+  `ConvertFrom-OfficeWordHtml`, `ConvertFrom-OfficeMarkdownHtml`, and
+  `ConvertFrom-OfficePdfHtml`. For PDF, keep `HtmlPdfProfile` as the rendering
+  path selector and use `HtmlConversionProfile` for semantic/document/print
+  intent when building nested options.
+- Add diagnostics/report output hooks for HTML conversions, such as
+  `-DiagnosticVariable`, `-ConversionReportVariable`, or a `-PassReport` mode.
+- Add safety/profile switches for common workflows: untrusted HTML, trusted
+  document HTML, and visual/print review. Do not expose every low-level URL
+  policy collection as first-class parameters initially; accept `-Options` for
+  advanced callers.
+- Add cookbook examples for invoice/report/contract/email/dashboard-print
+  scenarios that show blocked resources and diagnostics.
+
+### PR 1982: Excel and PowerPoint PDF fidelity
+
+OfficeIMO improved Excel chart title propagation, Excel `FitToHeight` scaling,
+PowerPoint common preset geometry rendering, inherited-layout shapes, and
+straight connector rendering in PDF output.
+
+PSWriteOffice already exposes the relevant inputs:
+
+- `Set-OfficeExcelPageSetup -FitToHeight`
+- `Set-OfficeExcelPrintArea`
+- Excel chart commands and PDF sidecar export through `New/Save-OfficeExcel`
+- `Add-OfficePowerPointShape` with Open XML shape preset names
+- PowerPoint PDF sidecar export through `New/Save-OfficePowerPoint`
+
+Recommended PSWriteOffice work:
+
+- No new wrapper parameters are needed for this PR.
+- Add or refresh examples that deliberately prove Excel chart titles,
+  `FitToHeight`, print areas, PowerPoint triangles/arrows/connectors, and
+  layout-inherited shapes survive `-PdfPath`.
+- Add focused Pester/readback smoke tests only for the PSWriteOffice command
+  contract. The shape geometry and layout fidelity remain OfficeIMO engine
+  tests.
+
+### Word diffs from PRs 1981, 1980, 1978
+
+OfficeIMO's recent Word work adds meaningful wrapper opportunities:
+
+- `#1981` improved native Word PDF parity across headers/footers, lists,
+  columns, paragraph spacing, tables, structured blocks, table style defaults,
+  conditional borders/padding, and diagnostics. PSWriteOffice currently exposes
+  only `-PdfPath`; it should add a shared Word PDF option builder for
+  `New-OfficeWord` and `Save-OfficeWord` that maps to
+  `OfficeIMO.Word.Pdf.PdfSaveOptions`.
+- `#1980` added shared HTML diagnostics and gallery contracts. Together with
+  `#1983`, this makes HTML import/reporting a first-class surface rather than
+  just a conversion helper.
+- `#1978` added `WordDocumentComparer.CompareStructure()` with deterministic
+  `WordComparisonResult` and findings across paragraphs, tables, rows, cells,
+  images, and block order. PSWriteOffice has no Word comparison cmdlet today.
+
+Recommended PSWriteOffice work:
+
+- Add `Compare-OfficeWordDocument` with two modes: a revision-mark document
+  mode using `WordDocumentComparer.Compare()` and a machine-readable mode using
+  `CompareStructure()`. Let callers save the diff document with `-OutputPath`
+  and optionally return findings through `-PassThru` or `-AsJson`.
+- Add Word PDF options to `New-OfficeWord` and `Save-OfficeWord`: `-PdfOptions`,
+  `-PdfFontFamily`, `-PdfAllowSystemFontEmbedding`, `-PdfPageSize`,
+  `-PdfOrientation`, `-PdfTitle`, `-PdfAuthor`, `-PdfSubject`, `-PdfKeywords`,
+  `-PdfIncludePageNumbers`, `-PdfPageNumberFormat`, `-PdfDefaultTableBorders`,
+  and a conversion report/warning output hook.
+- Expand `ConvertFrom-OfficeWordHtml` with `-ConversionProfile`,
+  `-HtmlProfile` presets for OfficeIMO, untrusted HTML, and trusted document
+  HTML, plus diagnostics/report output. Keep an advanced `-Options` escape
+  hatch for low-level URL/resource policies.
+- Expand `ConvertFrom-OfficeWordMarkdown` with `-Theme`,
+  `-AllowDataUriImages`, `-MaxDataUriImageBytes`, and warning/image-layout
+  diagnostic output. The command already exposes the core local/remote image
+  and fitting knobs.
+- Add examples that prove the new OfficeIMO engine work through PSWriteOffice:
+  Word PDF with headers, lists, columns, table styles, and structured blocks;
+  Word HTML import with diagnostics; Word Markdown import with themed output;
+  and a Word compare report that can be used in CI.
+
+## Markdown and PDF Exposure Assessment
+
+OfficeIMO now has enough shared Markdown/PDF option objects that PSWriteOffice
+should expose workflow-sized presets rather than one switch for every engine
+property.
+
+### Markdown engine capabilities worth exposing
+
+OfficeIMO.Markdown provides:
+
+- Reader dialect profiles: `OfficeIMO`, `CommonMark`,
+  `GitHubFlavoredMarkdown`, and `Portable`.
+- Reader safety/compatibility switches for front matter, callouts, task lists,
+  tables, definition lists, TOC placeholders, footnotes, raw/inline HTML,
+  autolinks, URL-scheme restrictions, max input length, and base URI.
+- Markdown writer profiles: OfficeIMO, portable, and HTML-image output, plus
+  image rendering mode, line endings, and unordered list marker.
+- Shared visual themes: `Plain`, `WordLike`, `TechnicalDocument`,
+  `GitHubLike`, `Compact`, and `Report`, with optional color schemes and table
+  styling.
+- Input-normalization presets for loose documentation imports and
+  transcript/model-output cleanup.
+- Semantic visual transforms that upgrade chart/network/dataview JSON fences
+  into typed semantic fenced blocks.
+- HTML conversion controls for base URI, script/style stripping, unsupported
+  HTML preservation, base64 image handling, listing-card metadata suppression,
+  markdown write options, and max input length.
+
+Recommended PSWriteOffice work:
+
+- Implemented first tranche: shared reader/write/PDF option helpers now expose
+  friendly Markdown profiles, URL safety, input normalization, HTML visual
+  themes, Markdown writer profiles, image rendering mode, line endings,
+  unordered list markers, and Markdown PDF metadata/theme/image/report options
+  across the existing Markdown commands, including `Get-OfficeMarkdown`.
+- Add visual-fence support as one focused switch, for example
+  `-EnableVisualFences`, with a small enum for preserve/generic/IntelligenceX
+  fence language output. Keep custom parser/renderer extensions as `-Options`.
+- Keep expanding examples so parsing, HTML, Word, and PDF flows show the same
+  dialect and safety surface.
+
+Defer:
+
+- Do not expose parser extension collections, inline renderer delegates,
+  custom HTML block converters, or visual round-trip hint collections as named
+  PowerShell parameters. Accept the native `-Options` object for those advanced
+  cases.
+
+### Markdown-to-PDF capabilities worth exposing
+
+OfficeIMO.Markdown.Pdf provides `MarkdownPdfSaveOptions` with:
+
+- PDF engine pass-through through `PdfOptions`.
+- Shared `MarkdownVisualTheme` and PDF-specific `MarkdownPdfVisualTheme`.
+- Built-in PDF themes: `Plain`, `WordLike`, `TechnicalDocument`,
+  `GitHubLike`, `Compact`, and `Report`.
+- Front matter theme/metadata handling, front matter render mode, first heading
+  as title, and outline creation from headings.
+- Explicit PDF metadata: title, author, subject, and keywords.
+- Local/data URI/remote image controls, base directory confinement, max image
+  byte limits, fallback image dimensions, warnings, and conversion report.
+
+Recommended PSWriteOffice work:
+
+- Implemented first tranche: `New-OfficeMarkdown` and `Save-OfficeMarkdown`
+  share a Markdown PDF option builder and expose first-class parameters for
+  `-PdfTheme`, `-PdfOptions`, `-PdfFontFamily`, metadata, base directory, image
+  controls, front matter behavior, first-heading title, heading outlines,
+  warning capture, and conversion-report capture.
+- Consider a direct `ConvertFrom-OfficeMarkdownPdf` cmdlet for file/text/document
+  input parity.
+
+### PDF engine capabilities worth exposing
+
+PSWriteOffice already wraps a substantial part of OfficeIMO.Pdf: document
+creation, themes, metadata, page setup, headers/footers, background color/image,
+background shapes, page borders, text/heading/list/table/panel/image/row
+composition, rich text runs, bookmarks, attachments, form fields, stamps, page
+operations, readback, preflight, compliance readiness, and HTML/PDF conversion.
+
+The best remaining PDF gaps are not basic block authoring; they are workflow
+options that make generated PDFs easier to ship:
+
+- Add `-Theme` directly to `New-OfficePdf` in addition to the DSL
+  `PdfTheme` command, and include a `Plain` preset if OfficeIMO adds or exposes
+  one for PDF themes.
+- Add catalog/viewer options: catalog page mode/layout, open action,
+  display-document-title, page labels, outline expansion level, document
+  language, and URI base.
+- Add diagnostics/report output for generated PDFs, HTML-to-PDF, Word-to-PDF,
+  and Markdown-to-PDF using the shared `PdfConversionReport` pattern.
+- Expand compliance/invoice workflows: expose Factur-X/ZUGFeRD groundwork,
+  invoice XML attachment, output intent selection, and embedded-file
+  relationships as a focused invoice/compliance command rather than making users
+  build raw `PdfOptions`.
+- Add generated-PDF font fallback helpers for common host font families, but
+  keep arbitrary embedded-font collection editing as an advanced `PdfOptions`
+  scenario.
+- Add generated annotation helpers for text/free-text/highlight annotations if
+  OfficeIMO.Pdf block APIs are stable enough for thin cmdlets.
+
+Defer:
+
+- Do not mirror every `PdfOptions` catalog/font/style property as a top-level
+  `New-OfficePdf` parameter. Keep advanced composition through DSL commands,
+  hashtable style builders, or native `PdfOptions` objects.
+
 ## Word
 
 | Capability | Status | Notes |
@@ -30,7 +308,7 @@ For the ImportExcel and PSWriteWord competitive crosswalk, see
 | Backgrounds and watermarks | Wrapped | Color/image backgrounds and watermarking exist |
 | Content controls | Wrapped | Checkbox, date, dropdown, combo, picture, repeating section |
 | Charts | Wrapped | Good enough for showcase reports |
-| HTML and Markdown conversion | Wrapped | Useful for sidecar previews/blog code |
+| HTML and Markdown conversion | Partial wrapper | Useful for sidecar previews/blog code; latest OfficeIMO profile/theme/diagnostic options need friendlier parameters |
 | Mail merge | Wrapped | Suitable for practical examples |
 | Footnotes/endnotes | Wrapped | Add/read wrappers return document-safe note snapshots |
 | Page setup and columns | Wrapped | `Set-OfficeWordPageSetup` covers page size, orientation, margins, and columns |
@@ -38,11 +316,12 @@ For the ImportExcel and PSWriteWord competitive crosswalk, see
 | Text boxes and shapes | Partial wrapper | `Add/Get/Set-OfficeWordShape` exposes basic shape authoring and styling; text boxes and richer templates remain |
 | Cover pages | Wrapped | `Add-OfficeWordCoverPage` exposes stable OfficeIMO templates and basic cover metadata |
 | Append/merge documents | Wrapped | `Join-OfficeWordDocument` appends one or more documents into a base document |
+| Document comparison | Wrapper gap | OfficeIMO exposes revision-mark comparison and structured findings through `WordDocumentComparer`; add `Compare-OfficeWordDocument` |
 | Equations and tab stops | Wrapped | `Add-OfficeWordEquation` and `Add-OfficeWordTabStop` expose stable OfficeIMO.Word APIs |
 | Document statistics | Wrapped | `Get-OfficeWordStatistics` exposes page/paragraph/word/object counts |
 | Macros | Deferred | Keep preview-only if added |
 | SmartArt authoring | Deferred | Detection/read helpers are safer first |
-| PDF export | Wrapped | `New/Save-OfficeWord -PdfPath` use OfficeIMO.Word.Pdf sidecar export |
+| PDF export | Partial wrapper | `New/Save-OfficeWord -PdfPath` use OfficeIMO.Word.Pdf sidecar export; expose `PdfSaveOptions` and report/warning hooks next |
 
 ## Excel
 
@@ -139,10 +418,11 @@ For the ImportExcel and PSWriteWord competitive crosswalk, see
 
 ## Recommended Next PRs
 
-1. Word run/paragraph style, row/column table mutation, and text box helpers.
-2. PowerPoint metrics/visual-frame helpers, fit diagnostics, and shape layout polish.
-3. Visio grouping/layer/layout and semantic diagram builder wrappers after OfficeIMO.Visio stabilizes the high-level workflows.
-4. OfficeIMO engine confidence for Excel pivot/sparkline desktop-open compatibility.
+1. Word comparison, Word PDF options/report hooks, and HTML/Markdown conversion diagnostics.
+2. Word run/paragraph style, row/column table mutation, and text box helpers.
+3. PowerPoint metrics/visual-frame helpers, fit diagnostics, and shape layout polish.
+4. Visio grouping/layer/layout and semantic diagram builder wrappers after OfficeIMO.Visio stabilizes the high-level workflows.
+5. OfficeIMO engine confidence for Excel pivot/sparkline desktop-open compatibility.
 
 ## Example Quality Bar
 

--- a/Sources/PSWriteOffice/Cmdlets/Markdown/ConvertFromOfficeMarkdownHtmlCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Markdown/ConvertFromOfficeMarkdownHtmlCommand.cs
@@ -4,6 +4,7 @@ using System.Management.Automation;
 using System.Text;
 using OfficeIMO.Markdown;
 using OfficeIMO.Markdown.Html;
+using PSWriteOffice.Services.Markdown;
 
 namespace PSWriteOffice.Cmdlets.Markdown;
 
@@ -25,6 +26,7 @@ namespace PSWriteOffice.Cmdlets.Markdown;
 [Alias("ConvertFrom-MarkdownHtml")]
 [OutputType(typeof(string), typeof(FileInfo), typeof(MarkdownDoc))]
 public sealed class ConvertFromOfficeMarkdownHtmlCommand : PSCmdlet
+    , IMarkdownWriteOptionSource
 {
     private const string ParameterSetHtml = "Html";
     private const string ParameterSetPath = "Path";
@@ -82,6 +84,42 @@ public sealed class ConvertFromOfficeMarkdownHtmlCommand : PSCmdlet
     /// <summary>Maximum input length, in characters, accepted by the converter.</summary>
     [Parameter]
     public int? MaxInputCharacters { get; set; }
+
+    /// <summary>Controls how base64 data URI images are converted.</summary>
+    [Parameter]
+    public HtmlBase64ImageHandling? Base64ImageHandling { get; set; }
+
+    /// <summary>Output directory for decoded base64 images when saving them to files.</summary>
+    [Parameter]
+    public string? Base64ImageOutputDirectory { get; set; }
+
+    /// <summary>Controls whether repeated listing-card metadata is preserved or suppressed.</summary>
+    [Parameter]
+    public HtmlListingCardMetadataMode? ListingCardMetadataMode { get; set; }
+
+    /// <summary>Maximum logical columns produced by expanding HTML table spans.</summary>
+    [Parameter]
+    public int? MaxTableExpandedColumns { get; set; }
+
+    /// <summary>Optional Markdown writer options for generated Markdown text.</summary>
+    [Parameter]
+    public MarkdownWriteOptions? WriteOptions { get; set; }
+
+    /// <summary>Friendly Markdown writer profile for generated Markdown text.</summary>
+    [Parameter]
+    public OfficeMarkdownWriteProfile? WriteProfile { get; set; }
+
+    /// <summary>Controls how generated Markdown images are serialized.</summary>
+    [Parameter]
+    public MarkdownImageRenderingMode? ImageRenderingMode { get; set; }
+
+    /// <summary>Markdown line ending: CRLF, LF, CR, or a literal line ending string.</summary>
+    [Parameter]
+    public string? LineEnding { get; set; }
+
+    /// <summary>Unordered list marker: '-', '*', or '+'.</summary>
+    [Parameter]
+    public string? UnorderedListMarker { get; set; }
 
     /// <inheritdoc />
     protected override void ProcessRecord()
@@ -172,6 +210,32 @@ public sealed class ConvertFromOfficeMarkdownHtmlCommand : PSCmdlet
         if (MaxInputCharacters.HasValue)
         {
             options.MaxInputCharacters = MaxInputCharacters.Value;
+        }
+
+        if (Base64ImageHandling.HasValue)
+        {
+            options.Base64Images = Base64ImageHandling.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(Base64ImageOutputDirectory))
+        {
+            options.Base64ImageOutputDirectory = SessionState.Path.GetUnresolvedProviderPathFromPSPath(Base64ImageOutputDirectory);
+        }
+
+        if (ListingCardMetadataMode.HasValue)
+        {
+            options.ListingCardMetadataMode = ListingCardMetadataMode.Value;
+        }
+
+        if (MaxTableExpandedColumns.HasValue)
+        {
+            options.MaxTableExpandedColumns = MaxTableExpandedColumns.Value;
+        }
+
+        var writeOptions = MarkdownOptionUtilities.BuildWriteOptions(this);
+        if (writeOptions != null)
+        {
+            options.MarkdownWriteOptions = writeOptions;
         }
 
         if (!string.IsNullOrWhiteSpace(BaseUri))

--- a/Sources/PSWriteOffice/Cmdlets/Markdown/ConvertToOfficeMarkdownHtmlCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Markdown/ConvertToOfficeMarkdownHtmlCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Management.Automation;
 using OfficeIMO.Markdown;
+using PSWriteOffice.Services.Markdown;
 
 namespace PSWriteOffice.Cmdlets.Markdown;
 
@@ -23,6 +24,7 @@ namespace PSWriteOffice.Cmdlets.Markdown;
 [Alias("ConvertTo-MarkdownHtml")]
 [OutputType(typeof(string), typeof(FileInfo))]
 public sealed class ConvertToOfficeMarkdownHtmlCommand : PSCmdlet
+    , IMarkdownReaderOptionSource
 {
     private const string ParameterSetPath = "Path";
     private const string ParameterSetText = "Text";
@@ -74,6 +76,106 @@ public sealed class ConvertToOfficeMarkdownHtmlCommand : PSCmdlet
     [Parameter]
     public MarkdownReaderOptions.MarkdownDialectProfile? Profile { get; set; }
 
+    /// <summary>Base URI used to resolve and restrict relative Markdown links and images.</summary>
+    [Parameter]
+    public string? BaseUri { get; set; }
+
+    /// <summary>Maximum Markdown input length accepted by the reader.</summary>
+    [Parameter]
+    public int? MaxInputCharacters { get; set; }
+
+    /// <summary>Applies a built-in Markdown input normalization preset before parsing.</summary>
+    [Parameter]
+    public MarkdownInputNormalizationPreset? NormalizeInput { get; set; }
+
+    /// <summary>Block file URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? DisallowFileUrls { get; set; }
+
+    /// <summary>Allow data URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? AllowDataUrls { get; set; }
+
+    /// <summary>Allow mailto URLs while parsing Markdown links.</summary>
+    [Parameter]
+    public bool? AllowMailtoUrls { get; set; }
+
+    /// <summary>Allow protocol-relative URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? AllowProtocolRelativeUrls { get; set; }
+
+    /// <summary>Restrict parsed URL schemes to the allow-list.</summary>
+    [Parameter]
+    public bool? RestrictUrlSchemes { get; set; }
+
+    /// <summary>Allowed URL schemes when URL scheme restriction is enabled.</summary>
+    [Parameter]
+    public string[]? AllowedUrlScheme { get; set; }
+
+    /// <summary>Shared Markdown visual theme for HTML output.</summary>
+    [Parameter]
+    public MarkdownVisualThemeKind? Theme { get; set; }
+
+    /// <summary>Controls how raw HTML blocks are emitted.</summary>
+    [Parameter]
+    public RawHtmlHandling? RawHtmlHandling { get; set; }
+
+    /// <summary>Add anchor links to headings.</summary>
+    [Parameter]
+    public SwitchParameter IncludeAnchorLinks { get; set; }
+
+    /// <summary>Emit GitHub-compatible task-list HTML.</summary>
+    [Parameter]
+    public SwitchParameter GitHubTaskListHtml { get; set; }
+
+    /// <summary>Emit GitHub-compatible footnote HTML.</summary>
+    [Parameter]
+    public SwitchParameter GitHubFootnoteHtml { get; set; }
+
+    /// <summary>Open external HTTP(S) links in a new tab.</summary>
+    [Parameter]
+    public SwitchParameter ExternalLinksTargetBlank { get; set; }
+
+    /// <summary>rel attribute value for external HTTP(S) links.</summary>
+    [Parameter]
+    public string? ExternalLinksRel { get; set; }
+
+    /// <summary>referrerpolicy value for external HTTP(S) links.</summary>
+    [Parameter]
+    public string? ExternalLinksReferrerPolicy { get; set; }
+
+    /// <summary>Restrict absolute HTTP(S) links to the base origin.</summary>
+    [Parameter]
+    public SwitchParameter RestrictHttpLinksToBaseOrigin { get; set; }
+
+    /// <summary>Restrict absolute HTTP(S) images to the base origin.</summary>
+    [Parameter]
+    public SwitchParameter RestrictHttpImagesToBaseOrigin { get; set; }
+
+    /// <summary>Block all absolute external HTTP(S) images.</summary>
+    [Parameter]
+    public SwitchParameter BlockExternalHttpImages { get; set; }
+
+    /// <summary>Add loading="lazy" to rendered images.</summary>
+    [Parameter]
+    public SwitchParameter ImagesLoadingLazy { get; set; }
+
+    /// <summary>Add decoding="async" to rendered images.</summary>
+    [Parameter]
+    public SwitchParameter ImagesDecodingAsync { get; set; }
+
+    /// <summary>referrerpolicy value for rendered images.</summary>
+    [Parameter]
+    public string? ImagesReferrerPolicy { get; set; }
+
+    /// <summary>Allowed HTTP(S) link hosts.</summary>
+    [Parameter]
+    public string[]? AllowedHttpLinkHost { get; set; }
+
+    /// <summary>Allowed HTTP(S) image hosts.</summary>
+    [Parameter]
+    public string[]? AllowedHttpImageHost { get; set; }
+
     /// <summary>Emit a <see cref="FileInfo"/> when saving to disk.</summary>
     [Parameter]
     public SwitchParameter PassThru { get; set; }
@@ -81,14 +183,7 @@ public sealed class ConvertToOfficeMarkdownHtmlCommand : PSCmdlet
     /// <inheritdoc />
     protected override void ProcessRecord()
     {
-        if (ReaderOptions != null && Profile.HasValue)
-        {
-            throw new PSArgumentException("Specify either -ReaderOptions or -Profile, not both.");
-        }
-
-        var readerOptions = ReaderOptions ?? (Profile.HasValue
-            ? MarkdownReaderOptions.CreateProfile(Profile.Value)
-            : null);
+        var readerOptions = MarkdownOptionUtilities.BuildReaderOptions(this);
 
         MarkdownDoc document;
         if (ParameterSetName == ParameterSetDocument)
@@ -117,6 +212,8 @@ public sealed class ConvertToOfficeMarkdownHtmlCommand : PSCmdlet
             AssetMode = AssetMode
         };
 
+        ApplyHtmlOptions(options);
+
         if (!string.IsNullOrWhiteSpace(Title))
         {
             options.Title = Title!;
@@ -142,6 +239,68 @@ public sealed class ConvertToOfficeMarkdownHtmlCommand : PSCmdlet
             WriteObject(options.Kind == HtmlKind.Document
                 ? document.ToHtmlDocument(options)
                 : document.ToHtmlFragment(options));
+        }
+    }
+
+    private void ApplyHtmlOptions(HtmlOptions options)
+    {
+        if (Theme.HasValue)
+        {
+            options.VisualTheme = MarkdownOptionUtilities.CreateTheme(Theme.Value);
+        }
+
+        if (RawHtmlHandling.HasValue)
+        {
+            options.RawHtmlHandling = RawHtmlHandling.Value;
+        }
+
+        options.IncludeAnchorLinks = IncludeAnchorLinks.IsPresent;
+        options.GitHubTaskListHtml = GitHubTaskListHtml.IsPresent;
+        options.GitHubFootnoteHtml = GitHubFootnoteHtml.IsPresent;
+        options.ExternalLinksTargetBlank = ExternalLinksTargetBlank.IsPresent;
+        options.RestrictHttpLinksToBaseOrigin = RestrictHttpLinksToBaseOrigin.IsPresent;
+        options.RestrictHttpImagesToBaseOrigin = RestrictHttpImagesToBaseOrigin.IsPresent;
+        options.BlockExternalHttpImages = BlockExternalHttpImages.IsPresent;
+        options.ImagesLoadingLazy = ImagesLoadingLazy.IsPresent;
+        options.ImagesDecodingAsync = ImagesDecodingAsync.IsPresent;
+
+        if (!string.IsNullOrWhiteSpace(BaseUri) && Uri.TryCreate(BaseUri, UriKind.Absolute, out var baseUri))
+        {
+            options.BaseUri = baseUri;
+        }
+
+        if (!string.IsNullOrWhiteSpace(ExternalLinksRel))
+        {
+            options.ExternalLinksRel = ExternalLinksRel!;
+        }
+
+        if (!string.IsNullOrWhiteSpace(ExternalLinksReferrerPolicy))
+        {
+            options.ExternalLinksReferrerPolicy = ExternalLinksReferrerPolicy!;
+        }
+
+        if (!string.IsNullOrWhiteSpace(ImagesReferrerPolicy))
+        {
+            options.ImagesReferrerPolicy = ImagesReferrerPolicy!;
+        }
+
+        AddRange(options.AllowedHttpLinkHosts, AllowedHttpLinkHost);
+        AddRange(options.AllowedHttpImageHosts, AllowedHttpImageHost);
+    }
+
+    private static void AddRange(System.Collections.Generic.ICollection<string> target, string[]? values)
+    {
+        if (values == null)
+        {
+            return;
+        }
+
+        foreach (var value in values)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                target.Add(value);
+            }
         }
     }
 }

--- a/Sources/PSWriteOffice/Cmdlets/Markdown/GetOfficeMarkdownCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Markdown/GetOfficeMarkdownCommand.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Management.Automation;
 using OfficeIMO.Markdown;
+using PSWriteOffice.Services.Markdown;
 
 namespace PSWriteOffice.Cmdlets.Markdown;
 
@@ -21,6 +22,7 @@ namespace PSWriteOffice.Cmdlets.Markdown;
 [Cmdlet(VerbsCommon.Get, "OfficeMarkdown", DefaultParameterSetName = ParameterSetPath)]
 [OutputType(typeof(MarkdownDoc))]
 public sealed class GetOfficeMarkdownCommand : PSCmdlet
+    , IMarkdownReaderOptionSource
 {
     private const string ParameterSetPath = "Path";
     private const string ParameterSetText = "Text";
@@ -36,23 +38,55 @@ public sealed class GetOfficeMarkdownCommand : PSCmdlet
 
     /// <summary>Optional reader options.</summary>
     [Parameter]
+    [Alias("ReaderOptions")]
     public MarkdownReaderOptions? Options { get; set; }
 
     /// <summary>Named reader profile used when <see cref="Options"/> is not supplied.</summary>
     [Parameter]
     public MarkdownReaderOptions.MarkdownDialectProfile? Profile { get; set; }
 
+    /// <summary>Base URI used to resolve and restrict relative Markdown links and images.</summary>
+    [Parameter]
+    public string? BaseUri { get; set; }
+
+    /// <summary>Maximum Markdown input length accepted by the reader.</summary>
+    [Parameter]
+    public int? MaxInputCharacters { get; set; }
+
+    /// <summary>Applies a built-in Markdown input normalization preset before parsing.</summary>
+    [Parameter]
+    public MarkdownInputNormalizationPreset? NormalizeInput { get; set; }
+
+    /// <summary>Block file URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? DisallowFileUrls { get; set; }
+
+    /// <summary>Allow data URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? AllowDataUrls { get; set; }
+
+    /// <summary>Allow mailto URLs while parsing Markdown links.</summary>
+    [Parameter]
+    public bool? AllowMailtoUrls { get; set; }
+
+    /// <summary>Allow protocol-relative URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? AllowProtocolRelativeUrls { get; set; }
+
+    /// <summary>Restrict parsed URL schemes to the allow-list.</summary>
+    [Parameter]
+    public bool? RestrictUrlSchemes { get; set; }
+
+    /// <summary>Allowed URL schemes when URL scheme restriction is enabled.</summary>
+    [Parameter]
+    public string[]? AllowedUrlScheme { get; set; }
+
+    MarkdownReaderOptions? IMarkdownReaderOptionSource.ReaderOptions => Options;
+
     /// <inheritdoc />
     protected override void ProcessRecord()
     {
-        if (Options != null && Profile.HasValue)
-        {
-            throw new PSArgumentException("Specify either -Options or -Profile, not both.");
-        }
-
-        var options = Options ?? (Profile.HasValue
-            ? MarkdownReaderOptions.CreateProfile(Profile.Value)
-            : null);
+        var options = MarkdownOptionUtilities.BuildReaderOptions(this);
 
         MarkdownDoc document;
         if (ParameterSetName == ParameterSetPath)

--- a/Sources/PSWriteOffice/Cmdlets/Markdown/GetOfficeMarkdownFrontMatterCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Markdown/GetOfficeMarkdownFrontMatterCommand.cs
@@ -25,6 +25,7 @@ namespace PSWriteOffice.Cmdlets.Markdown;
 [Cmdlet(VerbsCommon.Get, "OfficeMarkdownFrontMatter", DefaultParameterSetName = ParameterSetPath)]
 [OutputType(typeof(FrontMatterBlock.Entry))]
 public sealed class GetOfficeMarkdownFrontMatterCommand : PSCmdlet
+    , IMarkdownReaderOptionSource
 {
     private const string ParameterSetDocument = "Document";
     private const string ParameterSetPath = "Path";
@@ -45,15 +46,54 @@ public sealed class GetOfficeMarkdownFrontMatterCommand : PSCmdlet
 
     /// <summary>Optional reader options used when parsing path or text input.</summary>
     [Parameter]
+    [Alias("ReaderOptions")]
     public MarkdownReaderOptions? Options { get; set; }
 
     /// <summary>Named reader profile used when <see cref="Options"/> is not supplied.</summary>
     [Parameter]
     public MarkdownReaderOptions.MarkdownDialectProfile? Profile { get; set; }
 
+    /// <summary>Base URI used to resolve and restrict relative Markdown links and images.</summary>
+    [Parameter]
+    public string? BaseUri { get; set; }
+
+    /// <summary>Maximum Markdown input length accepted by the reader.</summary>
+    [Parameter]
+    public int? MaxInputCharacters { get; set; }
+
+    /// <summary>Applies a built-in Markdown input normalization preset before parsing.</summary>
+    [Parameter]
+    public MarkdownInputNormalizationPreset? NormalizeInput { get; set; }
+
+    /// <summary>Block file URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? DisallowFileUrls { get; set; }
+
+    /// <summary>Allow data URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? AllowDataUrls { get; set; }
+
+    /// <summary>Allow mailto URLs while parsing Markdown links.</summary>
+    [Parameter]
+    public bool? AllowMailtoUrls { get; set; }
+
+    /// <summary>Allow protocol-relative URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? AllowProtocolRelativeUrls { get; set; }
+
+    /// <summary>Restrict parsed URL schemes to the allow-list.</summary>
+    [Parameter]
+    public bool? RestrictUrlSchemes { get; set; }
+
+    /// <summary>Allowed URL schemes when URL scheme restriction is enabled.</summary>
+    [Parameter]
+    public string[]? AllowedUrlScheme { get; set; }
+
     /// <summary>Optional wildcard pattern matched against front matter keys.</summary>
     [Parameter]
     public string? Key { get; set; }
+
+    MarkdownReaderOptions? IMarkdownReaderOptionSource.ReaderOptions => Options;
 
     /// <summary>Use case-sensitive matching for key filters.</summary>
     [Parameter]
@@ -69,8 +109,7 @@ public sealed class GetOfficeMarkdownFrontMatterCommand : PSCmdlet
             Document,
             InputPath,
             Text,
-            Options,
-            Profile);
+            this);
 
         var wildcardOptions = CaseSensitive
             ? WildcardOptions.None

--- a/Sources/PSWriteOffice/Cmdlets/Markdown/GetOfficeMarkdownHeadingCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Markdown/GetOfficeMarkdownHeadingCommand.cs
@@ -21,6 +21,7 @@ namespace PSWriteOffice.Cmdlets.Markdown;
 [Cmdlet(VerbsCommon.Get, "OfficeMarkdownHeading", DefaultParameterSetName = ParameterSetPath)]
 [OutputType(typeof(MarkdownDoc.HeadingInfo))]
 public sealed class GetOfficeMarkdownHeadingCommand : PSCmdlet
+    , IMarkdownReaderOptionSource
 {
     private const string ParameterSetDocument = "Document";
     private const string ParameterSetPath = "Path";
@@ -41,16 +42,55 @@ public sealed class GetOfficeMarkdownHeadingCommand : PSCmdlet
 
     /// <summary>Optional reader options used when parsing path or text input.</summary>
     [Parameter]
+    [Alias("ReaderOptions")]
     public MarkdownReaderOptions? Options { get; set; }
 
     /// <summary>Named reader profile used when <see cref="Options"/> is not supplied.</summary>
     [Parameter]
     public MarkdownReaderOptions.MarkdownDialectProfile? Profile { get; set; }
 
+    /// <summary>Base URI used to resolve and restrict relative Markdown links and images.</summary>
+    [Parameter]
+    public string? BaseUri { get; set; }
+
+    /// <summary>Maximum Markdown input length accepted by the reader.</summary>
+    [Parameter]
+    public int? MaxInputCharacters { get; set; }
+
+    /// <summary>Applies a built-in Markdown input normalization preset before parsing.</summary>
+    [Parameter]
+    public MarkdownInputNormalizationPreset? NormalizeInput { get; set; }
+
+    /// <summary>Block file URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? DisallowFileUrls { get; set; }
+
+    /// <summary>Allow data URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? AllowDataUrls { get; set; }
+
+    /// <summary>Allow mailto URLs while parsing Markdown links.</summary>
+    [Parameter]
+    public bool? AllowMailtoUrls { get; set; }
+
+    /// <summary>Allow protocol-relative URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? AllowProtocolRelativeUrls { get; set; }
+
+    /// <summary>Restrict parsed URL schemes to the allow-list.</summary>
+    [Parameter]
+    public bool? RestrictUrlSchemes { get; set; }
+
+    /// <summary>Allowed URL schemes when URL scheme restriction is enabled.</summary>
+    [Parameter]
+    public string[]? AllowedUrlScheme { get; set; }
+
     /// <summary>Minimum heading level to return.</summary>
     [Parameter]
     [ValidateRange(1, 6)]
     public int MinLevel { get; set; } = 1;
+
+    MarkdownReaderOptions? IMarkdownReaderOptionSource.ReaderOptions => Options;
 
     /// <summary>Maximum heading level to return.</summary>
     [Parameter]
@@ -84,8 +124,7 @@ public sealed class GetOfficeMarkdownHeadingCommand : PSCmdlet
             Document,
             InputPath,
             Text,
-            Options,
-            Profile);
+            this);
 
         var wildcardOptions = CaseSensitive
             ? WildcardOptions.None

--- a/Sources/PSWriteOffice/Cmdlets/Markdown/GetOfficeMarkdownNodeCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Markdown/GetOfficeMarkdownNodeCommand.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Management.Automation;
 using System.Text;
 using OfficeIMO.Markdown;
+using PSWriteOffice.Services.Markdown;
 
 namespace PSWriteOffice.Cmdlets.Markdown;
 
@@ -23,6 +24,7 @@ namespace PSWriteOffice.Cmdlets.Markdown;
 [Cmdlet(VerbsCommon.Get, "OfficeMarkdownNode", DefaultParameterSetName = ParameterSetPath)]
 [OutputType(typeof(PSObject), typeof(MarkdownObject))]
 public sealed class GetOfficeMarkdownNodeCommand : PSCmdlet
+    , IMarkdownReaderOptionSource
 {
     private const string ParameterSetDocument = "Document";
     private const string ParameterSetPath = "Path";
@@ -43,15 +45,54 @@ public sealed class GetOfficeMarkdownNodeCommand : PSCmdlet
 
     /// <summary>Optional reader options used when parsing path or text input.</summary>
     [Parameter]
+    [Alias("ReaderOptions")]
     public MarkdownReaderOptions? Options { get; set; }
 
     /// <summary>Named reader profile used when <see cref="Options"/> is not supplied.</summary>
     [Parameter]
     public MarkdownReaderOptions.MarkdownDialectProfile? Profile { get; set; }
 
+    /// <summary>Base URI used to resolve and restrict relative Markdown links and images.</summary>
+    [Parameter]
+    public string? BaseUri { get; set; }
+
+    /// <summary>Maximum Markdown input length accepted by the reader.</summary>
+    [Parameter]
+    public int? MaxInputCharacters { get; set; }
+
+    /// <summary>Applies a built-in Markdown input normalization preset before parsing.</summary>
+    [Parameter]
+    public MarkdownInputNormalizationPreset? NormalizeInput { get; set; }
+
+    /// <summary>Block file URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? DisallowFileUrls { get; set; }
+
+    /// <summary>Allow data URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? AllowDataUrls { get; set; }
+
+    /// <summary>Allow mailto URLs while parsing Markdown links.</summary>
+    [Parameter]
+    public bool? AllowMailtoUrls { get; set; }
+
+    /// <summary>Allow protocol-relative URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? AllowProtocolRelativeUrls { get; set; }
+
+    /// <summary>Restrict parsed URL schemes to the allow-list.</summary>
+    [Parameter]
+    public bool? RestrictUrlSchemes { get; set; }
+
+    /// <summary>Allowed URL schemes when URL scheme restriction is enabled.</summary>
+    [Parameter]
+    public string[]? AllowedUrlScheme { get; set; }
+
     /// <summary>Optional wildcard pattern matched against node type names.</summary>
     [Parameter]
     public string? NodeType { get; set; }
+
+    MarkdownReaderOptions? IMarkdownReaderOptionSource.ReaderOptions => Options;
 
     /// <summary>Maximum traversal depth. Zero returns only the document root.</summary>
     [Parameter]
@@ -82,19 +123,12 @@ public sealed class GetOfficeMarkdownNodeCommand : PSCmdlet
 
     private MarkdownDoc ResolveDocument()
     {
-        if (Options != null && Profile.HasValue)
-        {
-            throw new PSArgumentException("Specify either -Options or -Profile, not both.");
-        }
-
         if (ParameterSetName == ParameterSetDocument)
         {
             return Document ?? throw new PSArgumentException("Provide a Markdown document.");
         }
 
-        var options = Options ?? (Profile.HasValue
-            ? MarkdownReaderOptions.CreateProfile(Profile.Value)
-            : null);
+        var options = MarkdownOptionUtilities.BuildReaderOptions(this);
 
         string markdown;
         if (ParameterSetName == ParameterSetPath)

--- a/Sources/PSWriteOffice/Cmdlets/Markdown/GetOfficeMarkdownTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Markdown/GetOfficeMarkdownTableCommand.cs
@@ -16,6 +16,7 @@ namespace PSWriteOffice.Cmdlets.Markdown;
 [Cmdlet(VerbsCommon.Get, "OfficeMarkdownTable", DefaultParameterSetName = ParameterSetPath)]
 [OutputType(typeof(TableBlock), typeof(PSObject))]
 public sealed class GetOfficeMarkdownTableCommand : PSCmdlet
+    , IMarkdownReaderOptionSource
 {
     private const string ParameterSetDocument = "Document";
     private const string ParameterSetPath = "Path";
@@ -36,15 +37,54 @@ public sealed class GetOfficeMarkdownTableCommand : PSCmdlet
 
     /// <summary>Optional reader options used when parsing path or text input.</summary>
     [Parameter]
+    [Alias("ReaderOptions")]
     public MarkdownReaderOptions? Options { get; set; }
 
     /// <summary>Named reader profile used when <see cref="Options"/> is not supplied.</summary>
     [Parameter]
     public MarkdownReaderOptions.MarkdownDialectProfile? Profile { get; set; }
 
+    /// <summary>Base URI used to resolve and restrict relative Markdown links and images.</summary>
+    [Parameter]
+    public string? BaseUri { get; set; }
+
+    /// <summary>Maximum Markdown input length accepted by the reader.</summary>
+    [Parameter]
+    public int? MaxInputCharacters { get; set; }
+
+    /// <summary>Applies a built-in Markdown input normalization preset before parsing.</summary>
+    [Parameter]
+    public MarkdownInputNormalizationPreset? NormalizeInput { get; set; }
+
+    /// <summary>Block file URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? DisallowFileUrls { get; set; }
+
+    /// <summary>Allow data URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? AllowDataUrls { get; set; }
+
+    /// <summary>Allow mailto URLs while parsing Markdown links.</summary>
+    [Parameter]
+    public bool? AllowMailtoUrls { get; set; }
+
+    /// <summary>Allow protocol-relative URLs while parsing Markdown links and images.</summary>
+    [Parameter]
+    public bool? AllowProtocolRelativeUrls { get; set; }
+
+    /// <summary>Restrict parsed URL schemes to the allow-list.</summary>
+    [Parameter]
+    public bool? RestrictUrlSchemes { get; set; }
+
+    /// <summary>Allowed URL schemes when URL scheme restriction is enabled.</summary>
+    [Parameter]
+    public string[]? AllowedUrlScheme { get; set; }
+
     /// <summary>Emit table rows as PowerShell objects instead of raw table blocks.</summary>
     [Parameter]
     public SwitchParameter AsObject { get; set; }
+
+    MarkdownReaderOptions? IMarkdownReaderOptionSource.ReaderOptions => Options;
 
     /// <inheritdoc />
     protected override void ProcessRecord()
@@ -56,8 +96,7 @@ public sealed class GetOfficeMarkdownTableCommand : PSCmdlet
             Document,
             InputPath,
             Text,
-            Options,
-            Profile);
+            this);
 
         foreach (var table in document.DescendantTables())
         {

--- a/Sources/PSWriteOffice/Cmdlets/Markdown/NewOfficeMarkdownCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Markdown/NewOfficeMarkdownCommand.cs
@@ -31,6 +31,8 @@ namespace PSWriteOffice.Cmdlets.Markdown;
 [Cmdlet(VerbsCommon.New, "OfficeMarkdown")]
 [OutputType(typeof(FileInfo), typeof(MarkdownDoc))]
 public sealed class NewOfficeMarkdownCommand : PSCmdlet
+    , IMarkdownWriteOptionSource
+    , IMarkdownPdfOptionSource
 {
     /// <summary>Destination path for the Markdown file.</summary>
     [Parameter(Mandatory = true, Position = 0)]
@@ -52,6 +54,118 @@ public sealed class NewOfficeMarkdownCommand : PSCmdlet
     /// <summary>Optional PDF path to create from the same Markdown document.</summary>
     [Parameter]
     public string? PdfPath { get; set; }
+
+    /// <summary>Optional Markdown writer options.</summary>
+    [Parameter]
+    public MarkdownWriteOptions? WriteOptions { get; set; }
+
+    /// <summary>Friendly Markdown writer profile.</summary>
+    [Parameter]
+    public OfficeMarkdownWriteProfile? WriteProfile { get; set; }
+
+    /// <summary>Controls how Markdown images are serialized.</summary>
+    [Parameter]
+    public MarkdownImageRenderingMode? ImageRenderingMode { get; set; }
+
+    /// <summary>Markdown line ending: CRLF, LF, CR, or a literal line ending string.</summary>
+    [Parameter]
+    public string? LineEnding { get; set; }
+
+    /// <summary>Unordered list marker: '-', '*', or '+'.</summary>
+    [Parameter]
+    public string? UnorderedListMarker { get; set; }
+
+    /// <summary>Advanced Markdown PDF options. Friendly PDF parameters override matching values.</summary>
+    [Parameter]
+    public MarkdownPdfSaveOptions? MarkdownPdfOptions { get; set; }
+
+    /// <summary>Underlying OfficeIMO.Pdf options used by Markdown PDF export.</summary>
+    [Parameter]
+    public OfficeIMO.Pdf.PdfOptions? PdfOptions { get; set; }
+
+    /// <summary>Built-in Markdown PDF visual theme.</summary>
+    [Parameter]
+    public MarkdownPdfThemeKind? PdfTheme { get; set; }
+
+    /// <summary>Default font family used by Markdown PDF export.</summary>
+    [Parameter]
+    public string? PdfFontFamily { get; set; }
+
+    /// <summary>PDF title metadata.</summary>
+    [Parameter]
+    public string? PdfTitle { get; set; }
+
+    /// <summary>PDF author metadata.</summary>
+    [Parameter]
+    public string? PdfAuthor { get; set; }
+
+    /// <summary>PDF subject metadata.</summary>
+    [Parameter]
+    public string? PdfSubject { get; set; }
+
+    /// <summary>PDF keywords metadata.</summary>
+    [Parameter]
+    public string? PdfKeywords { get; set; }
+
+    /// <summary>Base directory used to resolve local Markdown images during PDF export.</summary>
+    [Parameter]
+    public string? PdfBaseDirectory { get; set; }
+
+    /// <summary>Apply the built-in Word-like Markdown PDF baseline theme.</summary>
+    [Parameter]
+    public bool? PdfApplyWordLikeTheme { get; set; }
+
+    /// <summary>Embed supported local image files in Markdown PDF output.</summary>
+    [Parameter]
+    public bool? PdfIncludeLocalImages { get; set; }
+
+    /// <summary>Embed supported data URI images in Markdown PDF output.</summary>
+    [Parameter]
+    public bool? PdfIncludeDataUriImages { get; set; }
+
+    /// <summary>Require local images to resolve under the base directory.</summary>
+    [Parameter]
+    public bool? PdfRestrictLocalImagesToBaseDirectory { get; set; }
+
+    /// <summary>Maximum decoded bytes for one data URI image in Markdown PDF output.</summary>
+    [Parameter]
+    public int? PdfMaximumDataUriImageBytes { get; set; }
+
+    /// <summary>Fallback PDF image width in points.</summary>
+    [Parameter]
+    public double? PdfDefaultImageWidth { get; set; }
+
+    /// <summary>Fallback PDF image height in points.</summary>
+    [Parameter]
+    public double? PdfDefaultImageHeight { get; set; }
+
+    /// <summary>Controls how YAML front matter appears in the PDF body.</summary>
+    [Parameter]
+    public MarkdownPdfFrontMatterRenderMode? PdfFrontMatterRenderMode { get; set; }
+
+    /// <summary>Use front matter values to select a visual theme.</summary>
+    [Parameter]
+    public bool? PdfUseFrontMatterVisualTheme { get; set; }
+
+    /// <summary>Use front matter values as PDF metadata.</summary>
+    [Parameter]
+    public bool? PdfUseFrontMatterMetadata { get; set; }
+
+    /// <summary>Use the first Markdown heading as the PDF title when no title is supplied.</summary>
+    [Parameter]
+    public bool? PdfUseFirstHeadingAsTitle { get; set; }
+
+    /// <summary>Create PDF outlines from Markdown headings.</summary>
+    [Parameter]
+    public bool? PdfCreateOutlineFromHeadings { get; set; }
+
+    /// <summary>Variable name that receives Markdown PDF export warnings.</summary>
+    [Parameter]
+    public string? PdfWarningVariable { get; set; }
+
+    /// <summary>Variable name that receives the Markdown PDF conversion report.</summary>
+    [Parameter]
+    public string? PdfConversionReportVariable { get; set; }
 
     /// <inheritdoc />
     protected override void ProcessRecord()
@@ -78,8 +192,8 @@ public sealed class NewOfficeMarkdownCommand : PSCmdlet
             return;
         }
 
-        File.WriteAllText(fullPath, document.ToMarkdown(), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-        SavePdfIfRequested(document);
+        File.WriteAllText(fullPath, document.ToMarkdown(MarkdownOptionUtilities.BuildWriteOptions(this)), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        SavePdfIfRequested(document, Path.GetDirectoryName(fullPath));
 
         if (PassThru.IsPresent)
         {
@@ -95,7 +209,7 @@ public sealed class NewOfficeMarkdownCommand : PSCmdlet
             : Path.Combine(SessionState.Path.CurrentFileSystemLocation.Path, providerPath);
     }
 
-    private void SavePdfIfRequested(MarkdownDoc document)
+    private void SavePdfIfRequested(MarkdownDoc document, string? fallbackBaseDirectory)
     {
         if (string.IsNullOrWhiteSpace(PdfPath))
         {
@@ -104,6 +218,8 @@ public sealed class NewOfficeMarkdownCommand : PSCmdlet
 
         var pdfPath = PdfCommandUtilities.ResolvePath(this, PdfPath!);
         PdfCommandUtilities.EnsureDirectory(pdfPath);
-        document.SaveAsPdf(pdfPath);
+        var options = MarkdownOptionUtilities.BuildPdfOptions(this, this, fallbackBaseDirectory);
+        document.SaveAsPdf(pdfPath, options);
+        MarkdownOptionUtilities.SetPdfResultVariables(this, this, options);
     }
 }

--- a/Sources/PSWriteOffice/Cmdlets/Markdown/SaveOfficeMarkdownCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Markdown/SaveOfficeMarkdownCommand.cs
@@ -3,6 +3,7 @@ using System.Management.Automation;
 using System.Text;
 using OfficeIMO.Markdown;
 using OfficeIMO.Markdown.Pdf;
+using PSWriteOffice.Services.Markdown;
 using PSWriteOffice.Services.Pdf;
 
 namespace PSWriteOffice.Cmdlets.Markdown;
@@ -17,6 +18,8 @@ namespace PSWriteOffice.Cmdlets.Markdown;
 [Cmdlet(VerbsData.Save, "OfficeMarkdown")]
 [OutputType(typeof(MarkdownDoc), typeof(FileInfo))]
 public sealed class SaveOfficeMarkdownCommand : PSCmdlet
+    , IMarkdownWriteOptionSource
+    , IMarkdownPdfOptionSource
 {
     /// <summary>Markdown document to save.</summary>
     [Parameter(Mandatory = true, ValueFromPipeline = true, Position = 0)]
@@ -31,6 +34,118 @@ public sealed class SaveOfficeMarkdownCommand : PSCmdlet
     [Parameter]
     public string? PdfPath { get; set; }
 
+    /// <summary>Optional Markdown writer options.</summary>
+    [Parameter]
+    public MarkdownWriteOptions? WriteOptions { get; set; }
+
+    /// <summary>Friendly Markdown writer profile.</summary>
+    [Parameter]
+    public OfficeMarkdownWriteProfile? WriteProfile { get; set; }
+
+    /// <summary>Controls how Markdown images are serialized.</summary>
+    [Parameter]
+    public MarkdownImageRenderingMode? ImageRenderingMode { get; set; }
+
+    /// <summary>Markdown line ending: CRLF, LF, CR, or a literal line ending string.</summary>
+    [Parameter]
+    public string? LineEnding { get; set; }
+
+    /// <summary>Unordered list marker: '-', '*', or '+'.</summary>
+    [Parameter]
+    public string? UnorderedListMarker { get; set; }
+
+    /// <summary>Advanced Markdown PDF options. Friendly PDF parameters override matching values.</summary>
+    [Parameter]
+    public MarkdownPdfSaveOptions? MarkdownPdfOptions { get; set; }
+
+    /// <summary>Underlying OfficeIMO.Pdf options used by Markdown PDF export.</summary>
+    [Parameter]
+    public OfficeIMO.Pdf.PdfOptions? PdfOptions { get; set; }
+
+    /// <summary>Built-in Markdown PDF visual theme.</summary>
+    [Parameter]
+    public MarkdownPdfThemeKind? PdfTheme { get; set; }
+
+    /// <summary>Default font family used by Markdown PDF export.</summary>
+    [Parameter]
+    public string? PdfFontFamily { get; set; }
+
+    /// <summary>PDF title metadata.</summary>
+    [Parameter]
+    public string? PdfTitle { get; set; }
+
+    /// <summary>PDF author metadata.</summary>
+    [Parameter]
+    public string? PdfAuthor { get; set; }
+
+    /// <summary>PDF subject metadata.</summary>
+    [Parameter]
+    public string? PdfSubject { get; set; }
+
+    /// <summary>PDF keywords metadata.</summary>
+    [Parameter]
+    public string? PdfKeywords { get; set; }
+
+    /// <summary>Base directory used to resolve local Markdown images during PDF export.</summary>
+    [Parameter]
+    public string? PdfBaseDirectory { get; set; }
+
+    /// <summary>Apply the built-in Word-like Markdown PDF baseline theme.</summary>
+    [Parameter]
+    public bool? PdfApplyWordLikeTheme { get; set; }
+
+    /// <summary>Embed supported local image files in Markdown PDF output.</summary>
+    [Parameter]
+    public bool? PdfIncludeLocalImages { get; set; }
+
+    /// <summary>Embed supported data URI images in Markdown PDF output.</summary>
+    [Parameter]
+    public bool? PdfIncludeDataUriImages { get; set; }
+
+    /// <summary>Require local images to resolve under the base directory.</summary>
+    [Parameter]
+    public bool? PdfRestrictLocalImagesToBaseDirectory { get; set; }
+
+    /// <summary>Maximum decoded bytes for one data URI image in Markdown PDF output.</summary>
+    [Parameter]
+    public int? PdfMaximumDataUriImageBytes { get; set; }
+
+    /// <summary>Fallback PDF image width in points.</summary>
+    [Parameter]
+    public double? PdfDefaultImageWidth { get; set; }
+
+    /// <summary>Fallback PDF image height in points.</summary>
+    [Parameter]
+    public double? PdfDefaultImageHeight { get; set; }
+
+    /// <summary>Controls how YAML front matter appears in the PDF body.</summary>
+    [Parameter]
+    public MarkdownPdfFrontMatterRenderMode? PdfFrontMatterRenderMode { get; set; }
+
+    /// <summary>Use front matter values to select a visual theme.</summary>
+    [Parameter]
+    public bool? PdfUseFrontMatterVisualTheme { get; set; }
+
+    /// <summary>Use front matter values as PDF metadata.</summary>
+    [Parameter]
+    public bool? PdfUseFrontMatterMetadata { get; set; }
+
+    /// <summary>Use the first Markdown heading as the PDF title when no title is supplied.</summary>
+    [Parameter]
+    public bool? PdfUseFirstHeadingAsTitle { get; set; }
+
+    /// <summary>Create PDF outlines from Markdown headings.</summary>
+    [Parameter]
+    public bool? PdfCreateOutlineFromHeadings { get; set; }
+
+    /// <summary>Variable name that receives Markdown PDF export warnings.</summary>
+    [Parameter]
+    public string? PdfWarningVariable { get; set; }
+
+    /// <summary>Variable name that receives the Markdown PDF conversion report.</summary>
+    [Parameter]
+    public string? PdfConversionReportVariable { get; set; }
+
     /// <summary>Emit the Markdown document rather than the saved file.</summary>
     [Parameter]
     public SwitchParameter PassThru { get; set; }
@@ -43,7 +158,7 @@ public sealed class SaveOfficeMarkdownCommand : PSCmdlet
         {
             var fullPath = PdfCommandUtilities.ResolvePath(this, Path!);
             PdfCommandUtilities.EnsureDirectory(fullPath);
-            File.WriteAllText(fullPath, Document.ToMarkdown(), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            File.WriteAllText(fullPath, Document.ToMarkdown(MarkdownOptionUtilities.BuildWriteOptions(this)), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
             savedFile = new FileInfo(fullPath);
         }
 
@@ -51,9 +166,27 @@ public sealed class SaveOfficeMarkdownCommand : PSCmdlet
         {
             var pdfPath = PdfCommandUtilities.ResolvePath(this, PdfPath!);
             PdfCommandUtilities.EnsureDirectory(pdfPath);
-            Document.SaveAsPdf(pdfPath);
+            var options = MarkdownOptionUtilities.BuildPdfOptions(this, this, ResolvePdfBaseDirectory(savedFile));
+            Document.SaveAsPdf(pdfPath, options);
+            MarkdownOptionUtilities.SetPdfResultVariables(this, this, options);
         }
 
         WriteObject(PassThru.IsPresent ? Document : savedFile ?? (object)Document);
+    }
+
+    private string? ResolvePdfBaseDirectory(FileInfo? savedFile)
+    {
+        if (savedFile?.DirectoryName != null)
+        {
+            return savedFile.DirectoryName;
+        }
+
+        if (!string.IsNullOrWhiteSpace(PdfPath))
+        {
+            var pdfPath = PdfCommandUtilities.ResolvePath(this, PdfPath!);
+            return System.IO.Path.GetDirectoryName(pdfPath);
+        }
+
+        return null;
     }
 }

--- a/Sources/PSWriteOffice/Cmdlets/Pdf/NewOfficePdfCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Pdf/NewOfficePdfCommand.cs
@@ -78,6 +78,10 @@ public sealed class NewOfficePdfCommand : PSCmdlet
     [Parameter]
     public double? DefaultFontSize { get; set; }
 
+    /// <summary>Built-in OfficeIMO.Pdf theme applied before the DSL content runs.</summary>
+    [Parameter]
+    public OfficePdfThemePreset? Theme { get; set; }
+
     /// <summary>Embedded TrueType font family name for generated text.</summary>
     [Parameter]
     public string? FontFamily { get; set; }
@@ -143,6 +147,11 @@ public sealed class NewOfficePdfCommand : PSCmdlet
         if (DefaultFontSize.HasValue)
         {
             options.DefaultFontSize = DefaultFontSize.Value;
+        }
+
+        if (Theme.HasValue)
+        {
+            options.ApplyTheme(PdfThemeUtilities.ResolveTheme(Theme.Value));
         }
 
         if (!string.IsNullOrWhiteSpace(FontFamily))

--- a/Sources/PSWriteOffice/Cmdlets/Pdf/SetOfficePdfThemeCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Pdf/SetOfficePdfThemeCommand.cs
@@ -52,13 +52,6 @@ public sealed class SetOfficePdfThemeCommand : PSCmdlet
 
     private PdfTheme ResolveTheme()
     {
-        return Theme switch
-        {
-            OfficePdfThemePreset.WordLike => PdfTheme.WordLike(),
-            OfficePdfThemePreset.TechnicalDocument => PdfTheme.TechnicalDocument(),
-            OfficePdfThemePreset.Compact => PdfTheme.Compact(),
-            OfficePdfThemePreset.Report => PdfTheme.Report(),
-            _ => throw new PSArgumentOutOfRangeException(nameof(Theme), Theme, "Unsupported PDF theme preset.")
-        };
+        return PdfThemeUtilities.ResolveTheme(Theme);
     }
 }

--- a/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordMarkdownCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/ConvertFromOfficeWordMarkdownCommand.cs
@@ -107,6 +107,30 @@ public sealed class ConvertFromOfficeWordMarkdownCommand : PSCmdlet
     [Parameter]
     public MarkdownReaderOptions? ReaderOptions { get; set; }
 
+    /// <summary>Named Markdown reader profile used when <see cref="ReaderOptions"/> is not supplied.</summary>
+    [Parameter]
+    public MarkdownReaderOptions.MarkdownDialectProfile? Profile { get; set; }
+
+    /// <summary>Applies a built-in Markdown input normalization preset before parsing.</summary>
+    [Parameter]
+    public MarkdownInputNormalizationPreset? NormalizeInput { get; set; }
+
+    /// <summary>Shared Markdown visual theme for generated Word output.</summary>
+    [Parameter]
+    public MarkdownVisualThemeKind? Theme { get; set; }
+
+    /// <summary>Allow data URI Markdown images to be embedded in Word output.</summary>
+    [Parameter]
+    public bool? AllowDataUriImages { get; set; }
+
+    /// <summary>Maximum decoded size for one data URI image.</summary>
+    [Parameter]
+    public long? MaxDataUriImageBytes { get; set; }
+
+    /// <summary>Prefer narrative paragraphs for isolated single-line definition-list patterns.</summary>
+    [Parameter]
+    public SwitchParameter PreferNarrativeSingleLineDefinitions { get; set; }
+
     /// <summary>Fit Markdown images to the page content width.</summary>
     [Parameter]
     public SwitchParameter FitImagesToPageContentWidth { get; set; }
@@ -241,6 +265,11 @@ public sealed class ConvertFromOfficeWordMarkdownCommand : PSCmdlet
 
     private MarkdownToWordOptions BuildOptions()
     {
+        if (ReaderOptions != null && Profile.HasValue)
+        {
+            throw new PSArgumentException("Specify either -ReaderOptions or -Profile, not both.");
+        }
+
         var options = CreateOptions();
         options.AllowLocalImages = AllowLocalImages.IsPresent;
         options.AllowRemoteImages = AllowRemoteImages.IsPresent;
@@ -268,7 +297,40 @@ public sealed class ConvertFromOfficeWordMarkdownCommand : PSCmdlet
             options.BaseUri = ResolveBaseUri(BaseUri!);
         }
 
-        TrySetOptionProperty(options, "ReaderOptions", ReaderOptions);
+        if (Theme.HasValue)
+        {
+            options.Theme = MarkdownVisualTheme.Create(Theme.Value);
+        }
+
+        if (AllowDataUriImages.HasValue)
+        {
+            options.AllowDataUriImages = AllowDataUriImages.Value;
+        }
+
+        if (MaxDataUriImageBytes.HasValue)
+        {
+            options.MaxDataUriImageBytes = MaxDataUriImageBytes.Value;
+        }
+
+        if (PreferNarrativeSingleLineDefinitions.IsPresent)
+        {
+            options.PreferNarrativeSingleLineDefinitions = true;
+        }
+
+        var readerOptions = ReaderOptions ?? (Profile.HasValue
+            ? MarkdownReaderOptions.CreateProfile(Profile.Value)
+            : null);
+        if (readerOptions != null && NormalizeInput.HasValue)
+        {
+            readerOptions.InputNormalization.ApplyPreset(NormalizeInput.Value);
+        }
+        else if (readerOptions == null && NormalizeInput.HasValue)
+        {
+            readerOptions = MarkdownReaderOptions.CreateOfficeIMOProfile();
+            readerOptions.InputNormalization.ApplyPreset(NormalizeInput.Value);
+        }
+
+        options.ReaderOptions = readerOptions;
         TrySetOptionProperty(options, "FitImagesToPageContentWidth", FitImagesToPageContentWidth.IsPresent ? true : null);
         TrySetOptionProperty(options, "FitImagesToContextWidth", FitImagesToContextWidth.IsPresent ? true : null);
         TrySetOptionProperty(options, "MaxImageWidthPixels", MaxImageWidthPixels);

--- a/Sources/PSWriteOffice/PSWriteOffice.csproj
+++ b/Sources/PSWriteOffice/PSWriteOffice.csproj
@@ -20,7 +20,6 @@
 
     <ItemGroup>
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
-        <PackageReference Include="System.IO.Packaging" Version="10.0.8" />
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
@@ -93,35 +92,35 @@
         <ProjectReference Include="$(OfficeIMORoot)\OfficeIMO.Rtf.Pdf\OfficeIMO.Rtf.Pdf.csproj" />
     </ItemGroup>
     <ItemGroup Condition="'$(UseOfficeIMOProjectReferences)' != 'true'">
-        <PackageReference Include="OfficeIMO.Drawing" Version="1.0.20" />
-        <PackageReference Include="OfficeIMO.Word" Version="1.0.67" />
-        <PackageReference Include="OfficeIMO.Word.Markdown" Version="1.0.42" />
-        <PackageReference Include="OfficeIMO.Excel" Version="0.6.46" />
-        <PackageReference Include="OfficeIMO.PowerPoint" Version="1.0.41" />
-        <PackageReference Include="OfficeIMO.Markdown" Version="0.6.33" />
-        <PackageReference Include="OfficeIMO.Markdown.Html" Version="0.1.33" />
-        <PackageReference Include="OfficeIMO.Pdf" Version="0.1.41" />
-        <PackageReference Include="OfficeIMO.Word.Pdf" Version="1.0.39" />
-        <PackageReference Include="OfficeIMO.Excel.Pdf" Version="1.0.5" />
-        <PackageReference Include="OfficeIMO.Markdown.Pdf" Version="1.0.5" />
-        <PackageReference Include="OfficeIMO.Html.Pdf" Version="1.0.3" />
-        <PackageReference Include="OfficeIMO.PowerPoint.Pdf" Version="1.0.5" />
-        <PackageReference Include="OfficeIMO.CSV" Version="0.1.45" />
-        <PackageReference Include="OfficeIMO.Word.Html" Version="1.0.40" />
-        <PackageReference Include="OfficeIMO.Reader" Version="0.1.41" />
-        <PackageReference Include="OfficeIMO.Reader.Pdf" Version="0.0.4" />
-        <PackageReference Include="OfficeIMO.Reader.Html" Version="0.0.23" />
-        <PackageReference Include="OfficeIMO.Reader.Csv" Version="0.0.23" />
-        <PackageReference Include="OfficeIMO.Reader.Json" Version="0.0.23" />
-        <PackageReference Include="OfficeIMO.Reader.Xml" Version="0.0.23" />
-        <PackageReference Include="OfficeIMO.Reader.Yaml" Version="0.0.2" />
-        <PackageReference Include="OfficeIMO.Reader.Zip" Version="0.0.23" />
-        <PackageReference Include="OfficeIMO.Reader.Epub" Version="0.0.23" />
-        <PackageReference Include="OfficeIMO.Reader.Visio" Version="0.0.4" />
-        <PackageReference Include="OfficeIMO.Reader.Rtf" Version="0.0.2" />
-        <PackageReference Include="OfficeIMO.Visio" Version="1.0.5" />
-        <PackageReference Include="OfficeIMO.Rtf" Version="0.1.1" />
-        <PackageReference Include="OfficeIMO.Word.Rtf" Version="0.1.1" />
-        <PackageReference Include="OfficeIMO.Rtf.Pdf" Version="0.1.1" />
+        <PackageReference Include="OfficeIMO.Drawing" Version="1.0.21" />
+        <PackageReference Include="OfficeIMO.Word" Version="1.0.68" />
+        <PackageReference Include="OfficeIMO.Word.Markdown" Version="1.0.43" />
+        <PackageReference Include="OfficeIMO.Excel" Version="0.6.47" />
+        <PackageReference Include="OfficeIMO.PowerPoint" Version="1.0.42" />
+        <PackageReference Include="OfficeIMO.Markdown" Version="0.6.34" />
+        <PackageReference Include="OfficeIMO.Markdown.Html" Version="0.1.34" />
+        <PackageReference Include="OfficeIMO.Pdf" Version="0.1.42" />
+        <PackageReference Include="OfficeIMO.Word.Pdf" Version="1.0.41" />
+        <PackageReference Include="OfficeIMO.Excel.Pdf" Version="1.0.7" />
+        <PackageReference Include="OfficeIMO.Markdown.Pdf" Version="1.0.7" />
+        <PackageReference Include="OfficeIMO.Html.Pdf" Version="1.0.5" />
+        <PackageReference Include="OfficeIMO.PowerPoint.Pdf" Version="1.0.7" />
+        <PackageReference Include="OfficeIMO.CSV" Version="0.1.47" />
+        <PackageReference Include="OfficeIMO.Word.Html" Version="1.0.41" />
+        <PackageReference Include="OfficeIMO.Reader" Version="0.1.42" />
+        <PackageReference Include="OfficeIMO.Reader.Pdf" Version="0.0.6" />
+        <PackageReference Include="OfficeIMO.Reader.Html" Version="0.0.25" />
+        <PackageReference Include="OfficeIMO.Reader.Csv" Version="0.0.25" />
+        <PackageReference Include="OfficeIMO.Reader.Json" Version="0.0.25" />
+        <PackageReference Include="OfficeIMO.Reader.Xml" Version="0.0.25" />
+        <PackageReference Include="OfficeIMO.Reader.Yaml" Version="0.0.4" />
+        <PackageReference Include="OfficeIMO.Reader.Zip" Version="0.0.25" />
+        <PackageReference Include="OfficeIMO.Reader.Epub" Version="0.0.25" />
+        <PackageReference Include="OfficeIMO.Reader.Visio" Version="0.0.6" />
+        <PackageReference Include="OfficeIMO.Reader.Rtf" Version="0.0.3" />
+        <PackageReference Include="OfficeIMO.Visio" Version="1.0.7" />
+        <PackageReference Include="OfficeIMO.Rtf" Version="0.1.2" />
+        <PackageReference Include="OfficeIMO.Word.Rtf" Version="0.1.2" />
+        <PackageReference Include="OfficeIMO.Rtf.Pdf" Version="0.1.2" />
     </ItemGroup>
 </Project>

--- a/Sources/PSWriteOffice/Services/Markdown/MarkdownDocumentResolver.cs
+++ b/Sources/PSWriteOffice/Services/Markdown/MarkdownDocumentResolver.cs
@@ -14,6 +14,36 @@ internal static class MarkdownDocumentResolver
         MarkdownDoc? document,
         string? inputPath,
         string? text,
+        IMarkdownReaderOptionSource optionSource)
+    {
+        if (string.Equals(parameterSetName, documentParameterSetName, StringComparison.Ordinal))
+        {
+            return document ?? throw new PSArgumentException("Provide a Markdown document.");
+        }
+
+        var effectiveOptions = MarkdownOptionUtilities.BuildReaderOptions(optionSource);
+
+        if (!string.IsNullOrEmpty(inputPath))
+        {
+            var resolvedPath = cmdlet.SessionState.Path.GetUnresolvedProviderPathFromPSPath(inputPath);
+            if (!File.Exists(resolvedPath))
+            {
+                throw new FileNotFoundException($"File '{resolvedPath}' was not found.", resolvedPath);
+            }
+
+            return MarkdownReader.ParseFile(resolvedPath, effectiveOptions);
+        }
+
+        return MarkdownReader.Parse(text ?? string.Empty, effectiveOptions);
+    }
+
+    public static MarkdownDoc Resolve(
+        PSCmdlet cmdlet,
+        string parameterSetName,
+        string documentParameterSetName,
+        MarkdownDoc? document,
+        string? inputPath,
+        string? text,
         MarkdownReaderOptions? options,
         MarkdownReaderOptions.MarkdownDialectProfile? profile)
     {

--- a/Sources/PSWriteOffice/Services/Markdown/MarkdownOptionUtilities.cs
+++ b/Sources/PSWriteOffice/Services/Markdown/MarkdownOptionUtilities.cs
@@ -1,0 +1,252 @@
+using System;
+using System.IO;
+using System.Management.Automation;
+using OfficeIMO.Markdown;
+using OfficeIMO.Markdown.Pdf;
+using PSWriteOffice.Services.Pdf;
+
+namespace PSWriteOffice.Services.Markdown;
+
+internal interface IMarkdownReaderOptionSource
+{
+    MarkdownReaderOptions? ReaderOptions { get; }
+    MarkdownReaderOptions.MarkdownDialectProfile? Profile { get; }
+    string? BaseUri { get; }
+    int? MaxInputCharacters { get; }
+    MarkdownInputNormalizationPreset? NormalizeInput { get; }
+    bool? DisallowFileUrls { get; }
+    bool? AllowDataUrls { get; }
+    bool? AllowMailtoUrls { get; }
+    bool? AllowProtocolRelativeUrls { get; }
+    bool? RestrictUrlSchemes { get; }
+    string[]? AllowedUrlScheme { get; }
+}
+
+internal interface IMarkdownWriteOptionSource
+{
+    MarkdownWriteOptions? WriteOptions { get; }
+    OfficeMarkdownWriteProfile? WriteProfile { get; }
+    MarkdownImageRenderingMode? ImageRenderingMode { get; }
+    string? LineEnding { get; }
+    string? UnorderedListMarker { get; }
+}
+
+internal interface IMarkdownPdfOptionSource
+{
+    MarkdownPdfSaveOptions? MarkdownPdfOptions { get; }
+    OfficeIMO.Pdf.PdfOptions? PdfOptions { get; }
+    MarkdownPdfThemeKind? PdfTheme { get; }
+    string? PdfFontFamily { get; }
+    string? PdfTitle { get; }
+    string? PdfAuthor { get; }
+    string? PdfSubject { get; }
+    string? PdfKeywords { get; }
+    string? PdfBaseDirectory { get; }
+    bool? PdfApplyWordLikeTheme { get; }
+    bool? PdfIncludeLocalImages { get; }
+    bool? PdfIncludeDataUriImages { get; }
+    bool? PdfRestrictLocalImagesToBaseDirectory { get; }
+    int? PdfMaximumDataUriImageBytes { get; }
+    double? PdfDefaultImageWidth { get; }
+    double? PdfDefaultImageHeight { get; }
+    MarkdownPdfFrontMatterRenderMode? PdfFrontMatterRenderMode { get; }
+    bool? PdfUseFrontMatterVisualTheme { get; }
+    bool? PdfUseFrontMatterMetadata { get; }
+    bool? PdfUseFirstHeadingAsTitle { get; }
+    bool? PdfCreateOutlineFromHeadings { get; }
+    string? PdfWarningVariable { get; }
+    string? PdfConversionReportVariable { get; }
+}
+
+internal static class MarkdownOptionUtilities
+{
+    internal static MarkdownReaderOptions? BuildReaderOptions(IMarkdownReaderOptionSource source)
+    {
+        if (source.ReaderOptions != null && source.Profile.HasValue)
+        {
+            throw new PSArgumentException("Specify either -ReaderOptions or -Profile, not both.");
+        }
+
+        if (source.ReaderOptions == null && !source.Profile.HasValue && !HasReaderOverrides(source))
+        {
+            return null;
+        }
+
+        var options = source.ReaderOptions
+            ?? (source.Profile.HasValue
+                ? MarkdownReaderOptions.CreateProfile(source.Profile.Value)
+                : MarkdownReaderOptions.CreateOfficeIMOProfile());
+
+        if (!string.IsNullOrWhiteSpace(source.BaseUri))
+        {
+            options.BaseUri = source.BaseUri;
+        }
+
+        if (source.MaxInputCharacters.HasValue)
+        {
+            options.MaxInputCharacters = source.MaxInputCharacters.Value;
+        }
+
+        if (source.NormalizeInput.HasValue)
+        {
+            options.InputNormalization.ApplyPreset(source.NormalizeInput.Value);
+        }
+
+        if (source.DisallowFileUrls.HasValue)
+        {
+            options.DisallowFileUrls = source.DisallowFileUrls.Value;
+        }
+
+        if (source.AllowDataUrls.HasValue)
+        {
+            options.AllowDataUrls = source.AllowDataUrls.Value;
+        }
+
+        if (source.AllowMailtoUrls.HasValue)
+        {
+            options.AllowMailtoUrls = source.AllowMailtoUrls.Value;
+        }
+
+        if (source.AllowProtocolRelativeUrls.HasValue)
+        {
+            options.AllowProtocolRelativeUrls = source.AllowProtocolRelativeUrls.Value;
+        }
+
+        if (source.RestrictUrlSchemes.HasValue)
+        {
+            options.RestrictUrlSchemes = source.RestrictUrlSchemes.Value;
+        }
+
+        if (source.AllowedUrlScheme is { Length: > 0 })
+        {
+            options.AllowedUrlSchemes = source.AllowedUrlScheme;
+            options.RestrictUrlSchemes = true;
+        }
+
+        return options;
+    }
+
+    internal static MarkdownWriteOptions? BuildWriteOptions(IMarkdownWriteOptionSource source)
+    {
+        if (source.WriteOptions == null && !source.WriteProfile.HasValue && !source.ImageRenderingMode.HasValue
+            && string.IsNullOrWhiteSpace(source.LineEnding) && string.IsNullOrWhiteSpace(source.UnorderedListMarker))
+        {
+            return null;
+        }
+
+        var options = source.WriteOptions?.Clone() ?? CreateWriteProfile(source.WriteProfile);
+
+        if (source.ImageRenderingMode.HasValue)
+        {
+            options.ImageRenderingMode = source.ImageRenderingMode.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(source.LineEnding))
+        {
+            options.OutputLineEnding = ResolveLineEnding(source.LineEnding!);
+        }
+
+        if (!string.IsNullOrWhiteSpace(source.UnorderedListMarker))
+        {
+            var marker = source.UnorderedListMarker!.Trim();
+            if (marker.Length != 1)
+            {
+                throw new PSArgumentException("Unordered list marker must be '-', '*', or '+'.", nameof(source.UnorderedListMarker));
+            }
+
+            options.UnorderedListMarker = marker[0];
+        }
+
+        return options;
+    }
+
+    internal static MarkdownPdfSaveOptions BuildPdfOptions(IMarkdownPdfOptionSource source, PSCmdlet command, string? fallbackBaseDirectory)
+    {
+        var options = source.MarkdownPdfOptions ?? new MarkdownPdfSaveOptions();
+
+        if (source.PdfOptions != null) options.PdfOptions = source.PdfOptions;
+        if (source.PdfTheme.HasValue) options.VisualTheme = MarkdownPdfVisualTheme.Create(source.PdfTheme.Value);
+        if (!string.IsNullOrWhiteSpace(source.PdfFontFamily)) options.FontFamily = source.PdfFontFamily;
+        if (!string.IsNullOrWhiteSpace(source.PdfTitle)) options.Title = source.PdfTitle;
+        if (!string.IsNullOrWhiteSpace(source.PdfAuthor)) options.Author = source.PdfAuthor;
+        if (!string.IsNullOrWhiteSpace(source.PdfSubject)) options.Subject = source.PdfSubject;
+        if (!string.IsNullOrWhiteSpace(source.PdfKeywords)) options.Keywords = source.PdfKeywords;
+        if (source.PdfApplyWordLikeTheme.HasValue) options.ApplyWordLikeTheme = source.PdfApplyWordLikeTheme.Value;
+
+        if (!string.IsNullOrWhiteSpace(source.PdfBaseDirectory))
+        {
+            options.BaseDirectory = PdfCommandUtilities.ResolvePath(command, source.PdfBaseDirectory!);
+        }
+        else if (source.PdfIncludeLocalImages == true && !string.IsNullOrWhiteSpace(fallbackBaseDirectory))
+        {
+            options.BaseDirectory = Path.GetFullPath(fallbackBaseDirectory!);
+        }
+
+        if (source.PdfIncludeLocalImages.HasValue) options.IncludeLocalImages = source.PdfIncludeLocalImages.Value;
+        if (source.PdfIncludeDataUriImages.HasValue) options.IncludeDataUriImages = source.PdfIncludeDataUriImages.Value;
+        if (source.PdfRestrictLocalImagesToBaseDirectory.HasValue) options.RestrictLocalImagesToBaseDirectory = source.PdfRestrictLocalImagesToBaseDirectory.Value;
+        if (source.PdfMaximumDataUriImageBytes.HasValue) options.MaximumDataUriImageBytes = source.PdfMaximumDataUriImageBytes.Value;
+        if (source.PdfDefaultImageWidth.HasValue) options.DefaultImageWidth = source.PdfDefaultImageWidth.Value;
+        if (source.PdfDefaultImageHeight.HasValue) options.DefaultImageHeight = source.PdfDefaultImageHeight.Value;
+        if (source.PdfFrontMatterRenderMode.HasValue) options.FrontMatterRenderMode = source.PdfFrontMatterRenderMode.Value;
+        if (source.PdfUseFrontMatterVisualTheme.HasValue) options.UseFrontMatterVisualTheme = source.PdfUseFrontMatterVisualTheme.Value;
+        if (source.PdfUseFrontMatterMetadata.HasValue) options.UseFrontMatterMetadata = source.PdfUseFrontMatterMetadata.Value;
+        if (source.PdfUseFirstHeadingAsTitle.HasValue) options.UseFirstHeadingAsTitle = source.PdfUseFirstHeadingAsTitle.Value;
+        if (source.PdfCreateOutlineFromHeadings.HasValue) options.CreateOutlineFromHeadings = source.PdfCreateOutlineFromHeadings.Value;
+
+        return options;
+    }
+
+    internal static void SetPdfResultVariables(IMarkdownPdfOptionSource source, PSCmdlet command, MarkdownPdfSaveOptions options)
+    {
+        SetVariable(command, source.PdfWarningVariable, options.Warnings);
+        SetVariable(command, source.PdfConversionReportVariable, options.ConversionReport);
+    }
+
+    internal static MarkdownVisualTheme CreateTheme(MarkdownVisualThemeKind kind) => MarkdownVisualTheme.Create(kind);
+
+    private static MarkdownWriteOptions CreateWriteProfile(OfficeMarkdownWriteProfile? profile)
+    {
+        return profile switch
+        {
+            OfficeMarkdownWriteProfile.Portable => MarkdownWriteOptions.CreatePortableProfile(),
+            OfficeMarkdownWriteProfile.HtmlImage => MarkdownWriteOptions.CreateHtmlImageProfile(),
+            _ => MarkdownWriteOptions.CreateOfficeIMOProfile()
+        };
+    }
+
+    private static bool HasReaderOverrides(IMarkdownReaderOptionSource source) =>
+        !string.IsNullOrWhiteSpace(source.BaseUri)
+        || source.MaxInputCharacters.HasValue
+        || source.NormalizeInput.HasValue
+        || source.DisallowFileUrls.HasValue
+        || source.AllowDataUrls.HasValue
+        || source.AllowMailtoUrls.HasValue
+        || source.AllowProtocolRelativeUrls.HasValue
+        || source.RestrictUrlSchemes.HasValue
+        || source.AllowedUrlScheme is { Length: > 0 };
+
+    private static string ResolveLineEnding(string value)
+    {
+        return value.Trim().ToUpperInvariant() switch
+        {
+            "CRLF" => "\r\n",
+            "LF" => "\n",
+            "CR" => "\r",
+            "\\R\\N" => "\r\n",
+            "\\N" => "\n",
+            "\\R" => "\r",
+            _ => value
+        };
+    }
+
+    private static void SetVariable(PSCmdlet command, string? name, object? value)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return;
+        }
+
+        command.SessionState.PSVariable.Set(name!, value);
+    }
+}

--- a/Sources/PSWriteOffice/Services/Markdown/OfficeMarkdownWriteProfile.cs
+++ b/Sources/PSWriteOffice/Services/Markdown/OfficeMarkdownWriteProfile.cs
@@ -1,0 +1,14 @@
+namespace PSWriteOffice.Services.Markdown;
+
+/// <summary>Friendly Markdown writer profiles exposed by PSWriteOffice.</summary>
+public enum OfficeMarkdownWriteProfile
+{
+    /// <summary>OfficeIMO-flavored Markdown with rich round-trip hints.</summary>
+    OfficeIMO,
+
+    /// <summary>Portable Markdown for stricter hosts and broad compatibility.</summary>
+    Portable,
+
+    /// <summary>Markdown that emits raw HTML for images to preserve image metadata.</summary>
+    HtmlImage
+}

--- a/Sources/PSWriteOffice/Services/Pdf/PdfThemeUtilities.cs
+++ b/Sources/PSWriteOffice/Services/Pdf/PdfThemeUtilities.cs
@@ -1,0 +1,20 @@
+using System.Management.Automation;
+using OfficeIMO.Pdf;
+using PSWriteOffice.Cmdlets.Pdf;
+
+namespace PSWriteOffice.Services.Pdf;
+
+internal static class PdfThemeUtilities
+{
+    internal static PdfTheme ResolveTheme(OfficePdfThemePreset theme)
+    {
+        return theme switch
+        {
+            OfficePdfThemePreset.WordLike => PdfTheme.WordLike(),
+            OfficePdfThemePreset.TechnicalDocument => PdfTheme.TechnicalDocument(),
+            OfficePdfThemePreset.Compact => PdfTheme.Compact(),
+            OfficePdfThemePreset.Report => PdfTheme.Report(),
+            _ => throw new PSArgumentOutOfRangeException(nameof(theme), theme, "Unsupported PDF theme preset.")
+        };
+    }
+}

--- a/Tests/Pdf.Tests.ps1
+++ b/Tests/Pdf.Tests.ps1
@@ -409,10 +409,7 @@ Describe 'PDF cmdlets' {
 
     It 'applies PDF themes and decorative backgrounds' {
         $path = Join-Path $TestDrive 'styled-backgrounds.pdf'
-        $imagePath = Join-Path $TestDrive 'pixel.png'
-        [IO.File]::WriteAllBytes(
-            $imagePath,
-            [Convert]::FromBase64String('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=='))
+        $imagePath = Join-Path (Join-Path $PSScriptRoot 'Assets') 'CellImage.png'
 
         New-OfficePdf -Path $path {
             PdfTheme Report


### PR DESCRIPTION
## Summary

- Bump the OfficeIMO-backed PSWriteOffice dependency surface and document the current OfficeIMO support matrix.
- Add friendly Markdown/PDF/HTML options through shared Markdown and PDF helper services instead of duplicating mapping in each cmdlet.
- Expand the Excel benchmark harness with workbook open/OpenXML validation, append/update workflows, many-small-sheet workflows, read-focused followups, split chart/pivot scenarios, richer metadata, and README benchmark context.

## Validation

- `dotnet build .\Sources\PSWriteOffice\PSWriteOffice.csproj -c Release /p:UseOfficeIMOProjectReferences=false`
- `git diff --check`
- `git diff --cached --check`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -ListScenarios`
- Compact benchmark validation run covering default export, append/update, many-small-sheets, named range, chart-only, and pivot-only scenarios with workbook validation enabled.