### PR TITLE
Refresh benchmark suites and OfficeIMO dependencies

### DIFF
--- a/Benchmarks/Compare-CsvPerformance.ps1
+++ b/Benchmarks/Compare-CsvPerformance.ps1
@@ -19,7 +19,9 @@ param(
     [ValidateSet('Debug', 'Release')]
     [string] $PSWriteOfficeConfiguration = 'Release',
 
-    [switch] $SkipPSWriteOfficeBuild
+    [switch] $SkipPSWriteOfficeBuild,
+
+    [switch] $UpdateReadme
 )
 
 Set-StrictMode -Version Latest
@@ -35,22 +37,25 @@ if (-not (Get-Command Invoke-BenchmarkSuite -ErrorAction SilentlyContinue)) {
     throw 'The imported PSPublishModule does not expose Invoke-BenchmarkSuite.'
 }
 
-if (-not [string]::IsNullOrWhiteSpace($OfficeIMORoot)) {
-    $env:OfficeIMORoot = $OfficeIMORoot
-} elseif (-not $env:OfficeIMORoot) {
-    $env:OfficeIMORoot = Join-Path $repoRoot '.missing-officeimo'
-}
-
-if (-not $SkipPSWriteOfficeBuild.IsPresent) {
-    & dotnet build $projectPath -c $PSWriteOfficeConfiguration -v:minimal
-    if ($LASTEXITCODE -ne 0) {
-        throw "dotnet build failed for PSWriteOffice ($PSWriteOfficeConfiguration)."
+$requiresPSWriteOffice = -not $ListScenarios.IsPresent -and (@($Engine) -contains 'PSWriteOffice')
+if ($requiresPSWriteOffice) {
+    if (-not [string]::IsNullOrWhiteSpace($OfficeIMORoot)) {
+        $env:OfficeIMORoot = $OfficeIMORoot
+    } elseif (-not $env:OfficeIMORoot) {
+        $env:OfficeIMORoot = Join-Path $repoRoot '.missing-officeimo'
     }
-}
 
-$env:PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES = 'true'
-$env:PSWRITEOFFICE_DEVELOPMENT_CONFIGURATION = $PSWriteOfficeConfiguration
-Import-Module $moduleManifest -Force -ErrorAction Stop
+    if (-not $SkipPSWriteOfficeBuild.IsPresent) {
+        & dotnet build $projectPath -c $PSWriteOfficeConfiguration -v:minimal
+        if ($LASTEXITCODE -ne 0) {
+            throw "dotnet build failed for PSWriteOffice ($PSWriteOfficeConfiguration)."
+        }
+    }
+
+    $env:PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES = 'true'
+    $env:PSWRITEOFFICE_DEVELOPMENT_CONFIGURATION = $PSWriteOfficeConfiguration
+    Import-Module $moduleManifest -Force -ErrorAction Stop
+}
 
 $benchmarkVariables = @{
     Suite = $Suite
@@ -88,7 +93,7 @@ if ($ListScenarios.IsPresent) {
 
 $result = Invoke-BenchmarkSuite @invokeSplat
 $summaryPath = $result.Artifacts['summary.csv']
-if ($summaryPath) {
+if ($summaryPath -and $UpdateReadme.IsPresent) {
     & (Join-Path $PSScriptRoot 'Update-PerformanceBenchmarkReadme.ps1') `
         -SummaryPath $summaryPath `
         -ReadmePath (Join-Path $PSScriptRoot 'README.md') `

--- a/Benchmarks/Compare-CsvPerformance.ps1
+++ b/Benchmarks/Compare-CsvPerformance.ps1
@@ -37,6 +37,17 @@ if (-not (Get-Command Invoke-BenchmarkSuite -ErrorAction SilentlyContinue)) {
     throw 'The imported PSPublishModule does not expose Invoke-BenchmarkSuite.'
 }
 
+$Engine = @(
+    foreach ($engineName in @($Engine)) {
+        foreach ($part in ([string]$engineName -split ',')) {
+            $normalized = $part.Trim()
+            if (-not [string]::IsNullOrWhiteSpace($normalized)) {
+                $normalized
+            }
+        }
+    }
+) | Select-Object -Unique
+
 $requiresPSWriteOffice = -not $ListScenarios.IsPresent -and (@($Engine) -contains 'PSWriteOffice')
 if ($requiresPSWriteOffice) {
     if (-not [string]::IsNullOrWhiteSpace($OfficeIMORoot)) {

--- a/Benchmarks/Compare-CsvPerformance.ps1
+++ b/Benchmarks/Compare-CsvPerformance.ps1
@@ -8,17 +8,11 @@ param(
 
     [string[]] $Scenario,
 
-    [string[]] $Engine = @('PSWriteOffice', 'ImportExcel', 'ExcelFast'),
+    [string[]] $Engine = @('PSWriteOffice', 'NativeCsv'),
 
-    [string] $OutputDirectory = (Join-Path $PSScriptRoot '..\Ignore\Benchmarks\ExcelPerformance'),
+    [string] $OutputDirectory = (Join-Path $PSScriptRoot '..\Ignore\Benchmarks\CsvPerformance'),
 
     [switch] $ListScenarios,
-
-    [switch] $SkipWorkbookValidation,
-
-    [switch] $SkipImportExcelInstall,
-
-    [switch] $SkipExcelFastInstall,
 
     [string] $OfficeIMORoot,
 
@@ -32,7 +26,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
-$specPath = Join-Path $PSScriptRoot 'Excel\excel-performance.benchmark.ps1'
+$specPath = Join-Path $PSScriptRoot 'Csv\csv-performance.benchmark.ps1'
 $projectPath = Join-Path $repoRoot 'Sources\PSWriteOffice\PSWriteOffice.csproj'
 $moduleManifest = Join-Path $repoRoot 'PSWriteOffice.psd1'
 
@@ -61,9 +55,6 @@ Import-Module $moduleManifest -Force -ErrorAction Stop
 $benchmarkVariables = @{
     Suite = $Suite
     RowCount = if ($RowCount) { ($RowCount -join ',') } else { $null }
-    SkipWorkbookValidation = [string]$SkipWorkbookValidation.IsPresent
-    SkipImportExcelInstall = [string]$SkipImportExcelInstall.IsPresent
-    SkipExcelFastInstall = [string]$SkipExcelFastInstall.IsPresent
 }
 
 $invokeSplat = @{
@@ -101,6 +92,6 @@ if ($summaryPath) {
     & (Join-Path $PSScriptRoot 'Update-PerformanceBenchmarkReadme.ps1') `
         -SummaryPath $summaryPath `
         -ReadmePath (Join-Path $PSScriptRoot 'README.md') `
-        -BlockId ExcelComparison
+        -BlockId CsvComparison
 }
 $result

--- a/Benchmarks/Compare-CsvPerformance.ps1
+++ b/Benchmarks/Compare-CsvPerformance.ps1
@@ -48,6 +48,17 @@ $Engine = @(
     }
 ) | Select-Object -Unique
 
+$Scenario = @(
+    foreach ($scenarioName in @($Scenario)) {
+        foreach ($part in ([string]$scenarioName -split ',')) {
+            $normalized = $part.Trim()
+            if (-not [string]::IsNullOrWhiteSpace($normalized)) {
+                $normalized
+            }
+        }
+    }
+) | Select-Object -Unique
+
 $requiresPSWriteOffice = -not $ListScenarios.IsPresent -and (@($Engine) -contains 'PSWriteOffice')
 if ($requiresPSWriteOffice) {
     if (-not [string]::IsNullOrWhiteSpace($OfficeIMORoot)) {

--- a/Benchmarks/Compare-ExcelPerformance.ps1
+++ b/Benchmarks/Compare-ExcelPerformance.ps1
@@ -54,6 +54,17 @@ $Engine = @(
     }
 ) | Select-Object -Unique
 
+$Scenario = @(
+    foreach ($scenarioName in @($Scenario)) {
+        foreach ($part in ([string]$scenarioName -split ',')) {
+            $normalized = $part.Trim()
+            if (-not [string]::IsNullOrWhiteSpace($normalized)) {
+                $normalized
+            }
+        }
+    }
+) | Select-Object -Unique
+
 if (-not $ListScenarios.IsPresent -and (@($Engine) -contains 'ExcelFast')) {
     $excelFastModuleRoot = Join-Path $OutputDirectory 'Modules'
     New-Item -ItemType Directory -Force -Path $excelFastModuleRoot | Out-Null

--- a/Benchmarks/Compare-ExcelPerformance.ps1
+++ b/Benchmarks/Compare-ExcelPerformance.ps1
@@ -25,7 +25,9 @@ param(
     [ValidateSet('Debug', 'Release')]
     [string] $PSWriteOfficeConfiguration = 'Release',
 
-    [switch] $SkipPSWriteOfficeBuild
+    [switch] $SkipPSWriteOfficeBuild,
+
+    [switch] $UpdateReadme
 )
 
 Set-StrictMode -Version Latest
@@ -41,22 +43,49 @@ if (-not (Get-Command Invoke-BenchmarkSuite -ErrorAction SilentlyContinue)) {
     throw 'The imported PSPublishModule does not expose Invoke-BenchmarkSuite.'
 }
 
-if (-not [string]::IsNullOrWhiteSpace($OfficeIMORoot)) {
-    $env:OfficeIMORoot = $OfficeIMORoot
-} elseif (-not $env:OfficeIMORoot) {
-    $env:OfficeIMORoot = Join-Path $repoRoot '.missing-officeimo'
-}
+if (-not $ListScenarios.IsPresent -and (@($Engine) -contains 'ExcelFast')) {
+    $excelFastModuleRoot = Join-Path $OutputDirectory 'Modules'
+    New-Item -ItemType Directory -Force -Path $excelFastModuleRoot | Out-Null
+    if (-not (($env:PSModulePath -split [IO.Path]::PathSeparator) -contains $excelFastModuleRoot)) {
+        $env:PSModulePath = $excelFastModuleRoot + [IO.Path]::PathSeparator + $env:PSModulePath
+    }
 
-if (-not $SkipPSWriteOfficeBuild.IsPresent) {
-    & dotnet build $projectPath -c $PSWriteOfficeConfiguration -v:minimal
-    if ($LASTEXITCODE -ne 0) {
-        throw "dotnet build failed for PSWriteOffice ($PSWriteOfficeConfiguration)."
+    try {
+        if (-not (Get-Module -ListAvailable ExcelFast | Sort-Object Version -Descending | Select-Object -First 1)) {
+            if ([bool]$SkipExcelFastInstall) {
+                throw 'ExcelFast is not installed and -SkipExcelFastInstall was specified.'
+            }
+            Save-Module -Name ExcelFast -Path $excelFastModuleRoot -Repository PSGallery -AllowPrerelease -Force -ErrorAction Stop
+        }
+        Import-Module ExcelFast -Force -ErrorAction Stop
+    } catch {
+        Write-Warning "Skipping ExcelFast benchmark lanes because ExcelFast could not be prepared. $($_.Exception.Message)"
+        $Engine = @($Engine | Where-Object { $_ -ne 'ExcelFast' })
+        if ($Engine.Count -eq 0) {
+            throw 'No benchmark engines remain after ExcelFast availability checks.'
+        }
     }
 }
 
-$env:PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES = 'true'
-$env:PSWRITEOFFICE_DEVELOPMENT_CONFIGURATION = $PSWriteOfficeConfiguration
-Import-Module $moduleManifest -Force -ErrorAction Stop
+$requiresPSWriteOffice = -not $ListScenarios.IsPresent -and (@($Engine) -contains 'PSWriteOffice')
+if ($requiresPSWriteOffice) {
+    if (-not [string]::IsNullOrWhiteSpace($OfficeIMORoot)) {
+        $env:OfficeIMORoot = $OfficeIMORoot
+    } elseif (-not $env:OfficeIMORoot) {
+        $env:OfficeIMORoot = Join-Path $repoRoot '.missing-officeimo'
+    }
+
+    if (-not $SkipPSWriteOfficeBuild.IsPresent) {
+        & dotnet build $projectPath -c $PSWriteOfficeConfiguration -v:minimal
+        if ($LASTEXITCODE -ne 0) {
+            throw "dotnet build failed for PSWriteOffice ($PSWriteOfficeConfiguration)."
+        }
+    }
+
+    $env:PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES = 'true'
+    $env:PSWRITEOFFICE_DEVELOPMENT_CONFIGURATION = $PSWriteOfficeConfiguration
+    Import-Module $moduleManifest -Force -ErrorAction Stop
+}
 
 $benchmarkVariables = @{
     Suite = $Suite
@@ -97,7 +126,7 @@ if ($ListScenarios.IsPresent) {
 
 $result = Invoke-BenchmarkSuite @invokeSplat
 $summaryPath = $result.Artifacts['summary.csv']
-if ($summaryPath) {
+if ($summaryPath -and $UpdateReadme.IsPresent) {
     & (Join-Path $PSScriptRoot 'Update-PerformanceBenchmarkReadme.ps1') `
         -SummaryPath $summaryPath `
         -ReadmePath (Join-Path $PSScriptRoot 'README.md') `

--- a/Benchmarks/Compare-ExcelPerformance.ps1
+++ b/Benchmarks/Compare-ExcelPerformance.ps1
@@ -67,7 +67,10 @@ if (-not $ListScenarios.IsPresent -and (@($Engine) -contains 'ExcelFast')) {
     }
 }
 
-$requiresPSWriteOffice = -not $ListScenarios.IsPresent -and (@($Engine) -contains 'PSWriteOffice')
+$requiresPSWriteOffice = -not $ListScenarios.IsPresent -and (
+    (@($Engine) -contains 'PSWriteOffice') -or
+    -not $SkipWorkbookValidation.IsPresent
+)
 if ($requiresPSWriteOffice) {
     if (-not [string]::IsNullOrWhiteSpace($OfficeIMORoot)) {
         $env:OfficeIMORoot = $OfficeIMORoot

--- a/Benchmarks/Compare-ExcelPerformance.ps1
+++ b/Benchmarks/Compare-ExcelPerformance.ps1
@@ -43,6 +43,17 @@ if (-not (Get-Command Invoke-BenchmarkSuite -ErrorAction SilentlyContinue)) {
     throw 'The imported PSPublishModule does not expose Invoke-BenchmarkSuite.'
 }
 
+$Engine = @(
+    foreach ($engineName in @($Engine)) {
+        foreach ($part in ([string]$engineName -split ',')) {
+            $normalized = $part.Trim()
+            if (-not [string]::IsNullOrWhiteSpace($normalized)) {
+                $normalized
+            }
+        }
+    }
+) | Select-Object -Unique
+
 if (-not $ListScenarios.IsPresent -and (@($Engine) -contains 'ExcelFast')) {
     $excelFastModuleRoot = Join-Path $OutputDirectory 'Modules'
     New-Item -ItemType Directory -Force -Path $excelFastModuleRoot | Out-Null

--- a/Benchmarks/Csv/csv-performance.benchmark.ps1
+++ b/Benchmarks/Csv/csv-performance.benchmark.ps1
@@ -1,0 +1,61 @@
+. (Join-Path $PSScriptRoot '..\Excel\excel-performance.helpers.ps1')
+
+$repositoryRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..')).Path
+$suiteName = input Suite Standard
+$rowCounts = Assert-ExcelBenchmarkRowCount -RowCount (inputInt RowCount (Get-ExcelBenchmarkDefaultRowCount -Suite $suiteName))
+
+benchmark 'csv-performance' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\CsvPerformance') {
+    policy -Warmup 1 -Iterations (Get-ExcelBenchmarkIterationCount -Suite $suiteName) -Order Rotated -OutlierMode None
+    profile Current -Cleanup KeepOnFailure
+    caseSource (Get-CsvBenchmarkCase -Suite $suiteName)
+    axis RowCount $rowCounts
+
+    setup {
+        param($case, $run)
+
+        $run.RepositoryRoot = $repositoryRoot
+        $run.WorksheetName = 'Data'
+        $run.Path = $run.OutputPath + '.csv'
+        $run.SourcePath = $run.OutputPath + '.source.csv'
+        Initialize-ExcelBenchmarkEngine -Engine $case.Engine -Run $run
+    }
+
+    Set-BenchmarkDataFactory {
+        param($case, $run)
+
+        $profile = Get-ExcelBenchmarkData -Profile $case.DataProfile -Count ([int]$case.RowCount)
+        $run.Payload = $profile.Data
+        $run.ExpectedRows = [int]$case.RowCount
+        $run.ColumnCount = $profile.ColumnCount
+        Initialize-ExcelBenchmarkInput -Case $case -Run $run
+    }
+
+    skip {
+        param($case)
+
+        -not (Test-CsvBenchmarkEngineSupport -Engine $case.Engine -Case $case)
+    }
+
+    engine PSWriteOffice {
+        operation Run {
+            param($case, $run)
+            Invoke-ExcelBenchmarkOperation -Engine PSWriteOffice -Case $case -Run $run
+        }
+    }
+
+    engine NativeCsv {
+        operation Run {
+            param($case, $run)
+            Invoke-ExcelBenchmarkOperation -Engine NativeCsv -Case $case -Run $run
+        }
+    }
+
+    validate {
+        param($case, $run)
+
+        Test-CsvBenchmarkOutput -Case $case -Run $run
+    }
+
+    comparison Engine -Baseline PSWriteOffice -Metric MedianMs
+    artifacts Json, Csv, Markdown
+}

--- a/Benchmarks/Excel/excel-performance.benchmark.ps1
+++ b/Benchmarks/Excel/excel-performance.benchmark.ps1
@@ -1,0 +1,79 @@
+. (Join-Path $PSScriptRoot 'excel-performance.helpers.ps1')
+
+$repositoryRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..')).Path
+$suiteName = input Suite Standard
+$rowCounts = Assert-ExcelBenchmarkRowCount -RowCount (inputInt RowCount (Get-ExcelBenchmarkDefaultRowCount -Suite $suiteName))
+$skipWorkbookValidation = inputBool SkipWorkbookValidation false
+$skipImportExcelInstall = inputBool SkipImportExcelInstall false
+$skipExcelFastInstall = inputBool SkipExcelFastInstall false
+
+benchmark 'excel-performance' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\ExcelPerformance') {
+    policy -Warmup 1 -Iterations (Get-ExcelBenchmarkIterationCount -Suite $suiteName) -Order Rotated -OutlierMode None
+    profile Current -Cleanup KeepOnFailure
+    caseSource (Get-ExcelBenchmarkCase -Suite $suiteName)
+    axis RowCount $rowCounts
+
+    setup {
+        param($case, $run)
+
+        $run.RepositoryRoot = $repositoryRoot
+        $run.WorksheetName = 'Data'
+        $run.Path = $run.OutputPath + (Get-ExcelBenchmarkExtension -Case $case)
+        $run.SourcePath = $run.OutputPath + '.source.csv'
+        $run.SkipWorkbookValidation = $skipWorkbookValidation
+        $run.SkipImportExcelInstall = $skipImportExcelInstall
+        $run.SkipExcelFastInstall = $skipExcelFastInstall
+        $run.Range = Get-ExcelBenchmarkRange -ColumnCount (Get-ExcelBenchmarkColumnCount -Profile $case.DataProfile) -Rows ([int]$case.RowCount)
+        $run.RangeEndCell = Get-ExcelBenchmarkRangeEndCell -ColumnCount (Get-ExcelBenchmarkColumnCount -Profile $case.DataProfile) -Rows ([int]$case.RowCount)
+        Initialize-ExcelBenchmarkEngine -Engine $case.Engine -Run $run
+    }
+
+    Set-BenchmarkDataFactory {
+        param($case, $run)
+
+        $profile = Get-ExcelBenchmarkData -Profile $case.DataProfile -Count ([int]$case.RowCount)
+        $run.Payload = $profile.Data
+        $run.ExpectedRows = [int]$case.RowCount
+        $run.ColumnCount = $profile.ColumnCount
+        $run.WorksheetName = $profile.WorksheetName
+        $run.Range = Get-ExcelBenchmarkRange -ColumnCount $profile.ColumnCount -Rows ([int]$case.RowCount)
+        $run.RangeEndCell = Get-ExcelBenchmarkRangeEndCell -ColumnCount $profile.ColumnCount -Rows ([int]$case.RowCount)
+        Initialize-ExcelBenchmarkInput -Case $case -Run $run
+    }
+
+    skip {
+        param($case)
+
+        -not (Test-ExcelBenchmarkEngineSupport -Engine $case.Engine -Case $case)
+    }
+
+    engine PSWriteOffice {
+        operation Run {
+            param($case, $run)
+            Invoke-ExcelBenchmarkOperation -Engine PSWriteOffice -Case $case -Run $run
+        }
+    }
+
+    engine ImportExcel {
+        operation Run {
+            param($case, $run)
+            Invoke-ExcelBenchmarkOperation -Engine ImportExcel -Case $case -Run $run
+        }
+    }
+
+    engine ExcelFast {
+        operation Run {
+            param($case, $run)
+            Invoke-ExcelBenchmarkOperation -Engine ExcelFast -Case $case -Run $run
+        }
+    }
+
+    validate {
+        param($case, $run)
+
+        Test-ExcelBenchmarkOutput -Case $case -Run $run
+    }
+
+    comparison Engine -Baseline PSWriteOffice -Metric MedianMs
+    artifacts Json, Csv, Markdown
+}

--- a/Benchmarks/Excel/excel-performance.core.ps1
+++ b/Benchmarks/Excel/excel-performance.core.ps1
@@ -148,7 +148,8 @@ function Test-ExcelBenchmarkEngineSupport {
                 $name -ne 'dataset-worksheets'
         }
         ExcelFast {
-            return $name -in @('objects-default', 'wide-objects-default', 'import-default-full', 'import-default-range', 'read-no-header-range')
+            return $name -in @('objects-default', 'wide-objects-default', 'import-default-full', 'import-default-range', 'read-no-header-range') -and
+                [bool](Get-Module -ListAvailable ExcelFast | Sort-Object Version -Descending | Select-Object -First 1)
         }
         NativeCsv { return $false }
         default { return $false }
@@ -209,10 +210,7 @@ function Initialize-ExcelBenchmarkEngine {
         }
         ExcelFast {
             if (-not (Get-Module -ListAvailable ExcelFast | Sort-Object Version -Descending | Select-Object -First 1)) {
-                if ([bool]$Run.SkipExcelFastInstall) {
-                    throw 'ExcelFast is not installed. Rerun without -SkipExcelFastInstall to save it under the benchmark module folder.'
-                }
-                Save-Module -Name ExcelFast -Path $script:ExcelBenchmarkModuleRoot -Repository PSGallery -AllowPrerelease -Force
+                throw 'ExcelFast is not available. Use Compare-ExcelPerformance.ps1 to prepare optional ExcelFast lanes, or run without the ExcelFast engine.'
             }
             Import-Module ExcelFast -Force -ErrorAction Stop
         }

--- a/Benchmarks/Excel/excel-performance.core.ps1
+++ b/Benchmarks/Excel/excel-performance.core.ps1
@@ -1,0 +1,222 @@
+Set-StrictMode -Version Latest
+
+$script:ExcelBenchmarkModuleRoot = $null
+$script:ExcelBenchmarkPackageRoot = $null
+$script:ExcelBenchmarkInitializedEngines = [Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+
+function Get-ExcelBenchmarkDefaultRowCount {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Suite
+    )
+
+    switch ($Suite) {
+        Smoke { @(1000) }
+        Standard { @(1000, 10000, 25000) }
+        Large { @(25000, 100000, 250000) }
+        Full { @(1000, 10000, 25000, 100000) }
+        SuperLarge { @(250000, 500000, 1000000) }
+        default { @(1000, 10000, 25000) }
+    }
+}
+
+function Assert-ExcelBenchmarkRowCount {
+    param([int[]] $RowCount)
+    @(
+        foreach ($count in $RowCount) {
+            if ($count -le 0) { throw "RowCount must be greater than zero. Value: $count" }
+            $count
+        }
+    )
+}
+
+function Get-ExcelBenchmarkIterationCount {
+    param([string] $Suite)
+
+    switch ($Suite) {
+        Smoke { 1 }
+        Standard { 3 }
+        Large { 3 }
+        Full { 5 }
+        SuperLarge { 1 }
+        default { 3 }
+    }
+}
+
+function New-ExcelBenchmarkCase {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Name,
+
+        [Parameter(Mandatory)]
+        [string] $Label,
+
+        [Parameter(Mandatory)]
+        [string[]] $Suites,
+
+        [Parameter(Mandatory)]
+        [string] $OperationKey,
+
+        [Parameter(Mandatory)]
+        [string] $Profile,
+
+        [string] $FileExtension = '.xlsx',
+
+        [bool] $ValidateWorkbook = $true
+    )
+
+    [pscustomobject]@{
+        Name = $Name
+        Label = $Label
+        Suites = $Suites -join ','
+        OperationKey = $OperationKey
+        DataProfile = $Profile
+        FileExtension = $FileExtension
+        ValidateWorkbook = $ValidateWorkbook
+    }
+}
+
+function Get-ExcelBenchmarkCase {
+    param([string] $Suite)
+
+    $basic = @('Smoke', 'Standard', 'Large', 'Full', 'SuperLarge')
+    $table = @('Smoke', 'Standard', 'Large', 'Full')
+    $standard = @('Standard', 'Large', 'Full')
+    $scale = @('Standard', 'Large', 'Full', 'SuperLarge')
+    $workflow = @('Standard', 'Large', 'Full')
+    $report = @('Smoke', 'Standard', 'Large', 'Full')
+    $dataSet = @('Large', 'Full')
+
+    @(
+        New-ExcelBenchmarkCase -Name csv-to-excel -Label 'Create workbook from CSV source' -Suites $workflow -OperationKey CsvToExcel -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name objects-table -Label 'Export objects as table' -Suites $table -OperationKey WriteWorkbook -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name objects-default -Label 'Export objects default' -Suites $basic -OperationKey WriteWorkbook -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name objects-no-table -Label 'Export objects without a table' -Suites $scale -OperationKey WriteWorkbook -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name objects-table-autofit -Label 'Export objects as autofit table' -Suites $standard -OperationKey WriteWorkbook -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name objects-title-freeze -Label 'Export objects with title and frozen header' -Suites $workflow -OperationKey WriteWorkbook -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name wide-objects-default -Label 'Export wide objects default' -Suites $scale -OperationKey WriteWorkbook -Profile WideObjects
+        New-ExcelBenchmarkCase -Name datatable-default -Label 'Export DataTable default' -Suites $scale -OperationKey WriteWorkbook -Profile DataTable
+        New-ExcelBenchmarkCase -Name import-default-full -Label 'Read full sheet from default export' -Suites $basic -OperationKey ReadFullSheet -Profile MixedObjects -ValidateWorkbook:$false
+        New-ExcelBenchmarkCase -Name import-default-range -Label 'Read A1 range from default export' -Suites $scale -OperationKey ReadRange -Profile MixedObjects -ValidateWorkbook:$false
+        New-ExcelBenchmarkCase -Name read-no-header-range -Label 'Read selected range without headers' -Suites $standard -OperationKey ReadNoHeaderRange -Profile MixedObjects -ValidateWorkbook:$false
+        New-ExcelBenchmarkCase -Name read-used-range-datatable -Label 'Read used range as DataTable' -Suites $standard -OperationKey ReadUsedRangeDataTable -Profile MixedObjects -ValidateWorkbook:$false
+        New-ExcelBenchmarkCase -Name read-table-metadata -Label 'Read workbook table metadata' -Suites $standard -OperationKey ReadTableMetadata -Profile MixedObjects -ValidateWorkbook:$false
+        New-ExcelBenchmarkCase -Name multi-sheet-regions -Label 'Export regional workbook with one table per sheet' -Suites $workflow -OperationKey WriteWorkbook -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name summary-formulas -Label 'Export data workbook with summary formulas' -Suites $workflow -OperationKey WriteWorkbook -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name append-existing-table -Label 'Append rows to an existing workbook table' -Suites $workflow -OperationKey WriteWorkbook -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name update-existing-workbook -Label 'Update cells and formulas in an existing workbook' -Suites $workflow -OperationKey WriteWorkbook -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name many-small-sheets -Label 'Export many small worksheets' -Suites $workflow -OperationKey WriteWorkbook -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name workbook-package-merge -Label 'Merge workbook sheets with package copy' -Suites $workflow -OperationKey WriteWorkbook -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name named-range-workbook -Label 'Export workbook with named data range' -Suites $workflow -OperationKey WriteWorkbook -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name read-named-range-metadata -Label 'Read workbook named range metadata' -Suites $standard -OperationKey ReadNamedRangeMetadata -Profile MixedObjects -ValidateWorkbook:$false
+        New-ExcelBenchmarkCase -Name chart-only-workbook -Label 'Export workbook with table and chart' -Suites $workflow -OperationKey WriteWorkbook -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name pivot-only-workbook -Label 'Export workbook with table and pivot' -Suites $workflow -OperationKey WriteWorkbook -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name report-workbook -Label 'Export report workbook with table chart pivot formatting' -Suites $report -OperationKey WriteWorkbook -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name dataset-worksheets -Label 'Export DataSet worksheets' -Suites $dataSet -OperationKey WriteWorkbook -Profile DataSet
+    ) | Where-Object { (($_.Suites -split ',') -contains $Suite) }
+}
+
+function Get-CsvBenchmarkCase {
+    param([string] $Suite)
+
+    $csv = @('Smoke', 'Standard', 'Large', 'Full', 'SuperLarge')
+    @(
+        New-ExcelBenchmarkCase -Name csv-write -Label 'Write CSV file' -Suites $csv -OperationKey WriteCsv -Profile MixedObjects -FileExtension '.csv' -ValidateWorkbook:$false
+        New-ExcelBenchmarkCase -Name csv-read-source -Label 'Read CSV file' -Suites $csv -OperationKey ReadCsvSource -Profile MixedObjects -FileExtension '.csv' -ValidateWorkbook:$false
+    ) | Where-Object { (($_.Suites -split ',') -contains $Suite) }
+}
+
+function Test-ExcelBenchmarkEngineSupport {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Engine,
+
+        [Parameter(Mandatory)]
+        [object] $Case
+    )
+
+    $operation = [string]$Case.OperationKey
+    $name = [string]$Case.Scenario
+    if ($name.Length -eq 0 -and $Case.PSObject.Properties['Name']) {
+        $name = [string]$Case.Name
+    }
+
+    switch ($Engine) {
+        PSWriteOffice { return $true }
+        ImportExcel {
+            return $operation -notin @('WriteCsv', 'ReadCsvSource', 'ReadUsedRangeDataTable', 'ReadTableMetadata', 'ReadNamedRangeMetadata') -and
+                $name -ne 'dataset-worksheets'
+        }
+        ExcelFast {
+            return $name -in @('objects-default', 'wide-objects-default', 'import-default-full', 'import-default-range', 'read-no-header-range')
+        }
+        NativeCsv { return $false }
+        default { return $false }
+    }
+}
+
+function Test-CsvBenchmarkEngineSupport {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Engine,
+
+        [Parameter(Mandatory)]
+        [object] $Case
+    )
+
+    switch ($Engine) {
+        PSWriteOffice { return $true }
+        NativeCsv { return [string]$Case.OperationKey -in @('WriteCsv', 'ReadCsvSource') }
+        default { return $false }
+    }
+}
+
+function Initialize-ExcelBenchmarkEngine {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Engine,
+
+        [Parameter(Mandatory)]
+        [object] $Run
+    )
+
+    if ($null -eq $script:ExcelBenchmarkInitializedEngines) {
+        $script:ExcelBenchmarkInitializedEngines = [Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    }
+
+    if (-not $script:ExcelBenchmarkModuleRoot) {
+        $script:ExcelBenchmarkModuleRoot = Join-Path $Run.OutputRoot 'Modules'
+        $script:ExcelBenchmarkPackageRoot = Join-Path $Run.OutputRoot 'Packages'
+        New-Item -ItemType Directory -Force -Path $script:ExcelBenchmarkModuleRoot, $script:ExcelBenchmarkPackageRoot | Out-Null
+        if (-not (($env:PSModulePath -split [IO.Path]::PathSeparator) -contains $script:ExcelBenchmarkModuleRoot)) {
+            $env:PSModulePath = $script:ExcelBenchmarkModuleRoot + [IO.Path]::PathSeparator + $env:PSModulePath
+        }
+    }
+
+    if ($script:ExcelBenchmarkInitializedEngines.Contains($Engine)) {
+        return
+    }
+
+    switch ($Engine) {
+        ImportExcel {
+            if (-not (Get-Module -ListAvailable ImportExcel | Sort-Object Version -Descending | Select-Object -First 1)) {
+                if ([bool]$Run.SkipImportExcelInstall) {
+                    throw 'ImportExcel is not installed. Rerun without -SkipImportExcelInstall to save it under the benchmark module folder.'
+                }
+                Save-Module -Name ImportExcel -Path $script:ExcelBenchmarkModuleRoot -Repository PSGallery -Force
+            }
+            Import-Module ImportExcel -Force -ErrorAction Stop
+        }
+        ExcelFast {
+            if (-not (Get-Module -ListAvailable ExcelFast | Sort-Object Version -Descending | Select-Object -First 1)) {
+                if ([bool]$Run.SkipExcelFastInstall) {
+                    throw 'ExcelFast is not installed. Rerun without -SkipExcelFastInstall to save it under the benchmark module folder.'
+                }
+                Save-Module -Name ExcelFast -Path $script:ExcelBenchmarkModuleRoot -Repository PSGallery -AllowPrerelease -Force
+            }
+            Import-Module ExcelFast -Force -ErrorAction Stop
+        }
+    }
+
+    [void]$script:ExcelBenchmarkInitializedEngines.Add($Engine)
+}

--- a/Benchmarks/Excel/excel-performance.data.ps1
+++ b/Benchmarks/Excel/excel-performance.data.ps1
@@ -1,0 +1,240 @@
+function Get-ExcelBenchmarkData {
+    param(
+        [string] $Profile,
+        [int] $Count
+    )
+
+    switch ($Profile) {
+        MixedObjects {
+            [pscustomobject]@{ Data = @(New-ExcelBenchmarkRows -Count $Count); ColumnCount = 10; WorksheetName = 'Data' }
+        }
+        WideObjects {
+            [pscustomobject]@{ Data = @(New-ExcelBenchmarkWideRows -Count $Count); ColumnCount = 40; WorksheetName = 'Data' }
+        }
+        DataTable {
+            [pscustomobject]@{ Data = New-ExcelBenchmarkDataTable -Count $Count; ColumnCount = 6; WorksheetName = 'Data' }
+        }
+        DataSet {
+            [pscustomobject]@{ Data = New-ExcelBenchmarkDataSet -Count $Count; ColumnCount = 6; WorksheetName = 'Sales' }
+        }
+        default { throw "Unknown benchmark profile '$Profile'." }
+    }
+}
+
+function Get-ExcelBenchmarkPayloadCount {
+    param([object] $Value)
+
+    if ($Value -is [Data.DataSet]) {
+        $count = 0
+        foreach ($table in $Value.Tables) {
+            $count += $table.Rows.Count
+        }
+        return $count
+    }
+
+    if ($Value -is [Data.DataTable]) {
+        return $Value.Rows.Count
+    }
+
+    return @($Value).Count
+}
+
+function New-ExcelBenchmarkRows {
+    param([int] $Count)
+
+    for ($i = 1; $i -le $Count; $i++) {
+        [pscustomobject]@{
+            Id = $i
+            Name = 'Server-{0:000000}' -f $i
+            Department = 'Department-{0}' -f ($i % 25)
+            Region = @('NA', 'EU', 'APAC', 'LATAM')[$i % 4]
+            IsEnabled = ($i % 3) -ne 0
+            Created = ([datetime]'2024-01-01').AddMinutes($i)
+            Score = [math]::Round(($i * 1.137) % 1000, 3)
+            Owner = 'owner{0}@example.test' -f ($i % 250)
+            TicketCount = $i % 17
+            Notes = 'Benchmark row {0}' -f $i
+        }
+    }
+}
+
+function New-ExcelBenchmarkWideRows {
+    param([int] $Count)
+
+    for ($i = 1; $i -le $Count; $i++) {
+        $row = [ordered]@{
+            Id = $i
+            Name = 'Wide-{0:000000}' -f $i
+            Created = ([datetime]'2024-01-01').AddSeconds($i)
+            Enabled = ($i % 2) -eq 0
+        }
+        for ($column = 1; $column -le 36; $column++) {
+            $row["Metric$column"] = [math]::Round((($i + $column) * 1.017) % 10000, 4)
+        }
+        [pscustomobject]$row
+    }
+}
+
+function New-ExcelBenchmarkDataTable {
+    param([int] $Count)
+
+    $table = [Data.DataTable]::new('Data')
+    $null = $table.Columns.Add('Id', [int])
+    $null = $table.Columns.Add('Name', [string])
+    $null = $table.Columns.Add('Created', [datetime])
+    $null = $table.Columns.Add('Amount', [decimal])
+    $null = $table.Columns.Add('Enabled', [bool])
+    $null = $table.Columns.Add('Notes', [string])
+    for ($i = 1; $i -le $Count; $i++) {
+        $row = $table.NewRow()
+        $row.Id = $i
+        $row.Name = 'Account-{0:000000}' -f $i
+        $row.Created = ([datetime]'2024-01-01').AddMinutes($i)
+        $row.Amount = [decimal]([math]::Round(($i * 11.317) % 100000, 2))
+        $row.Enabled = ($i % 4) -ne 0
+        $row.Notes = 'DataTable row {0}' -f $i
+        $table.Rows.Add($row)
+    }
+    , $table
+}
+
+function New-ExcelBenchmarkDataSet {
+    param([int] $Count)
+
+    $dataSet = [Data.DataSet]::new('Report')
+    $sales = New-ExcelBenchmarkDataTable -Count $Count
+    $sales.TableName = 'Sales'
+    $inventory = [Data.DataTable]::new('Inventory')
+    $null = $inventory.Columns.Add('Sku', [string])
+    $null = $inventory.Columns.Add('Quantity', [int])
+    $null = $inventory.Columns.Add('Updated', [datetime])
+    for ($i = 1; $i -le ([math]::Max(1, [math]::Floor($Count / 4))); $i++) {
+        $row = $inventory.NewRow()
+        $row.Sku = 'SKU-{0:000000}' -f $i
+        $row.Quantity = $i % 500
+        $row.Updated = ([datetime]'2024-01-01').AddHours($i)
+        $inventory.Rows.Add($row)
+    }
+    $dataSet.Tables.Add($sales)
+    $dataSet.Tables.Add($inventory)
+    , $dataSet
+}
+
+function Get-ExcelBenchmarkColumnName {
+    param([int] $ColumnNumber)
+
+    $name = ''
+    $value = $ColumnNumber
+    while ($value -gt 0) {
+        $value--
+        $name = [char][int](65 + ($value % 26)) + $name
+        $value = [int][math]::Floor($value / 26)
+    }
+    $name
+}
+
+function Get-ExcelBenchmarkColumnCount {
+    param([string] $Profile)
+
+    switch ($Profile) {
+        WideObjects { 40 }
+        DataTable { 6 }
+        DataSet { 6 }
+        default { 10 }
+    }
+}
+
+function Get-ExcelBenchmarkRange {
+    param([int] $ColumnCount, [int] $Rows)
+
+    'A1:{0}{1}' -f (Get-ExcelBenchmarkColumnName -ColumnNumber $ColumnCount), ($Rows + 1)
+}
+
+function Get-ExcelBenchmarkRangeEndCell {
+    param([int] $ColumnCount, [int] $Rows)
+
+    '{0}{1}' -f (Get-ExcelBenchmarkColumnName -ColumnNumber $ColumnCount), ($Rows + 1)
+}
+
+function Get-ExcelBenchmarkExtension {
+    param([object] $Case)
+
+    $extension = [string]$Case.FileExtension
+    if ([string]::IsNullOrWhiteSpace($extension)) { return '.xlsx' }
+    if ($extension.StartsWith('.')) { return $extension }
+    ".$extension"
+}
+
+function Initialize-ExcelBenchmarkInput {
+    param([object] $Case, [object] $Run)
+
+    foreach ($path in @($Run.Path, $Run.SourcePath)) {
+        if ($path -and (Test-Path -LiteralPath $path)) {
+            Remove-Item -LiteralPath $path -Force
+        }
+    }
+
+    switch ([string]$Case.OperationKey) {
+        ReadCsvSource {
+            $Run.Payload | Export-Csv -Path $Run.SourcePath -NoTypeInformation -Encoding utf8
+        }
+        CsvToExcel {
+            $Run.Payload | Export-Csv -Path $Run.SourcePath -NoTypeInformation -Encoding utf8
+        }
+        ReadFullSheet { New-ExcelBenchmarkDefaultWorkbook -Engine $Case.Engine -Run $Run }
+        ReadRange { New-ExcelBenchmarkDefaultWorkbook -Engine $Case.Engine -Run $Run }
+        ReadNoHeaderRange { New-ExcelBenchmarkDefaultWorkbook -Engine $Case.Engine -Run $Run }
+        ReadUsedRangeDataTable { New-ExcelBenchmarkDefaultWorkbook -Engine PSWriteOffice -Run $Run }
+        ReadTableMetadata { New-ExcelBenchmarkDefaultWorkbook -Engine PSWriteOffice -Run $Run -TableName Data }
+        ReadNamedRangeMetadata { New-ExcelBenchmarkNamedRangeWorkbook -Engine PSWriteOffice -Run $Run }
+    }
+}
+
+function New-ExcelBenchmarkDefaultWorkbook {
+    param(
+        [string] $Engine,
+        [object] $Run,
+        [string] $TableName
+    )
+
+    switch ($Engine) {
+        PSWriteOffice {
+            if ($TableName) {
+                $Run.Payload | Export-OfficeExcel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName $TableName
+            } else {
+                $Run.Payload | Export-OfficeExcel -Path $Run.Path -WorksheetName $Run.WorksheetName
+            }
+        }
+        ImportExcel {
+            if ($TableName) {
+                $Run.Payload | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName $TableName -AutoFilter
+            } else {
+                $Run.Payload | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName
+            }
+        }
+        ExcelFast {
+            Export-Workbook -Destination $Run.Path -InputObject $Run.Payload -SheetName $Run.WorksheetName -Force
+        }
+        default {
+            throw "Engine '$Engine' cannot create workbook input."
+        }
+    }
+}
+
+function New-ExcelBenchmarkNamedRangeWorkbook {
+    param([string] $Engine, [object] $Run)
+
+    switch ($Engine) {
+        PSWriteOffice {
+            New-OfficeExcel -Path $Run.Path {
+                Add-OfficeExcelSheet -Name $Run.WorksheetName -Content {
+                    Add-OfficeExcelTable -Data $Run.Payload -TableName Data
+                    Set-OfficeExcelNamedRange -Name SalesData -Range $Run.Range
+                }
+            } | Out-Null
+        }
+        ImportExcel {
+            $Run.Payload | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName Data -AutoFilter -RangeName SalesData
+        }
+    }
+}

--- a/Benchmarks/Excel/excel-performance.helpers.ps1
+++ b/Benchmarks/Excel/excel-performance.helpers.ps1
@@ -1,0 +1,7 @@
+Set-StrictMode -Version Latest
+
+$helperRoot = $PSScriptRoot
+. (Join-Path $helperRoot 'excel-performance.core.ps1')
+. (Join-Path $helperRoot 'excel-performance.data.ps1')
+. (Join-Path $helperRoot 'excel-performance.operations.ps1')
+. (Join-Path $helperRoot 'excel-performance.validation.ps1')

--- a/Benchmarks/Excel/excel-performance.operations.ps1
+++ b/Benchmarks/Excel/excel-performance.operations.ps1
@@ -38,6 +38,7 @@ function Invoke-ExcelBenchmarkReadCsv {
         NativeCsv { @(Import-Csv -Path $Run.SourcePath) }
         default { throw "Engine '$Engine' does not support CSV read." }
     }
+    $Run.ActualRows = @($rows).Count
 }
 
 function Invoke-ExcelBenchmarkCsvToExcel {
@@ -76,6 +77,7 @@ function Invoke-ExcelBenchmarkReadWorkbook {
             }
         }
     }
+    $Run.ActualRows = @($rows).Count
 }
 function Invoke-ExcelBenchmarkWriteWorkbook {
     param([string] $Engine, [object] $Case, [object] $Run)

--- a/Benchmarks/Excel/excel-performance.operations.ps1
+++ b/Benchmarks/Excel/excel-performance.operations.ps1
@@ -13,9 +13,20 @@ function Invoke-ExcelBenchmarkOperation {
         ReadFullSheet { Invoke-ExcelBenchmarkReadWorkbook -Engine $Engine -Case $Case -Run $Run -Mode Full }
         ReadRange { Invoke-ExcelBenchmarkReadWorkbook -Engine $Engine -Case $Case -Run $Run -Mode Range }
         ReadNoHeaderRange { Invoke-ExcelBenchmarkReadWorkbook -Engine $Engine -Case $Case -Run $Run -Mode NoHeader }
-        ReadUsedRangeDataTable { Get-OfficeExcelUsedRange -Path $Run.Path -Sheet $Run.WorksheetName -AsDataTable | Out-Null }
-        ReadTableMetadata { Get-OfficeExcelTable -Path $Run.Path -Sheet $Run.WorksheetName | Out-Null }
-        ReadNamedRangeMetadata { Get-OfficeExcelNamedRange -Path $Run.Path -Sheet $Run.WorksheetName | Out-Null }
+        ReadUsedRangeDataTable {
+            $dataTable = Get-OfficeExcelUsedRange -Path $Run.Path -Sheet $Run.WorksheetName -AsDataTable
+            $Run.ActualRows = if ($dataTable -and $dataTable.Rows) { [int]$dataTable.Rows.Count } else { 0 }
+        }
+        ReadTableMetadata {
+            $tables = @(Get-OfficeExcelTable -Path $Run.Path -Sheet $Run.WorksheetName)
+            $Run.ActualTableCount = $tables.Count
+            $Run.ActualTableNames = @($tables | ForEach-Object { $_.Name })
+        }
+        ReadNamedRangeMetadata {
+            $ranges = @(Get-OfficeExcelNamedRange -Path $Run.Path -Sheet $Run.WorksheetName)
+            $Run.ActualNamedRangeCount = $ranges.Count
+            $Run.ActualNamedRangeNames = @($ranges | ForEach-Object { $_.Name })
+        }
         default { throw "Unknown benchmark operation '$($Case.OperationKey)'." }
     }
 }

--- a/Benchmarks/Excel/excel-performance.operations.ps1
+++ b/Benchmarks/Excel/excel-performance.operations.ps1
@@ -1,0 +1,433 @@
+function Invoke-ExcelBenchmarkOperation {
+    param(
+        [string] $Engine,
+        [object] $Case,
+        [object] $Run
+    )
+
+    switch ([string]$Case.OperationKey) {
+        WriteCsv { Invoke-ExcelBenchmarkWriteCsv -Engine $Engine -Run $Run }
+        ReadCsvSource { Invoke-ExcelBenchmarkReadCsv -Engine $Engine -Run $Run }
+        CsvToExcel { Invoke-ExcelBenchmarkCsvToExcel -Engine $Engine -Run $Run }
+        WriteWorkbook { Invoke-ExcelBenchmarkWriteWorkbook -Engine $Engine -Case $Case -Run $Run }
+        ReadFullSheet { Invoke-ExcelBenchmarkReadWorkbook -Engine $Engine -Case $Case -Run $Run -Mode Full }
+        ReadRange { Invoke-ExcelBenchmarkReadWorkbook -Engine $Engine -Case $Case -Run $Run -Mode Range }
+        ReadNoHeaderRange { Invoke-ExcelBenchmarkReadWorkbook -Engine $Engine -Case $Case -Run $Run -Mode NoHeader }
+        ReadUsedRangeDataTable { Get-OfficeExcelUsedRange -Path $Run.Path -Sheet $Run.WorksheetName -AsDataTable | Out-Null }
+        ReadTableMetadata { Get-OfficeExcelTable -Path $Run.Path -Sheet $Run.WorksheetName | Out-Null }
+        ReadNamedRangeMetadata { Get-OfficeExcelNamedRange -Path $Run.Path -Sheet $Run.WorksheetName | Out-Null }
+        default { throw "Unknown benchmark operation '$($Case.OperationKey)'." }
+    }
+}
+
+function Invoke-ExcelBenchmarkWriteCsv {
+    param([string] $Engine, [object] $Run)
+
+    switch ($Engine) {
+        PSWriteOffice { $Run.Payload | Export-OfficeCsv -Path $Run.Path }
+        NativeCsv { $Run.Payload | Export-Csv -Path $Run.Path -NoTypeInformation -Encoding utf8 -UseQuotes AsNeeded }
+        default { throw "Engine '$Engine' does not support CSV write." }
+    }
+}
+
+function Invoke-ExcelBenchmarkReadCsv {
+    param([string] $Engine, [object] $Run)
+
+    $rows = switch ($Engine) {
+        PSWriteOffice { @(Import-OfficeCsv -Path $Run.SourcePath) }
+        NativeCsv { @(Import-Csv -Path $Run.SourcePath) }
+        default { throw "Engine '$Engine' does not support CSV read." }
+    }
+}
+
+function Invoke-ExcelBenchmarkCsvToExcel {
+    param([string] $Engine, [object] $Run)
+
+    switch ($Engine) {
+        PSWriteOffice { Import-OfficeExcelDelimitedText -Path $Run.Path -SourcePath $Run.SourcePath -SheetName $Run.WorksheetName | Out-Null }
+        ImportExcel { Import-Csv -Path $Run.SourcePath | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName }
+        default { throw "Engine '$Engine' does not support CSV-to-Excel conversion." }
+    }
+}
+
+function Invoke-ExcelBenchmarkReadWorkbook {
+    param([string] $Engine, [object] $Case, [object] $Run, [string] $Mode)
+
+    switch ($Engine) {
+        PSWriteOffice {
+            $rows = switch ($Mode) {
+                Full { @(Import-OfficeExcel -Path $Run.Path -WorksheetName $Run.WorksheetName) }
+                Range { @(Import-OfficeExcel -Path $Run.Path -WorksheetName $Run.WorksheetName -Range $Run.Range) }
+                NoHeader { @(Import-OfficeExcel -Path $Run.Path -WorksheetName $Run.WorksheetName -Range $Run.Range -NoHeader) }
+            }
+        }
+        ImportExcel {
+            $rows = switch ($Mode) {
+                Full { @(Import-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName) }
+                Range { @(Import-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName -StartRow 1 -EndRow ([int]$Case.RowCount + 1) -StartColumn 1 -EndColumn $Run.ColumnCount) }
+                NoHeader { @(Import-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName -StartRow 1 -EndRow ([int]$Case.RowCount + 1) -StartColumn 1 -EndColumn $Run.ColumnCount -NoHeader) }
+            }
+        }
+        ExcelFast {
+            $rows = switch ($Mode) {
+                Full { @(Import-Workbook -Path $Run.Path -SheetName $Run.WorksheetName) }
+                Range { @(Import-Workbook -Path $Run.Path -SheetName $Run.WorksheetName -StartCell 'A1' -EndCell $Run.RangeEndCell) }
+                NoHeader { @(Import-Workbook -Path $Run.Path -SheetName $Run.WorksheetName -StartCell 'A1' -EndCell $Run.RangeEndCell -NoHeaders) }
+            }
+        }
+    }
+}
+function Invoke-ExcelBenchmarkWriteWorkbook {
+    param([string] $Engine, [object] $Case, [object] $Run)
+
+    switch ([string]$Case.Scenario) {
+        objects-table { Invoke-ExcelBenchmarkObjectsTable -Engine $Engine -Run $Run }
+        objects-default { Invoke-ExcelBenchmarkObjectsDefault -Engine $Engine -Run $Run }
+        objects-no-table { Invoke-ExcelBenchmarkObjectsNoTable -Engine $Engine -Run $Run }
+        objects-table-autofit { Invoke-ExcelBenchmarkObjectsTableAutofit -Engine $Engine -Run $Run }
+        objects-title-freeze { Invoke-ExcelBenchmarkObjectsTitleFreeze -Engine $Engine -Run $Run }
+        wide-objects-default { Invoke-ExcelBenchmarkObjectsDefault -Engine $Engine -Run $Run }
+        datatable-default { Invoke-ExcelBenchmarkDataTableDefault -Engine $Engine -Run $Run }
+        multi-sheet-regions { Invoke-ExcelBenchmarkMultiSheetRegions -Engine $Engine -Run $Run }
+        summary-formulas { Invoke-ExcelBenchmarkSummaryFormulas -Engine $Engine -Run $Run }
+        append-existing-table { Invoke-ExcelBenchmarkAppendExistingTable -Engine $Engine -Run $Run }
+        update-existing-workbook { Invoke-ExcelBenchmarkUpdateExistingWorkbook -Engine $Engine -Run $Run }
+        many-small-sheets { Invoke-ExcelBenchmarkManySmallSheets -Engine $Engine -Run $Run }
+        workbook-package-merge { Invoke-ExcelBenchmarkWorkbookPackageMerge -Engine $Engine -Run $Run }
+        named-range-workbook { New-ExcelBenchmarkNamedRangeWorkbook -Engine $Engine -Run $Run }
+        chart-only-workbook { Invoke-ExcelBenchmarkChartOnlyWorkbook -Engine $Engine -Run $Run }
+        pivot-only-workbook { Invoke-ExcelBenchmarkPivotOnlyWorkbook -Engine $Engine -Run $Run }
+        report-workbook { Invoke-ExcelBenchmarkReportWorkbook -Engine $Engine -Run $Run }
+        dataset-worksheets { Export-OfficeExcel -Path $Run.Path -InputObject $Run.Payload }
+        default { throw "Unknown workbook scenario '$($Case.Scenario)'." }
+    }
+}
+
+function Invoke-ExcelBenchmarkObjectsTable {
+    param([string] $Engine, [object] $Run)
+    switch ($Engine) {
+        PSWriteOffice { $Run.Payload | Export-OfficeExcel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName Data }
+        ImportExcel { $Run.Payload | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName Data -AutoFilter }
+    }
+}
+
+function Invoke-ExcelBenchmarkObjectsDefault {
+    param([string] $Engine, [object] $Run)
+    switch ($Engine) {
+        PSWriteOffice { $Run.Payload | Export-OfficeExcel -Path $Run.Path -WorksheetName $Run.WorksheetName }
+        ImportExcel { $Run.Payload | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName }
+        ExcelFast { Export-Workbook -Destination $Run.Path -InputObject $Run.Payload -SheetName $Run.WorksheetName -Force }
+    }
+}
+
+function Invoke-ExcelBenchmarkObjectsNoTable {
+    param([string] $Engine, [object] $Run)
+    switch ($Engine) {
+        PSWriteOffice { $Run.Payload | Export-OfficeExcel -Path $Run.Path -WorksheetName $Run.WorksheetName -NoTable }
+        ImportExcel { $Run.Payload | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName }
+    }
+}
+
+function Invoke-ExcelBenchmarkObjectsTableAutofit {
+    param([string] $Engine, [object] $Run)
+    switch ($Engine) {
+        PSWriteOffice { $Run.Payload | Export-OfficeExcel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName Data -AutoFit }
+        ImportExcel { $Run.Payload | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName Data -AutoFilter -AutoSize }
+    }
+}
+
+function Invoke-ExcelBenchmarkObjectsTitleFreeze {
+    param([string] $Engine, [object] $Run)
+    switch ($Engine) {
+        PSWriteOffice { $Run.Payload | Export-OfficeExcel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName Data -Title 'Operational export' -StartRow 3 -FreezeTopRow -BoldTopRow }
+        ImportExcel { $Run.Payload | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName Data -AutoFilter -Title 'Operational export' -StartRow 3 -FreezeTopRow -BoldTopRow }
+    }
+}
+
+function Invoke-ExcelBenchmarkDataTableDefault {
+    param([string] $Engine, [object] $Run)
+    switch ($Engine) {
+        PSWriteOffice { Export-OfficeExcel -Path $Run.Path -InputObject $Run.Payload -WorksheetName $Run.WorksheetName -TableName Data }
+        ImportExcel { $Run.Payload | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName }
+    }
+}
+
+function Invoke-ExcelBenchmarkMultiSheetRegions {
+    param([string] $Engine, [object] $Run)
+    switch ($Engine) {
+        PSWriteOffice {
+            New-OfficeExcel -Path $Run.Path {
+                foreach ($group in (Get-ExcelBenchmarkRegionGroups -Rows $Run.Payload)) {
+                    Add-OfficeExcelSheet -Name $group.Name -Content {
+                        Add-OfficeExcelTable -Data $group.Data -TableName $group.TableName
+                        Set-OfficeExcelFreeze -TopRows 1
+                    }
+                }
+            } | Out-Null
+        }
+        ImportExcel {
+            $excel = $null
+            try {
+                foreach ($group in (Get-ExcelBenchmarkRegionGroups -Rows $Run.Payload)) {
+                    $excel = if ($excel) {
+                        $group.Data | Export-Excel -ExcelPackage $excel -WorksheetName $group.Name -TableName $group.TableName -AutoFilter -FreezeTopRow -BoldTopRow -PassThru
+                    } else {
+                        $group.Data | Export-Excel -Path $Run.Path -WorksheetName $group.Name -TableName $group.TableName -AutoFilter -FreezeTopRow -BoldTopRow -PassThru
+                    }
+                }
+            } finally {
+                if ($excel) { Close-ExcelPackage -ExcelPackage $excel }
+            }
+        }
+    }
+}
+
+function Invoke-ExcelBenchmarkSummaryFormulas {
+    param([string] $Engine, [object] $Run)
+    $summaryRows = Get-ExcelBenchmarkSummaryRows -Rows ([int]$Run.Payload.Count)
+    switch ($Engine) {
+        PSWriteOffice {
+            New-OfficeExcel -Path $Run.Path {
+                Add-OfficeExcelSheet -Name $Run.WorksheetName -Content {
+                    Add-OfficeExcelTable -Data $Run.Payload -TableName Data
+                    Set-OfficeExcelFreeze -TopRows 1
+                }
+                Add-OfficeExcelSheet -Name Summary -Content {
+                    Set-OfficeExcelCell -Address A1 -Value Metric
+                    Set-OfficeExcelCell -Address B1 -Value Value
+                    $row = 2
+                    foreach ($summaryRow in $summaryRows) {
+                        Set-OfficeExcelCell -Row $row -Column 1 -Value $summaryRow.Metric
+                        Set-OfficeExcelFormula -Address ('B{0}' -f $row) -Formula $summaryRow.Formula
+                        Set-OfficeExcelCell -Row $row -Column 2 -NumberFormat $summaryRow.NumberFormat
+                        $row++
+                    }
+                }
+            } | Out-Null
+        }
+        ImportExcel {
+            $excel = $Run.Payload | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName Data -AutoFilter -FreezeTopRow -BoldTopRow -PassThru
+            try {
+                $summary = $excel.Workbook.Worksheets.Add('Summary')
+                $summary.Cells['A1'].Value = 'Metric'
+                $summary.Cells['B1'].Value = 'Value'
+                $row = 2
+                foreach ($summaryRow in $summaryRows) {
+                    $summary.Cells[$row, 1].Value = $summaryRow.Metric
+                    $summary.Cells[$row, 2].Formula = $summaryRow.Formula
+                    $summary.Cells[$row, 2].Style.Numberformat.Format = $summaryRow.NumberFormat
+                    $row++
+                }
+            } finally {
+                Close-ExcelPackage -ExcelPackage $excel
+            }
+        }
+    }
+}
+
+function Invoke-ExcelBenchmarkAppendExistingTable {
+    param([string] $Engine, [object] $Run)
+    $split = Get-ExcelBenchmarkAppendSplit -Rows $Run.Payload
+    switch ($Engine) {
+        PSWriteOffice {
+            $split.Initial | Export-OfficeExcel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName Data
+            if ($split.Append.Count -gt 0) { Add-OfficeExcelTableRow -InputPath $Run.Path -Sheet $Run.WorksheetName -TableName Data -InputObject $split.Append | Out-Null }
+        }
+        ImportExcel {
+            $split.Initial | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName Data -AutoFilter
+            if ($split.Append.Count -gt 0) { $split.Append | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName -Append }
+        }
+    }
+}
+
+function Invoke-ExcelBenchmarkUpdateExistingWorkbook {
+    param([string] $Engine, [object] $Run)
+    switch ($Engine) {
+        PSWriteOffice {
+            $Run.Payload | Export-OfficeExcel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName Data
+            Edit-OfficeExcelRow -InputPath $Run.Path -Sheet $Run.WorksheetName -ScriptBlock {
+                param($row)
+                $row.Set('TicketCount', ([int]$row.Get[int]('TicketCount') + 1))
+                if ($row.Get[bool]('IsEnabled')) { $row.Set('Notes', 'Reviewed') }
+            } | Out-Null
+            $document = Get-OfficeExcel -Path $Run.Path
+            try {
+                $sheet = $document.Sheets | Where-Object { $_.Name -eq $Run.WorksheetName } | Select-Object -First 1
+                $formulaColumn = $Run.ColumnCount + 1
+                $sheet.Cell(1, $formulaColumn, 'ScoreDouble', $null, $null)
+                $sheet.Cell(2, $formulaColumn, $null, 'G2*2', '#,##0.00')
+                $document | Save-OfficeExcel
+            } finally {
+                $document | Close-OfficeExcel
+            }
+        }
+        ImportExcel {
+            $Run.Payload | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName Data -AutoFilter
+            $excel = Open-ExcelPackage -Path $Run.Path
+            try {
+                $sheet = $excel.Workbook.Worksheets[$Run.WorksheetName]
+                for ($row = 2; $row -le ([int]$Run.Payload.Count + 1); $row++) {
+                    $sheet.Cells[$row, 9].Value = [int]$sheet.Cells[$row, 9].Value + 1
+                    if ([bool]$sheet.Cells[$row, 5].Value) { $sheet.Cells[$row, 10].Value = 'Reviewed' }
+                }
+                $formulaColumn = $Run.ColumnCount + 1
+                $sheet.Cells[1, $formulaColumn].Value = 'ScoreDouble'
+                $sheet.Cells[2, $formulaColumn].Formula = 'G2*2'
+                $sheet.Cells[2, $formulaColumn].Style.Numberformat.Format = '#,##0.00'
+            } finally {
+                Close-ExcelPackage -ExcelPackage $excel
+            }
+        }
+    }
+}
+
+function Invoke-ExcelBenchmarkManySmallSheets {
+    param([string] $Engine, [object] $Run)
+    switch ($Engine) {
+        PSWriteOffice {
+            New-OfficeExcel -Path $Run.Path {
+                foreach ($group in (Get-ExcelBenchmarkSmallSheetGroups -Rows $Run.Payload -SheetCount 20)) {
+                    Add-OfficeExcelSheet -Name $group.Name -Content {
+                        Add-OfficeExcelTable -Data $group.Data -TableName $group.TableName
+                        Set-OfficeExcelFreeze -TopRows 1
+                    }
+                }
+            } | Out-Null
+        }
+        ImportExcel {
+            $excel = $null
+            try {
+                foreach ($group in (Get-ExcelBenchmarkSmallSheetGroups -Rows $Run.Payload -SheetCount 20)) {
+                    $excel = if ($excel) {
+                        $group.Data | Export-Excel -ExcelPackage $excel -WorksheetName $group.Name -TableName $group.TableName -AutoFilter -FreezeTopRow -BoldTopRow -PassThru
+                    } else {
+                        $group.Data | Export-Excel -Path $Run.Path -WorksheetName $group.Name -TableName $group.TableName -AutoFilter -FreezeTopRow -BoldTopRow -PassThru
+                    }
+                }
+            } finally {
+                if ($excel) { Close-ExcelPackage -ExcelPackage $excel }
+            }
+        }
+    }
+}
+
+function Invoke-ExcelBenchmarkWorkbookPackageMerge {
+    param([string] $Engine, [object] $Run)
+    $input = Get-ExcelBenchmarkWorkbookMergeInput -Rows $Run.Payload -BasePath $Run.Path
+    switch ($Engine) {
+        PSWriteOffice {
+            $input.RowsA | Export-OfficeExcel -Path $input.SourceA -WorksheetName Data -TableName DataA
+            $input.RowsB | Export-OfficeExcel -Path $input.SourceB -WorksheetName Data -TableName DataB
+            Join-OfficeExcelWorkbook -Path $Run.Path -SourcePath @($input.SourceA, $input.SourceB) -CopyMode Package -SheetNamePrefix Merged | Out-Null
+        }
+        ImportExcel {
+            $input.RowsA | Export-Excel -Path $input.SourceA -WorksheetName Data -TableName DataA -AutoFilter
+            $input.RowsB | Export-Excel -Path $input.SourceB -WorksheetName Data -TableName DataB -AutoFilter
+            $targetPackage = [OfficeOpenXml.ExcelPackage]::new([IO.FileInfo]$Run.Path)
+            try {
+                foreach ($item in @(
+                    [pscustomobject]@{ Path = $input.SourceA; Name = 'MergedDataA' }
+                    [pscustomobject]@{ Path = $input.SourceB; Name = 'MergedDataB' }
+                )) {
+                    $sourcePackage = [OfficeOpenXml.ExcelPackage]::new([IO.FileInfo]$item.Path)
+                    try {
+                        $null = $targetPackage.Workbook.Worksheets.Add($item.Name, $sourcePackage.Workbook.Worksheets['Data'])
+                    } finally {
+                        $sourcePackage.Dispose()
+                    }
+                }
+                $targetPackage.Save()
+            } finally {
+                $targetPackage.Dispose()
+            }
+        }
+    }
+}
+
+function Invoke-ExcelBenchmarkChartOnlyWorkbook {
+    param([string] $Engine, [object] $Run)
+    switch ($Engine) {
+        PSWriteOffice {
+            New-OfficeExcel -Path $Run.Path {
+                Add-OfficeExcelSheet -Name $Run.WorksheetName -Content {
+                    Add-OfficeExcelTable -Data $Run.Payload -TableName Data
+                    Add-OfficeExcelChart -TableName Data -Row 2 -Column 12 -Type ColumnClustered -Title 'Score by region'
+                }
+            } | Out-Null
+        }
+        ImportExcel {
+            $lastRow = [int]$Run.Payload.Count + 1
+            $excel = $Run.Payload | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName Data -AutoFilter -PassThru
+            try {
+                Add-ExcelChart -Worksheet $excel.Workbook.Worksheets[$Run.WorksheetName] -ChartType ColumnClustered -Title 'Score by region' -XRange "D2:D$lastRow" -YRange "G2:G$lastRow" -Row 2 -Column 12 -Width 640 -Height 360
+            } finally {
+                Close-ExcelPackage -ExcelPackage $excel
+            }
+        }
+    }
+}
+
+function Invoke-ExcelBenchmarkPivotOnlyWorkbook {
+    param([string] $Engine, [object] $Run)
+    switch ($Engine) {
+        PSWriteOffice {
+            New-OfficeExcel -Path $Run.Path {
+                Add-OfficeExcelSheet -Name $Run.WorksheetName -Content {
+                    Add-OfficeExcelTable -Data $Run.Payload -TableName Data
+                    Add-OfficeExcelPivotTable -SourceRange $Run.Range -DestinationCell L4 -Name SummaryPivot -RowField Region -ColumnField Department -DataField Score, TicketCount -DataFunction Average, Sum -DataDisplayName 'Average Score', Tickets -DataNumberFormat '#,##0.00', '#,##0'
+                }
+            } | Out-Null
+        }
+        ImportExcel {
+            $excel = $Run.Payload | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName Data -AutoFilter -PassThru
+            try {
+                $worksheet = $excel.Workbook.Worksheets[$Run.WorksheetName]
+                Add-PivotTable -ExcelPackage $excel -Address $worksheet.Cells['L4'] -SourceWorksheet $worksheet -SourceRange $worksheet.Tables[0].Address -PivotTableName SummaryPivot -PivotRows Region -PivotColumns Department -PivotData @{ Score = 'Average'; TicketCount = 'Sum' } -PivotNumberFormat '#,##0.00'
+            } finally {
+                Close-ExcelPackage -ExcelPackage $excel
+            }
+        }
+    }
+}
+
+function Invoke-ExcelBenchmarkReportWorkbook {
+    param([string] $Engine, [object] $Run)
+    switch ($Engine) {
+        PSWriteOffice {
+            $lastRow = [int]$Run.Payload.Count + 1
+            New-OfficeExcel -Path $Run.Path {
+                Add-OfficeExcelSheet -Name $Run.WorksheetName -Content {
+                    Add-OfficeExcelTable -Data $Run.Payload -TableName Data -AutoFit
+                    Set-OfficeExcelFreeze -TopRows 1
+                    Add-OfficeExcelConditionalRule -Range "G2:G$lastRow" -Operator GreaterThan -Formula1 '750'
+                    Add-OfficeExcelConditionalDataBar -Range "G2:G$lastRow" -Color '#70AD47'
+                    Add-OfficeExcelConditionalColorScale -Range "I2:I$lastRow" -StartColor '#F4CCCC' -EndColor '#D9EAD3'
+                    Add-OfficeExcelConditionalIconSet -Range "I2:I$lastRow"
+                    Add-OfficeExcelValidationList -Range "D2:D$lastRow" -Values NA, EU, APAC, LATAM
+                    Set-OfficeExcelColumnStyleByHeader -Header Score -NumberFormat '#,##0.000'
+                    Set-OfficeExcelColumnStyleByHeader -Header Created -NumberFormat 'yyyy-mm-dd hh:mm'
+                    Add-OfficeExcelChart -TableName Data -Row 2 -Column 12 -Type ColumnClustered -Title 'Score by region'
+                    Add-OfficeExcelPivotTable -SourceRange $Run.Range -DestinationCell L24 -Name SummaryPivot -RowField Region -ColumnField Department -DataField Score, TicketCount -DataFunction Average, Sum -DataDisplayName 'Average Score', Tickets -DataNumberFormat '#,##0.00', '#,##0'
+                }
+            } | Out-Null
+        }
+        ImportExcel {
+            $lastRow = [int]$Run.Payload.Count + 1
+            $excel = $Run.Payload | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName -TableName Data -AutoFilter -AutoSize -FreezeTopRow -BoldTopRow -PassThru
+            try {
+                $worksheet = $excel.Workbook.Worksheets[$Run.WorksheetName]
+                Add-ConditionalFormatting -Worksheet $worksheet -Address "G2:G$lastRow" -RuleType GreaterThan -ConditionValue 750 -BackgroundColor LightPink
+                Add-ConditionalFormatting -Worksheet $worksheet -Address "G2:G$lastRow" -DataBarColor Green
+                Add-ConditionalFormatting -Worksheet $worksheet -Address "I2:I$lastRow" -RuleType ThreeColorScale
+                Add-ConditionalFormatting -Worksheet $worksheet -Address "I2:I$lastRow" -ThreeIconsSet TrafficLights1
+                Add-ExcelDataValidationRule -Worksheet $worksheet -Range "D2:D$lastRow" -ValidationType List -ValueSet @('NA', 'EU', 'APAC', 'LATAM')
+                $worksheet.Cells["G2:G$lastRow"].Style.Numberformat.Format = '#,##0.000'
+                $worksheet.Cells["F2:F$lastRow"].Style.Numberformat.Format = 'yyyy-mm-dd hh:mm'
+                Add-ExcelChart -Worksheet $worksheet -ChartType ColumnClustered -Title 'Score by region' -XRange "D2:D$lastRow" -YRange "G2:G$lastRow" -Row 2 -Column 12 -Width 640 -Height 360
+                Add-PivotTable -ExcelPackage $excel -Address $worksheet.Cells['L24'] -SourceWorksheet $worksheet -SourceRange $worksheet.Tables[0].Address -PivotTableName SummaryPivot -PivotRows Region -PivotColumns Department -PivotData @{ Score = 'Average'; TicketCount = 'Sum' } -PivotNumberFormat '#,##0.00'
+            } finally {
+                Close-ExcelPackage -ExcelPackage $excel
+            }
+        }
+    }
+}

--- a/Benchmarks/Excel/excel-performance.validation.ps1
+++ b/Benchmarks/Excel/excel-performance.validation.ps1
@@ -66,6 +66,15 @@ function Test-ExcelBenchmarkOutput {
         assertPath $Run.Path
     }
 
+    if ($Case.OperationKey -in @('ReadFullSheet', 'ReadRange', 'ReadNoHeaderRange')) {
+        $expectedRows = if ($Case.OperationKey -eq 'ReadNoHeaderRange') {
+            [int]$Run.ExpectedRows + 1
+        } else {
+            [int]$Run.ExpectedRows
+        }
+        assertValue ([int]$Run.ActualRows) $expectedRows -Message "Expected $expectedRows rows returned by '$($Case.OperationKey)'."
+    }
+
     if ([bool]$Run.SkipWorkbookValidation) {
         return
     }
@@ -83,11 +92,14 @@ function Test-ExcelBenchmarkOutput {
 function Test-CsvBenchmarkOutput {
     param([object] $Case, [object] $Run)
 
-    $path = if ($Case.OperationKey -eq 'ReadCsvSource') { $Run.SourcePath } else { $Run.Path }
-    assertPath $path
-
     $expectedRows = [int]$Run.ExpectedRows
+    if ($Case.OperationKey -eq 'ReadCsvSource') {
+        assertValue ([int]$Run.ActualRows) $expectedRows -Message "Expected $expectedRows rows returned by '$($Case.OperationKey)'."
+        return
+    }
 
+    $path = $Run.Path
+    assertPath $path
     $actualRows = @(Import-Csv -Path $path).Count
     assertValue $actualRows $expectedRows -Message "Expected $expectedRows rows in '$path'."
 }

--- a/Benchmarks/Excel/excel-performance.validation.ps1
+++ b/Benchmarks/Excel/excel-performance.validation.ps1
@@ -1,0 +1,93 @@
+function Get-ExcelBenchmarkRegionGroups {
+    param([object[]] $Rows)
+
+    foreach ($region in @('NA', 'EU', 'APAC', 'LATAM')) {
+        [pscustomobject]@{
+            Name = $region
+            TableName = 'Data_' + $region
+            Data = @($Rows | Where-Object { $_.Region -eq $region })
+        }
+    }
+}
+
+function Get-ExcelBenchmarkSummaryRows {
+    param([int] $Rows)
+
+    @(
+        [pscustomobject]@{ Metric = 'Rows'; Formula = 'COUNTA(Data!A2:A{0})' -f ($Rows + 1); NumberFormat = '#,##0' }
+        [pscustomobject]@{ Metric = 'Average score'; Formula = 'AVERAGE(Data!G2:G{0})' -f ($Rows + 1); NumberFormat = '#,##0.00' }
+        [pscustomobject]@{ Metric = 'Tickets'; Formula = 'SUM(Data!I2:I{0})' -f ($Rows + 1); NumberFormat = '#,##0' }
+        [pscustomobject]@{ Metric = 'Enabled'; Formula = 'COUNTIF(Data!E2:E{0},TRUE)' -f ($Rows + 1); NumberFormat = '#,##0' }
+    )
+}
+
+function Get-ExcelBenchmarkAppendSplit {
+    param([object[]] $Rows)
+
+    $initialCount = [math]::Max(1, [math]::Floor($Rows.Count * 0.8))
+    [pscustomobject]@{
+        Initial = @($Rows | Select-Object -First $initialCount)
+        Append = @($Rows | Select-Object -Skip $initialCount)
+    }
+}
+
+function Get-ExcelBenchmarkSmallSheetGroups {
+    param([object[]] $Rows, [int] $SheetCount = 20)
+
+    $safeSheetCount = [math]::Max(1, [math]::Min($SheetCount, [math]::Max(1, $Rows.Count)))
+    $rowsPerSheet = [math]::Max(1, [math]::Ceiling($Rows.Count / $safeSheetCount))
+    for ($sheetIndex = 0; $sheetIndex -lt $safeSheetCount; $sheetIndex++) {
+        $sheetRows = @($Rows | Select-Object -Skip ($sheetIndex * $rowsPerSheet) -First $rowsPerSheet)
+        if ($sheetRows.Count -eq 0) { continue }
+        [pscustomobject]@{
+            Name = 'Sheet{0:00}' -f ($sheetIndex + 1)
+            TableName = 'Data{0:00}' -f ($sheetIndex + 1)
+            Data = $sheetRows
+        }
+    }
+}
+
+function Get-ExcelBenchmarkWorkbookMergeInput {
+    param([object[]] $Rows, [string] $BasePath)
+
+    $firstCount = [math]::Max(1, [math]::Floor($Rows.Count / 2))
+    [pscustomobject]@{
+        SourceA = [IO.Path]::Combine([IO.Path]::GetDirectoryName($BasePath), ([IO.Path]::GetFileNameWithoutExtension($BasePath) + '.source-a.xlsx'))
+        SourceB = [IO.Path]::Combine([IO.Path]::GetDirectoryName($BasePath), ([IO.Path]::GetFileNameWithoutExtension($BasePath) + '.source-b.xlsx'))
+        RowsA = @($Rows | Select-Object -First $firstCount)
+        RowsB = @($Rows | Select-Object -Skip $firstCount)
+    }
+}
+
+function Test-ExcelBenchmarkOutput {
+    param([object] $Case, [object] $Run)
+
+    if ($Case.OperationKey -in @('WriteCsv', 'CsvToExcel', 'WriteWorkbook')) {
+        assertPath $Run.Path
+    }
+
+    if ([bool]$Run.SkipWorkbookValidation) {
+        return
+    }
+
+    if (-not [bool]$Case.ValidateWorkbook -or [string]$Case.FileExtension -ne '.xlsx') {
+        return
+    }
+
+    $document = Get-OfficeExcel -Path $Run.Path -ReadOnly
+    if ($document) {
+        Close-OfficeExcel -Document $document
+    }
+}
+
+function Test-CsvBenchmarkOutput {
+    param([object] $Case, [object] $Run)
+
+    $path = if ($Case.OperationKey -eq 'ReadCsvSource') { $Run.SourcePath } else { $Run.Path }
+    assertPath $path
+
+    $expectedRows = [int]$Run.ExpectedRows
+
+    $actualRows = @(Import-Csv -Path $path).Count
+    assertValue $actualRows $expectedRows -Message "Expected $expectedRows rows in '$path'."
+}

--- a/Benchmarks/Excel/excel-performance.validation.ps1
+++ b/Benchmarks/Excel/excel-performance.validation.ps1
@@ -75,6 +75,21 @@ function Test-ExcelBenchmarkOutput {
         assertValue ([int]$Run.ActualRows) $expectedRows -Message "Expected $expectedRows rows returned by '$($Case.OperationKey)'."
     }
 
+    if ($Case.OperationKey -eq 'ReadUsedRangeDataTable') {
+        $expectedRows = [int]$Run.ExpectedRows
+        assertValue ([int]$Run.ActualRows) $expectedRows -Message "Expected $expectedRows rows returned by '$($Case.OperationKey)'."
+    }
+
+    if ($Case.OperationKey -eq 'ReadTableMetadata') {
+        assertValue ([int]$Run.ActualTableCount) 1 -Message 'Expected one workbook table metadata result.'
+        assertValue (@($Run.ActualTableNames) -contains 'Data') $true -Message "Expected table metadata to include 'Data'."
+    }
+
+    if ($Case.OperationKey -eq 'ReadNamedRangeMetadata') {
+        assertValue ([int]$Run.ActualNamedRangeCount) 1 -Message 'Expected one workbook named range metadata result.'
+        assertValue (@($Run.ActualNamedRangeNames) -contains 'SalesData') $true -Message "Expected named range metadata to include 'SalesData'."
+    }
+
     if ([bool]$Run.SkipWorkbookValidation) {
         return
     }
@@ -87,6 +102,7 @@ function Test-ExcelBenchmarkOutput {
     if ($document) {
         Close-OfficeExcel -Document $document
     }
+    Test-ExcelBenchmarkOpenXml -Path $Run.Path
 }
 
 function Test-CsvBenchmarkOutput {
@@ -102,4 +118,25 @@ function Test-CsvBenchmarkOutput {
     assertPath $path
     $actualRows = @(Import-Csv -Path $path).Count
     assertValue $actualRows $expectedRows -Message "Expected $expectedRows rows in '$path'."
+}
+
+function Test-ExcelBenchmarkOpenXml {
+    param([string] $Path)
+
+    $validatorType = 'DocumentFormat.OpenXml.Validation.OpenXmlValidator' -as [type]
+    $spreadsheetType = 'DocumentFormat.OpenXml.Packaging.SpreadsheetDocument' -as [type]
+    if ($null -eq $validatorType -or $null -eq $spreadsheetType) {
+        return
+    }
+
+    $document = $spreadsheetType::Open($Path, $false)
+    try {
+        $validator = [Activator]::CreateInstance($validatorType)
+        $errors = @($validator.Validate($document))
+        assertValue $errors.Count 0 -Message "Expected '$Path' to pass OpenXML validation."
+    } finally {
+        if ($document) {
+            $document.Dispose()
+        }
+    }
 }

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -26,7 +26,8 @@ pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-Excel
     -Suite Standard `
     -RowCount 1000,5000,10000 `
     -RepeatCount 2 `
-    -Engine PSWriteOffice,ImportExcel,ExcelFast
+    -Engine PSWriteOffice,ImportExcel,ExcelFast `
+    -UpdateReadme
 ```
 
 <!-- BENCHMARK:ExcelComparison:START -->
@@ -127,25 +128,28 @@ pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-CsvPe
     -Suite Standard `
     -RowCount 1000,5000,10000 `
     -RepeatCount 3 `
-    -Engine PSWriteOffice,NativeCsv
+    -Engine PSWriteOffice,NativeCsv `
+    -UpdateReadme
 ```
 
 <!-- BENCHMARK:CsvComparison:START -->
 | Scenario | Rows | PSWriteOffice | NativeCsv | Result |
 | --- | ---: | ---: | ---: | --- |
-| csv-read-source | 1000 | 53.8 ms (1.00x) | 20.8 ms (0.39x faster) | NativeCsv fastest; PSWriteOffice 2.58x slower |
-| csv-read-source | 5000 | 61.8 ms (1.00x) | 16.7 ms (0.27x faster) | NativeCsv fastest; PSWriteOffice 3.70x slower |
+| csv-read-source | 1000 | 53.8 ms (1.00x) | 20.8 ms (2.58x faster) | NativeCsv fastest; PSWriteOffice 2.58x slower |
+| csv-read-source | 5000 | 61.8 ms (1.00x) | 16.7 ms (3.70x faster) | NativeCsv fastest; PSWriteOffice 3.70x slower |
 | csv-read-source | 10000 | 62.2 ms (1.00x) | 179.4 ms (2.89x slower) | PSWriteOffice fastest |
-| csv-write | 1000 | 60.0 ms (1.00x) | 51.1 ms (0.85x faster) | NativeCsv fastest; PSWriteOffice 1.17x slower |
-| csv-write | 5000 | 124.8 ms (1.00x) | 24.6 ms (0.20x faster) | NativeCsv fastest; PSWriteOffice 5.08x slower |
-| csv-write | 10000 | 238.6 ms (1.00x) | 77.3 ms (0.32x faster) | NativeCsv fastest; PSWriteOffice 3.09x slower |
+| csv-write | 1000 | 60.0 ms (1.00x) | 51.1 ms (1.17x faster) | NativeCsv fastest; PSWriteOffice 1.17x slower |
+| csv-write | 5000 | 124.8 ms (1.00x) | 24.6 ms (5.08x faster) | NativeCsv fastest; PSWriteOffice 5.08x slower |
+| csv-write | 10000 | 238.6 ms (1.00x) | 77.3 ms (3.09x faster) | NativeCsv fastest; PSWriteOffice 3.09x slower |
 <!-- BENCHMARK:CsvComparison:END -->
 
 ## Options
 
 The wrappers build PSWriteOffice in `Release` mode by default and import local
-development binaries. Use `-PSWriteOfficeConfiguration Debug` for diagnostics or
-`-SkipPSWriteOfficeBuild` when intentionally reusing a previous build.
+development binaries when a selected run includes `PSWriteOffice`. Use
+`-PSWriteOfficeConfiguration Debug` for diagnostics or `-SkipPSWriteOfficeBuild`
+when intentionally reusing a previous build. Quick and focused runs leave this
+README unchanged unless `-UpdateReadme` is specified.
 
 The scripts use published OfficeIMO packages by default by setting
 `OfficeIMORoot` to `.missing-officeimo`. Use `-OfficeIMORoot` when validating

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -1,175 +1,173 @@
-# Excel Benchmarks
+# PSWriteOffice Benchmarks
 
-`Compare-ExcelPerformance.ps1` compares PSWriteOffice against ImportExcel, ExcelFast, native PowerShell CSV commands, and CsvHelper across common PowerShell workbook and CSV workflows. It writes raw results, a summary, one-line comparison outputs, and metadata under `Ignore\Benchmarks\ExcelPerformance\Run-*`.
+PSWriteOffice benchmarks use the PSPublishModule/PowerForge benchmark DSL. The
+suite is split by file format so workbook behavior is compared with workbook
+tools and CSV behavior is compared with CSV tools.
 
-The script uses published OfficeIMO packages by default by setting `OfficeIMORoot` to `.missing-officeimo`, so PSWriteOffice measures the package-mode path instead of a local OfficeIMO checkout.
+## Excel
 
-Use `-OfficeIMORoot` when validating unreleased OfficeIMO source changes:
+`Compare-ExcelPerformance.ps1` measures OfficeIMO-backed PSWriteOffice Excel
+cmdlets against PowerShell-facing Excel alternatives:
 
-```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Standard -OfficeIMORoot C:\Support\GitHub\OfficeIMO
-```
-
-PSWriteOffice is built and imported from local development binaries for benchmark runs. The benchmark uses `-PSWriteOfficeConfiguration Release` by default so local source is compared in release mode; use `-PSWriteOfficeConfiguration Debug` for development diagnostics or `-SkipPSWriteOfficeBuild` only when intentionally reusing an existing build.
-
-This is the PowerShell/user-workflow scoreboard. .NET engine comparisons against ClosedXML, current EPPlus, legacy EPPlus, MiniExcel, LargeXlsx, ExcelDataReader, and Sylvan.Data.Excel live in the OfficeIMO benchmark harness. Keep the two views separate: PSWriteOffice measures cmdlet ergonomics and module-level workflows, while OfficeIMO measures raw engine/library paths.
-
-## Common Runs
-
-List available scenarios:
-
-```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -ListScenarios
-```
-
-Fast sanity run:
+- `PSWriteOffice`
+- `ImportExcel`
+- `ExcelFast` for the workbook lanes it supports
 
 ```powershell
 pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Smoke
 ```
 
-Default comparison run:
-
 ```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Standard
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Standard -ListScenarios
 ```
 
-Large comparison run:
-
 ```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Large
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 `
+    -Suite Standard `
+    -RowCount 1000,5000,10000 `
+    -RepeatCount 2 `
+    -Engine PSWriteOffice,ImportExcel,ExcelFast
 ```
 
-Longer comparison run:
+<!-- BENCHMARK:ExcelComparison:START -->
+| Scenario | Rows | PSWriteOffice | ExcelFast | ImportExcel | Result |
+| --- | ---: | ---: | ---: | ---: | --- |
+| append-existing-table | 1000 | 74.8 ms (1.00x) | Skipped | 344.6 ms (4.61x slower) | PSWriteOffice fastest |
+| append-existing-table | 5000 | 443.0 ms (1.00x) | Skipped | 1.16 s (2.61x slower) | PSWriteOffice fastest |
+| append-existing-table | 10000 | 931.8 ms (1.00x) | Skipped | 2.47 s (2.65x slower) | PSWriteOffice fastest |
+| chart-only-workbook | 1000 | 113.8 ms (1.00x) | Skipped | 422.5 ms (3.71x slower) | PSWriteOffice fastest |
+| chart-only-workbook | 5000 | 626.1 ms (1.00x) | Skipped | 1.09 s (1.74x slower) | PSWriteOffice fastest |
+| chart-only-workbook | 10000 | 1.34 s (1.00x) | Skipped | 2.24 s (1.68x slower) | PSWriteOffice fastest |
+| csv-to-excel | 1000 | 78.4 ms (1.00x) | Skipped | 440.0 ms (5.61x slower) | PSWriteOffice fastest |
+| csv-to-excel | 5000 | 406.9 ms (1.00x) | Skipped | 1.86 s (4.58x slower) | PSWriteOffice fastest |
+| csv-to-excel | 10000 | 737.4 ms (1.00x) | Skipped | 3.52 s (4.78x slower) | PSWriteOffice fastest |
+| datatable-default | 1000 | 22.4 ms (1.00x) | Skipped | 254.1 ms (11.36x slower) | PSWriteOffice fastest |
+| datatable-default | 5000 | 31.7 ms (1.00x) | Skipped | 819.9 ms (25.88x slower) | PSWriteOffice fastest |
+| datatable-default | 10000 | 47.2 ms (1.00x) | Skipped | 1.47 s (31.26x slower) | PSWriteOffice fastest |
+| import-default-full | 1000 | 26.4 ms (1.00x) | 45.1 ms (1.71x slower) | 125.2 ms (4.74x slower) | PSWriteOffice fastest |
+| import-default-full | 5000 | 117.0 ms (1.00x) | 331.9 ms (2.84x slower) | 321.9 ms (2.75x slower) | PSWriteOffice fastest |
+| import-default-full | 10000 | 286.4 ms (1.00x) | 391.2 ms (1.37x slower) | 453.8 ms (1.58x slower) | PSWriteOffice fastest |
+| import-default-range | 1000 | 16.3 ms (1.00x) | 34.6 ms (2.13x slower) | 100.4 ms (6.17x slower) | PSWriteOffice fastest |
+| import-default-range | 5000 | 75.5 ms (1.00x) | 239.8 ms (3.18x slower) | 237.6 ms (3.15x slower) | PSWriteOffice fastest |
+| import-default-range | 10000 | 231.5 ms (1.00x) | 357.8 ms (1.55x slower) | 415.2 ms (1.79x slower) | PSWriteOffice fastest |
+| many-small-sheets | 1000 | 120.1 ms (1.00x) | Skipped | 310.3 ms (2.58x slower) | PSWriteOffice fastest |
+| many-small-sheets | 5000 | 496.2 ms (1.00x) | Skipped | 1.10 s (2.22x slower) | PSWriteOffice fastest |
+| many-small-sheets | 10000 | 976.4 ms (1.00x) | Skipped | 2.13 s (2.18x slower) | PSWriteOffice fastest |
+| multi-sheet-regions | 1000 | 150.2 ms (1.00x) | Skipped | 406.6 ms (2.71x slower) | PSWriteOffice fastest |
+| multi-sheet-regions | 5000 | 505.7 ms (1.00x) | Skipped | 1.12 s (2.22x slower) | PSWriteOffice fastest |
+| multi-sheet-regions | 10000 | 955.5 ms (1.00x) | Skipped | 2.13 s (2.23x slower) | PSWriteOffice fastest |
+| named-range-workbook | 1000 | 59.9 ms (1.00x) | Skipped | 271.3 ms (4.53x slower) | PSWriteOffice fastest |
+| named-range-workbook | 5000 | 405.0 ms (1.00x) | Skipped | 1.05 s (2.60x slower) | PSWriteOffice fastest |
+| named-range-workbook | 10000 | 922.9 ms (1.00x) | Skipped | 2.10 s (2.28x slower) | PSWriteOffice fastest |
+| objects-default | 1000 | 80.8 ms (1.00x) | 131.6 ms (1.63x slower) | 300.6 ms (3.72x slower) | PSWriteOffice fastest |
+| objects-default | 5000 | 101.7 ms (1.00x) | 177.9 ms (1.75x slower) | 1.01 s (9.94x slower) | PSWriteOffice fastest |
+| objects-default | 10000 | 304.6 ms (1.00x) | 367.5 ms (1.21x slower) | 2.52 s (8.27x slower) | PSWriteOffice fastest |
+| objects-no-table | 1000 | 31.1 ms (1.00x) | Skipped | 315.8 ms (10.16x slower) | PSWriteOffice fastest |
+| objects-no-table | 5000 | 102.5 ms (1.00x) | Skipped | 1.16 s (11.27x slower) | PSWriteOffice fastest |
+| objects-no-table | 10000 | 469.5 ms (1.00x) | Skipped | 2.26 s (4.81x slower) | PSWriteOffice fastest |
+| objects-table | 1000 | 33.2 ms (1.00x) | Skipped | 310.1 ms (9.33x slower) | PSWriteOffice fastest |
+| objects-table | 5000 | 106.6 ms (1.00x) | Skipped | 1.02 s (9.55x slower) | PSWriteOffice fastest |
+| objects-table | 10000 | 301.2 ms (1.00x) | Skipped | 2.03 s (6.73x slower) | PSWriteOffice fastest |
+| objects-table-autofit | 1000 | 43.1 ms (1.00x) | Skipped | 336.4 ms (7.80x slower) | PSWriteOffice fastest |
+| objects-table-autofit | 5000 | 129.1 ms (1.00x) | Skipped | 1.28 s (9.93x slower) | PSWriteOffice fastest |
+| objects-table-autofit | 10000 | 341.0 ms (1.00x) | Skipped | 2.30 s (6.75x slower) | PSWriteOffice fastest |
+| objects-title-freeze | 1000 | 100.9 ms (1.00x) | Skipped | 360.5 ms (3.57x slower) | PSWriteOffice fastest |
+| objects-title-freeze | 5000 | 721.8 ms (1.00x) | Skipped | 1.18 s (1.63x slower) | PSWriteOffice fastest |
+| objects-title-freeze | 10000 | 1.05 s (1.00x) | Skipped | 2.07 s (1.97x slower) | PSWriteOffice fastest |
+| pivot-only-workbook | 1000 | 115.8 ms (1.00x) | Skipped | 387.2 ms (3.34x slower) | PSWriteOffice fastest |
+| pivot-only-workbook | 5000 | 392.5 ms (1.00x) | Skipped | 1.46 s (3.71x slower) | PSWriteOffice fastest |
+| pivot-only-workbook | 10000 | 737.3 ms (1.00x) | Skipped | 2.50 s (3.40x slower) | PSWriteOffice fastest |
+| read-named-range-metadata | 1000 | 10.8 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| read-named-range-metadata | 5000 | 60.7 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| read-named-range-metadata | 10000 | 13.4 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| read-no-header-range | 1000 | 21.7 ms (1.00x) | 30.7 ms (1.42x slower) | 92.6 ms (4.27x slower) | PSWriteOffice fastest |
+| read-no-header-range | 5000 | 87.4 ms (1.00x) | 285.0 ms (3.26x slower) | 251.1 ms (2.87x slower) | PSWriteOffice fastest |
+| read-no-header-range | 10000 | 215.5 ms (1.00x) | 311.1 ms (1.44x slower) | 475.3 ms (2.21x slower) | PSWriteOffice fastest |
+| read-table-metadata | 1000 | 23.6 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| read-table-metadata | 5000 | 12.2 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| read-table-metadata | 10000 | 23.1 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| read-used-range-datatable | 1000 | 18.2 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| read-used-range-datatable | 5000 | 97.3 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| read-used-range-datatable | 10000 | 145.0 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| report-workbook | 1000 | 119.4 ms (1.00x) | Skipped | 358.8 ms (3.00x slower) | PSWriteOffice fastest |
+| report-workbook | 5000 | 571.1 ms (1.00x) | Skipped | 1.27 s (2.23x slower) | PSWriteOffice fastest |
+| report-workbook | 10000 | 1.48 s (1.00x) | Skipped | 2.10 s (1.41x slower) | PSWriteOffice fastest |
+| summary-formulas | 1000 | 62.0 ms (1.00x) | Skipped | 263.0 ms (4.24x slower) | PSWriteOffice fastest |
+| summary-formulas | 5000 | 354.7 ms (1.00x) | Skipped | 943.4 ms (2.66x slower) | PSWriteOffice fastest |
+| summary-formulas | 10000 | 743.6 ms (1.00x) | Skipped | 1.72 s (2.31x slower) | PSWriteOffice fastest |
+| update-existing-workbook | 1000 | 218.3 ms (1.00x) | Skipped | 458.1 ms (2.10x slower) | PSWriteOffice fastest |
+| update-existing-workbook | 5000 | 906.7 ms (1.00x) | Skipped | 1.33 s (1.47x slower) | PSWriteOffice fastest |
+| update-existing-workbook | 10000 | 1.57 s (1.00x) | Skipped | 2.14 s (1.36x slower) | PSWriteOffice fastest |
+| wide-objects-default | 1000 | 77.4 ms (1.00x) | 176.2 ms (2.28x slower) | 242.0 ms (3.13x slower) | PSWriteOffice fastest |
+| wide-objects-default | 5000 | 312.6 ms (1.00x) | 345.8 ms (1.11x slower) | 1.03 s (3.29x slower) | PSWriteOffice fastest |
+| wide-objects-default | 10000 | 497.9 ms (1.00x) | 680.7 ms (1.37x slower) | 1.66 s (3.33x slower) | PSWriteOffice fastest |
+| workbook-package-merge | 1000 | 180.5 ms (1.00x) | Skipped | 608.7 ms (3.37x slower) | PSWriteOffice fastest |
+| workbook-package-merge | 5000 | 1.34 s (1.00x) | Skipped | 1.46 s (1.09x slower) | PSWriteOffice fastest |
+| workbook-package-merge | 10000 | 1.46 s (1.00x) | Skipped | 2.90 s (1.98x slower) | PSWriteOffice fastest |
+<!-- BENCHMARK:ExcelComparison:END -->
+
+## CSV
+
+`Compare-CsvPerformance.ps1` measures PSWriteOffice CSV cmdlets against native
+PowerShell CSV import/export:
+
+- `PSWriteOffice`
+- `NativeCsv`
 
 ```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Full
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-CsvPerformance.ps1 -Suite Smoke
 ```
-
-Scale stress run:
 
 ```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite SuperLarge
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-CsvPerformance.ps1 -Suite Standard -ListScenarios
 ```
-
-Focus on a specific workflow:
 
 ```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Standard -Scenario objects-default -RowCount 25000 -RepeatCount 5
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-CsvPerformance.ps1 `
+    -Suite Standard `
+    -RowCount 1000,5000,10000 `
+    -RepeatCount 3 `
+    -Engine PSWriteOffice,NativeCsv
 ```
 
-Run the richer report workbook workflow:
+<!-- BENCHMARK:CsvComparison:START -->
+| Scenario | Rows | PSWriteOffice | NativeCsv | Result |
+| --- | ---: | ---: | ---: | --- |
+| csv-read-source | 1000 | 53.8 ms (1.00x) | 20.8 ms (0.39x faster) | NativeCsv fastest; PSWriteOffice 2.58x slower |
+| csv-read-source | 5000 | 61.8 ms (1.00x) | 16.7 ms (0.27x faster) | NativeCsv fastest; PSWriteOffice 3.70x slower |
+| csv-read-source | 10000 | 62.2 ms (1.00x) | 179.4 ms (2.89x slower) | PSWriteOffice fastest |
+| csv-write | 1000 | 60.0 ms (1.00x) | 51.1 ms (0.85x faster) | NativeCsv fastest; PSWriteOffice 1.17x slower |
+| csv-write | 5000 | 124.8 ms (1.00x) | 24.6 ms (0.20x faster) | NativeCsv fastest; PSWriteOffice 5.08x slower |
+| csv-write | 10000 | 238.6 ms (1.00x) | 77.3 ms (0.32x faster) | NativeCsv fastest; PSWriteOffice 3.09x slower |
+<!-- BENCHMARK:CsvComparison:END -->
+
+## Options
+
+The wrappers build PSWriteOffice in `Release` mode by default and import local
+development binaries. Use `-PSWriteOfficeConfiguration Debug` for diagnostics or
+`-SkipPSWriteOfficeBuild` when intentionally reusing a previous build.
+
+The scripts use published OfficeIMO packages by default by setting
+`OfficeIMORoot` to `.missing-officeimo`. Use `-OfficeIMORoot` when validating
+unreleased OfficeIMO source changes:
 
 ```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Standard -Scenario report-workbook -RowCount 1000,10000 -RepeatCount 3 -Engine PSWriteOffice,ImportExcel
+$evotecRoot = if ($env:EVOTEC_GITHUB_ROOT) { $env:EVOTEC_GITHUB_ROOT } else { 'C:\Support\GitHub' }
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 `
+    -Suite Standard `
+    -OfficeIMORoot (Join-Path $evotecRoot 'OfficeIMO')
 ```
 
-Run the more operational workbook workflows:
+## Output
 
-```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Standard -Scenario objects-title-freeze,multi-sheet-regions,summary-formulas -RowCount 1000,10000,25000 -RepeatCount 3 -Engine PSWriteOffice,ImportExcel
-```
+Benchmark artifacts are written under `Ignore\Benchmarks\ExcelPerformance` and
+`Ignore\Benchmarks\CsvPerformance`:
 
-Run the append, update, many-sheet, read-focused, and chart/pivot split workflows:
+- `samples.json` / `samples.csv`
+- `summary.json` / `summary.csv`
+- `comparison.json` / `comparison.md`
+- `metadata.json`
+- `run-report.json`
 
-```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Standard -Scenario objects-default,append-existing-table,update-existing-workbook,many-small-sheets,named-range-workbook,chart-only-workbook,pivot-only-workbook -RowCount 1000,10000,25000 -RepeatCount 3
-```
-
-Measure workbook package-copy merges without row-object materialization:
-
-```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Standard -Scenario workbook-package-merge -RowCount 1000,10000,25000 -RepeatCount 3 -Engine PSWriteOffice,ImportExcel
-```
-
-The ImportExcel lane for `workbook-package-merge` intentionally uses the `OfficeOpenXml.ExcelPackage` API loaded by ImportExcel, not row-by-row `Import-Excel`/`Export-Excel`, because that is the fair fast path for workbook sheet copying. The run metadata records the loaded `OfficeOpenXml` assembly version so the result can be traced back to the actual EPPlus generation.
-
-Measure export creation without import follow-up timing:
-
-```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Standard -Scenario objects-default,wide-objects-default -RowCount 25000 -RepeatCount 3 -Engine PSWriteOffice,ImportExcel,ExcelFast -SkipFollowUps
-```
-
-Compare only selected engines:
-
-```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Standard -Engine PSWriteOffice,ExcelFast
-```
-
-Measure CSV write/read and CSV-source-to-workbook conversion:
-
-```powershell
-pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Standard -Scenario csv-write,csv-read,csv-read-source,csv-to-excel -RowCount 10000,100000 -Engine PSWriteOffice,ImportExcel,NativeCsv,CsvHelper
-```
-
-The CsvHelper lane is benchmark-only. It measures the cost of using CsvHelper from the same PowerShell-shaped object workflow as the other CSV lanes, so it is useful for user-facing comparison but should not be read as a pure typed C# CsvHelper microbenchmark.
-
-The NativeCsv write lane uses `Export-Csv -UseQuotes AsNeeded` so it is compared against PSWriteOffice's default compact CSV output instead of PowerShell's legacy quote-every-field default.
-
-CSV read/write microbenchmarks are short enough that three repeats are too noisy. When `-RepeatCount` is not provided, the harness raises CSV read/write scenarios to a suite-specific minimum repeat count (`Smoke` 11, `Standard`/`Full` 51, `Large` 11, `SuperLarge` 3). Explicit `-RepeatCount` values are respected exactly. The effective per-scenario policy is recorded in `metadata.json`.
-
-Use `csv-read-source` when you want to time only the read path from the same external CSV shape for every engine. The older `csv-read` row remains a follow-up read of each engine's `csv-write` output, which is useful workflow evidence but couples the read measurement to a parent write scenario.
-
-## Scenario Suites
-
-`Smoke` is a quick confidence pass for default workbook export/import paths plus CSV file write/read coverage.
-
-`Standard` covers the everyday decisions people make: default export, table export, no-table export, autofit, full-sheet import, range import, no-header reads, used-range DataTable reads, table/named-range metadata reads, append-to-existing-table workflows, update-existing-workbook workflows, wide objects, DataTable input, CSV write/read, CSV-source-to-workbook conversion, title/start-row/frozen-header exports, regional multi-sheet workbooks, many-small-sheet workbooks, formula summary sheets, chart-only and pivot-only workbooks, and a full report workbook with a table, freeze row, conditional formatting, validation, a chart, and a pivot table.
-
-`Large` runs the broad workflow family at `25k`, `100k`, and `250k` rows, including the PSWriteOffice DataSet worksheet path.
-
-`Full` includes everything in `Standard` plus a `100k` row count, more repeats, and PSWriteOffice-only DataSet worksheet export.
-
-`SuperLarge` runs scale-safe workflows at `250k`, `500k`, and `1m` rows. It intentionally skips table/autofit/DataSet defaults; use `-Scenario` and `-RowCount` when you want to force those expensive paths.
-
-## Output Files
-
-Every run writes these files:
-
-- `excel-performance-comparison.csv`: one row per scenario/row count with fastest engine, per-engine status (`tested`, `failed`, `not selected`, or `not supported by scenario`), PSWriteOffice rank, PSWriteOffice vs fastest text, competitor timings, file sizes, and compact memory deltas.
-- `excel-performance-comparison.json`: nested comparison data with per-engine rank, timing ratio, file-size ratio, and memory fields.
-- `excel-performance-summary.csv`: median/min/max data grouped by engine and scenario, including median working-set, peak working-set, and managed-memory deltas.
-- `excel-performance-results.csv`: raw per-iteration results, including failures, file size, working-set before/after, peak working set, and managed-memory delta.
-- `metadata.json`: exact module versions including prerelease labels, machine/runtime details, selected suite, engines, filters, repeat policy, module cache paths, and output paths.
-
-For quick reading, start with `excel-performance-comparison.csv`. See
-[Artifact Schema](#artifact-schema) when you need exact column meanings.
-
-## Artifact Schema
-
-`excel-performance-results.csv` is the raw evidence. Important columns:
-
-- `Status` / `Error`: whether the timed operation itself passed.
-- `WorkbookValidationStatus`: post-operation workbook validation result for export scenarios.
-- `WorkbookOpenStatus`: whether PSWriteOffice could open the generated workbook.
-- `WorkbookOpenXmlStatus`: whether Open XML validation passed, failed, or was skipped because validator types were unavailable.
-- `WorkbookValidationMs`: validation time, recorded separately from the timed operation.
-- `WorkingSetBeforeMB`, `WorkingSetAfterMB`, `WorkingSetDeltaMB`, `PeakWorkingSetDeltaMB`, `ManagedDeltaMB`: memory diagnostics for the operation.
-
-`excel-performance-summary.csv` groups raw rows by engine, scenario, profile,
-and row count. It reports median/min/max time, median file size, median memory
-deltas, and workbook-validation pass/fail/skip counts.
-
-`excel-performance-comparison.csv` is the comparison view. It includes:
-
-- `FastestEngine`, `FastestMs`, and PSWriteOffice rank/ratio text.
-- Per-engine status columns: `tested`, `failed`, `not selected`, or `not supported by scenario`.
-- Per-engine workbook validation status and validation time.
-- Per-engine median file size and memory deltas.
-
-`metadata.json` records exact module versions including prerelease labels,
-loaded `OfficeOpenXml` and `OfficeIMO.Excel` assembly versions,
-machine/runtime details, selected engines/scenarios, repeat policy, module
-cache paths, OfficeIMO root, and output paths.
-
-## Notes
-
-The benchmark records failures as rows in `excel-performance-results.csv` instead of hiding them. That makes unsupported competitor scenarios visible without stopping the whole run.
-
-Install behavior is controlled by `-SkipImportExcelInstall`, `-SkipExcelFastInstall`, and `-SkipCsvHelperInstall`. Without those switches, missing competitor modules are saved into the benchmark module cache under `Ignore`, and CsvHelper is restored into the normal NuGet package cache through a small restore project under `Ignore\Benchmarks\ExcelPerformance\Packages`. ExcelFast is currently consumed as a prerelease package when available from PSGallery; if installation fails, put ExcelFast on `PSModulePath` and rerun the selected lane.
-
-CsvHelper is not a PSWriteOffice runtime dependency. The benchmark loads the restored CsvHelper assembly only for selected CsvHelper runs and records its version in `metadata.json`.
-
-Workbook validation is enabled by default for export scenarios. Use
-`-SkipWorkbookValidation` only when you need raw timing without post-export
-open/OpenXML checks.
+Start with `comparison.md` or the generated README table for the comparison,
+then use `samples.csv` when diagnosing individual failures.

--- a/Benchmarks/Update-PerformanceBenchmarkReadme.ps1
+++ b/Benchmarks/Update-PerformanceBenchmarkReadme.ps1
@@ -14,6 +14,12 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+function ConvertTo-BenchmarkDouble {
+    param([object] $Value)
+
+    [double]::Parse([string]$Value, [Globalization.CultureInfo]::InvariantCulture)
+}
+
 function Format-BenchmarkDuration {
     param([double] $Milliseconds)
 
@@ -33,7 +39,7 @@ function Format-BenchmarkResult {
     $successful = @(
         foreach ($entry in $ByEngine.GetEnumerator()) {
             if ($entry.Value.Status -eq 'Succeeded') {
-                [pscustomobject]@{ Engine = $entry.Key; MedianMs = [double]$entry.Value.MedianMs }
+                [pscustomobject]@{ Engine = $entry.Key; MedianMs = ConvertTo-BenchmarkDouble -Value $entry.Value.MedianMs }
             }
         }
     ) | Sort-Object MedianMs, Engine
@@ -48,7 +54,7 @@ function Format-BenchmarkResult {
     }
 
     if ($ByEngine.ContainsKey($Baseline) -and $ByEngine[$Baseline].Status -eq 'Succeeded') {
-        $ratio = [double]$ByEngine[$Baseline].MedianMs / [double]$winner.MedianMs
+        $ratio = (ConvertTo-BenchmarkDouble -Value $ByEngine[$Baseline].MedianMs) / [double]$winner.MedianMs
         return ([string]::Format([Globalization.CultureInfo]::InvariantCulture, '{0} fastest; {1} {2:n2}x slower', $winner.Engine, $Baseline, $ratio))
     }
 
@@ -100,12 +106,12 @@ function Format-BenchmarkCell {
         return 'Failed'
     }
 
-    $duration = Format-BenchmarkDuration -Milliseconds ([double]$Row.MedianMs)
+    $duration = Format-BenchmarkDuration -Milliseconds (ConvertTo-BenchmarkDouble -Value $Row.MedianMs)
     if ($null -eq $BaselineRow -or $BaselineRow.Status -ne 'Succeeded') {
         return $duration
     }
 
-    $ratio = Format-BenchmarkRatio -Milliseconds ([double]$Row.MedianMs) -BaselineMilliseconds ([double]$BaselineRow.MedianMs) -Engine $Engine -Baseline $Baseline
+    $ratio = Format-BenchmarkRatio -Milliseconds (ConvertTo-BenchmarkDouble -Value $Row.MedianMs) -BaselineMilliseconds (ConvertTo-BenchmarkDouble -Value $BaselineRow.MedianMs) -Engine $Engine -Baseline $Baseline
     if ([string]::IsNullOrWhiteSpace($ratio)) {
         return $duration
     }

--- a/Benchmarks/Update-PerformanceBenchmarkReadme.ps1
+++ b/Benchmarks/Update-PerformanceBenchmarkReadme.ps1
@@ -1,0 +1,175 @@
+param(
+    [Parameter(Mandatory)]
+    [string] $SummaryPath,
+
+    [Parameter(Mandatory)]
+    [string] $ReadmePath,
+
+    [Parameter(Mandatory)]
+    [string] $BlockId,
+
+    [string] $BaselineEngine = 'PSWriteOffice'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Format-BenchmarkDuration {
+    param([double] $Milliseconds)
+
+    if ($Milliseconds -ge 1000) {
+        return ([string]::Format([Globalization.CultureInfo]::InvariantCulture, '{0:n2} s', ($Milliseconds / 1000)))
+    }
+
+    [string]::Format([Globalization.CultureInfo]::InvariantCulture, '{0:n1} ms', $Milliseconds)
+}
+
+function Format-BenchmarkResult {
+    param(
+        [hashtable] $ByEngine,
+        [string] $Baseline
+    )
+
+    $successful = @(
+        foreach ($entry in $ByEngine.GetEnumerator()) {
+            if ($entry.Value.Status -eq 'Succeeded') {
+                [pscustomobject]@{ Engine = $entry.Key; MedianMs = [double]$entry.Value.MedianMs }
+            }
+        }
+    ) | Sort-Object MedianMs, Engine
+
+    if ($successful.Count -eq 0) {
+        return 'No successful rows'
+    }
+
+    $winner = $successful[0]
+    if ($winner.Engine -eq $Baseline) {
+        return "$Baseline fastest"
+    }
+
+    if ($ByEngine.ContainsKey($Baseline) -and $ByEngine[$Baseline].Status -eq 'Succeeded') {
+        $ratio = [double]$ByEngine[$Baseline].MedianMs / [double]$winner.MedianMs
+        return ([string]::Format([Globalization.CultureInfo]::InvariantCulture, '{0} fastest; {1} {2:n2}x slower', $winner.Engine, $Baseline, $ratio))
+    }
+
+    "$($winner.Engine) fastest"
+}
+
+function Format-BenchmarkRatio {
+    param(
+        [double] $Milliseconds,
+        [double] $BaselineMilliseconds,
+        [string] $Engine,
+        [string] $Baseline
+    )
+
+    if ($BaselineMilliseconds -le 0) {
+        return ''
+    }
+
+    if ($Engine -eq $Baseline) {
+        return '1.00x'
+    }
+
+    $ratio = $Milliseconds / $BaselineMilliseconds
+    if ($ratio -ge 1) {
+        return ([string]::Format([Globalization.CultureInfo]::InvariantCulture, '{0:n2}x slower', $ratio))
+    }
+
+    return ([string]::Format([Globalization.CultureInfo]::InvariantCulture, '{0:n2}x faster', $ratio))
+}
+
+function Format-BenchmarkCell {
+    param(
+        [object] $Row,
+        [object] $BaselineRow,
+        [string] $Engine,
+        [string] $Baseline
+    )
+
+    if ($null -eq $Row) {
+        return 'n/a'
+    }
+
+    if ($Row.Status -eq 'Skipped') {
+        return 'Skipped'
+    }
+
+    if ($Row.Status -ne 'Succeeded') {
+        return 'Failed'
+    }
+
+    $duration = Format-BenchmarkDuration -Milliseconds ([double]$Row.MedianMs)
+    if ($null -eq $BaselineRow -or $BaselineRow.Status -ne 'Succeeded') {
+        return $duration
+    }
+
+    $ratio = Format-BenchmarkRatio -Milliseconds ([double]$Row.MedianMs) -BaselineMilliseconds ([double]$BaselineRow.MedianMs) -Engine $Engine -Baseline $Baseline
+    if ([string]::IsNullOrWhiteSpace($ratio)) {
+        return $duration
+    }
+
+    "$duration ($ratio)"
+}
+
+function Update-MarkdownBlock {
+    param(
+        [string] $Path,
+        [string] $Id,
+        [string] $Content
+    )
+
+    $start = "<!-- BENCHMARK:$Id`:START -->"
+    $end = "<!-- BENCHMARK:$Id`:END -->"
+    $text = Get-Content -Raw -LiteralPath $Path
+    $pattern = [regex]::Escape($start) + '(?s).*?' + [regex]::Escape($end)
+    $replacement = $start + [Environment]::NewLine + $Content.TrimEnd() + [Environment]::NewLine + $end
+    if ($text -notmatch $pattern) {
+        throw "Benchmark block '$Id' was not found in '$Path'."
+    }
+
+    $updated = [regex]::Replace($text, $pattern, [System.Text.RegularExpressions.MatchEvaluator]{ param($match) $replacement })
+    Set-Content -LiteralPath $Path -Value $updated -NoNewline
+}
+
+$summary = Import-Csv -LiteralPath $SummaryPath
+$engines = @(
+    $BaselineEngine
+    $summary.Engine |
+        Where-Object { $_ -ne $BaselineEngine } |
+        Sort-Object -Unique
+) | Select-Object -Unique
+
+$markdown = [Text.StringBuilder]::new()
+[void]$markdown.Append('| Scenario | Rows |')
+foreach ($engine in $engines) {
+    [void]$markdown.Append(' ').Append($engine).Append(' |')
+}
+[void]$markdown.AppendLine(' Result |')
+[void]$markdown.Append('| --- | ---: |')
+foreach ($engine in $engines) {
+    [void]$markdown.Append(' ---: |')
+}
+[void]$markdown.AppendLine(' --- |')
+
+$groups = $summary |
+    Group-Object Scenario, RowCount |
+    Sort-Object @{ Expression = { $_.Group[0].Scenario } }, @{ Expression = { [int]$_.Group[0].RowCount } }
+
+foreach ($group in $groups) {
+    $first = $group.Group[0]
+    $byEngine = @{}
+    foreach ($row in $group.Group) {
+        $byEngine[$row.Engine] = $row
+    }
+    $baselineRow = if ($byEngine.ContainsKey($BaselineEngine)) { $byEngine[$BaselineEngine] } else { $null }
+
+    [void]$markdown.Append('| ').Append($first.Scenario).Append(' | ').Append($first.RowCount).Append(' |')
+    foreach ($engine in $engines) {
+        $row = if ($byEngine.ContainsKey($engine)) { $byEngine[$engine] } else { $null }
+        [void]$markdown.Append(' ').Append((Format-BenchmarkCell -Row $row -BaselineRow $baselineRow -Engine $engine -Baseline $BaselineEngine)).Append(' |')
+    }
+    [void]$markdown.Append(' ').Append((Format-BenchmarkResult -ByEngine $byEngine -Baseline $BaselineEngine)).AppendLine(' |')
+}
+
+Update-MarkdownBlock -Path $ReadmePath -Id $BlockId -Content $markdown.ToString()

--- a/Benchmarks/Update-PerformanceBenchmarkReadme.ps1
+++ b/Benchmarks/Update-PerformanceBenchmarkReadme.ps1
@@ -76,7 +76,8 @@ function Format-BenchmarkRatio {
         return ([string]::Format([Globalization.CultureInfo]::InvariantCulture, '{0:n2}x slower', $ratio))
     }
 
-    return ([string]::Format([Globalization.CultureInfo]::InvariantCulture, '{0:n2}x faster', $ratio))
+    $speedup = $BaselineMilliseconds / $Milliseconds
+    return ([string]::Format([Globalization.CultureInfo]::InvariantCulture, '{0:n2}x faster', $speedup))
 }
 
 function Format-BenchmarkCell {

--- a/Sources/PSWriteOffice/PSWriteOffice.csproj
+++ b/Sources/PSWriteOffice/PSWriteOffice.csproj
@@ -92,35 +92,35 @@
         <ProjectReference Include="$(OfficeIMORoot)\OfficeIMO.Rtf.Pdf\OfficeIMO.Rtf.Pdf.csproj" />
     </ItemGroup>
     <ItemGroup Condition="'$(UseOfficeIMOProjectReferences)' != 'true'">
-        <PackageReference Include="OfficeIMO.Drawing" Version="1.0.25" />
-        <PackageReference Include="OfficeIMO.Word" Version="1.0.72" />
-        <PackageReference Include="OfficeIMO.Word.Markdown" Version="1.0.47" />
-        <PackageReference Include="OfficeIMO.Excel" Version="0.6.51" />
-        <PackageReference Include="OfficeIMO.PowerPoint" Version="1.0.46" />
-        <PackageReference Include="OfficeIMO.Markdown" Version="0.6.38" />
-        <PackageReference Include="OfficeIMO.Markdown.Html" Version="0.1.38" />
-        <PackageReference Include="OfficeIMO.Pdf" Version="0.1.46" />
-        <PackageReference Include="OfficeIMO.Word.Pdf" Version="1.0.45" />
-        <PackageReference Include="OfficeIMO.Excel.Pdf" Version="1.0.11" />
-        <PackageReference Include="OfficeIMO.Markdown.Pdf" Version="1.0.11" />
-        <PackageReference Include="OfficeIMO.Html.Pdf" Version="1.0.9" />
-        <PackageReference Include="OfficeIMO.PowerPoint.Pdf" Version="1.0.11" />
-        <PackageReference Include="OfficeIMO.CSV" Version="0.1.51" />
-        <PackageReference Include="OfficeIMO.Word.Html" Version="1.0.45" />
-        <PackageReference Include="OfficeIMO.Reader" Version="0.1.46" />
-        <PackageReference Include="OfficeIMO.Reader.Pdf" Version="0.0.10" />
-        <PackageReference Include="OfficeIMO.Reader.Html" Version="0.0.29" />
-        <PackageReference Include="OfficeIMO.Reader.Csv" Version="0.0.29" />
-        <PackageReference Include="OfficeIMO.Reader.Json" Version="0.0.29" />
-        <PackageReference Include="OfficeIMO.Reader.Xml" Version="0.0.29" />
-        <PackageReference Include="OfficeIMO.Reader.Yaml" Version="0.0.8" />
-        <PackageReference Include="OfficeIMO.Reader.Zip" Version="0.0.29" />
-        <PackageReference Include="OfficeIMO.Reader.Epub" Version="0.0.29" />
-        <PackageReference Include="OfficeIMO.Reader.Visio" Version="0.0.10" />
-        <PackageReference Include="OfficeIMO.Reader.Rtf" Version="0.0.7" />
-        <PackageReference Include="OfficeIMO.Visio" Version="1.0.11" />
-        <PackageReference Include="OfficeIMO.Rtf" Version="0.1.6" />
-        <PackageReference Include="OfficeIMO.Word.Rtf" Version="0.1.6" />
-        <PackageReference Include="OfficeIMO.Rtf.Pdf" Version="0.1.6" />
+        <PackageReference Include="OfficeIMO.Drawing" Version="1.0.26" />
+        <PackageReference Include="OfficeIMO.Word" Version="1.0.73" />
+        <PackageReference Include="OfficeIMO.Word.Markdown" Version="1.0.48" />
+        <PackageReference Include="OfficeIMO.Excel" Version="0.6.52" />
+        <PackageReference Include="OfficeIMO.PowerPoint" Version="1.0.47" />
+        <PackageReference Include="OfficeIMO.Markdown" Version="0.6.39" />
+        <PackageReference Include="OfficeIMO.Markdown.Html" Version="0.1.39" />
+        <PackageReference Include="OfficeIMO.Pdf" Version="0.1.47" />
+        <PackageReference Include="OfficeIMO.Word.Pdf" Version="1.0.46" />
+        <PackageReference Include="OfficeIMO.Excel.Pdf" Version="1.0.12" />
+        <PackageReference Include="OfficeIMO.Markdown.Pdf" Version="1.0.12" />
+        <PackageReference Include="OfficeIMO.Html.Pdf" Version="1.0.10" />
+        <PackageReference Include="OfficeIMO.PowerPoint.Pdf" Version="1.0.12" />
+        <PackageReference Include="OfficeIMO.CSV" Version="0.1.52" />
+        <PackageReference Include="OfficeIMO.Word.Html" Version="1.0.46" />
+        <PackageReference Include="OfficeIMO.Reader" Version="0.1.47" />
+        <PackageReference Include="OfficeIMO.Reader.Pdf" Version="0.0.11" />
+        <PackageReference Include="OfficeIMO.Reader.Html" Version="0.0.30" />
+        <PackageReference Include="OfficeIMO.Reader.Csv" Version="0.0.30" />
+        <PackageReference Include="OfficeIMO.Reader.Json" Version="0.0.30" />
+        <PackageReference Include="OfficeIMO.Reader.Xml" Version="0.0.30" />
+        <PackageReference Include="OfficeIMO.Reader.Yaml" Version="0.0.9" />
+        <PackageReference Include="OfficeIMO.Reader.Zip" Version="0.0.30" />
+        <PackageReference Include="OfficeIMO.Reader.Epub" Version="0.0.30" />
+        <PackageReference Include="OfficeIMO.Reader.Visio" Version="0.0.11" />
+        <PackageReference Include="OfficeIMO.Reader.Rtf" Version="0.0.8" />
+        <PackageReference Include="OfficeIMO.Visio" Version="1.0.12" />
+        <PackageReference Include="OfficeIMO.Rtf" Version="0.1.7" />
+        <PackageReference Include="OfficeIMO.Word.Rtf" Version="0.1.7" />
+        <PackageReference Include="OfficeIMO.Rtf.Pdf" Version="0.1.7" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Bump PSWriteOffice OfficeIMO package references to the latest direct versions available from the configured sources.
- Replace the old monolithic benchmark script with PSPublishModule/PowerForge benchmark specs split by domain: Excel-to-Excel and CSV-to-CSV.
- Refresh benchmark documentation with performance-focused tables that show PSWriteOffice as the 1.00x baseline and competitor ratios by row count.
- Harden benchmark wrappers and validation so focused runs do not rewrite README tables, comma-delimited filters work from non-PowerShell shells, optional ExcelFast lanes skip cleanly, and read/metadata/OpenXML validation catches bad benchmark output.

## Benchmark coverage
- Excel: PSWriteOffice vs ImportExcel and ExcelFast where the compared workbook lane is supported.
- CSV: PSWriteOffice vs native PowerShell CSV import/export.

## Validation
- Package update check found no remaining direct dependency updates.
- Release build and solution tests pass locally.
- Focused Excel and CSV benchmark runs cover list mode, competitor-only lanes, comma-delimited filters, workbook validation, read-result validation, and README table generation.