### PR TITLE
Improve CSV benchmark coverage and projection performance

### DIFF
--- a/Benchmarks/Excel/excel-performance.core.ps1
+++ b/Benchmarks/Excel/excel-performance.core.ps1
@@ -121,8 +121,15 @@ function Get-CsvBenchmarkCase {
 
     $csv = @('Smoke', 'Standard', 'Large', 'Full', 'SuperLarge')
     @(
-        New-ExcelBenchmarkCase -Name csv-write -Label 'Write CSV file' -Suites $csv -OperationKey WriteCsv -Profile MixedObjects -FileExtension '.csv' -ValidateWorkbook:$false
-        New-ExcelBenchmarkCase -Name csv-read-source -Label 'Read CSV file' -Suites $csv -OperationKey ReadCsvSource -Profile MixedObjects -FileExtension '.csv' -ValidateWorkbook:$false
+        foreach ($csvProfile in @(
+            [pscustomobject]@{ Profile = 'MixedObjects'; Label = 'mixed' }
+            [pscustomobject]@{ Profile = 'CsvQuotedObjects'; Label = 'quoted' }
+            [pscustomobject]@{ Profile = 'CsvMultilineObjects'; Label = 'multiline' }
+            [pscustomobject]@{ Profile = 'CsvWideObjects'; Label = 'wide' }
+        )) {
+            New-ExcelBenchmarkCase -Name ('csv-write-{0}' -f $csvProfile.Label) -Label ('Write CSV file ({0})' -f $csvProfile.Label) -Suites $csv -OperationKey WriteCsv -Profile $csvProfile.Profile -FileExtension '.csv' -ValidateWorkbook:$false
+            New-ExcelBenchmarkCase -Name ('csv-read-source-{0}' -f $csvProfile.Label) -Label ('Read CSV file ({0})' -f $csvProfile.Label) -Suites $csv -OperationKey ReadCsvSource -Profile $csvProfile.Profile -FileExtension '.csv' -ValidateWorkbook:$false
+        }
     ) | Where-Object { (($_.Suites -split ',') -contains $Suite) }
 }
 

--- a/Benchmarks/Excel/excel-performance.data.ps1
+++ b/Benchmarks/Excel/excel-performance.data.ps1
@@ -11,6 +11,15 @@ function Get-ExcelBenchmarkData {
         WideObjects {
             [pscustomobject]@{ Data = @(New-ExcelBenchmarkWideRows -Count $Count); ColumnCount = 40; WorksheetName = 'Data' }
         }
+        CsvQuotedObjects {
+            [pscustomobject]@{ Data = @(New-ExcelBenchmarkCsvQuotedRows -Count $Count); ColumnCount = 10; WorksheetName = 'Data' }
+        }
+        CsvMultilineObjects {
+            [pscustomobject]@{ Data = @(New-ExcelBenchmarkCsvMultilineRows -Count $Count); ColumnCount = 10; WorksheetName = 'Data' }
+        }
+        CsvWideObjects {
+            [pscustomobject]@{ Data = @(New-ExcelBenchmarkWideRows -Count $Count); ColumnCount = 40; WorksheetName = 'Data' }
+        }
         DataTable {
             [pscustomobject]@{ Data = New-ExcelBenchmarkDataTable -Count $Count; ColumnCount = 6; WorksheetName = 'Data' }
         }
@@ -72,6 +81,44 @@ function New-ExcelBenchmarkWideRows {
             $row["Metric$column"] = [math]::Round((($i + $column) * 1.017) % 10000, 4)
         }
         [pscustomobject]$row
+    }
+}
+
+function New-ExcelBenchmarkCsvQuotedRows {
+    param([int] $Count)
+
+    for ($i = 1; $i -le $Count; $i++) {
+        [pscustomobject]@{
+            Id = $i
+            Name = 'Server, "{0:000000}"' -f $i
+            Department = 'Department "{0}"' -f ($i % 25)
+            Region = @('NA, East', 'EU "West"', 'APAC', 'LATAM')[$i % 4]
+            IsEnabled = ($i % 3) -ne 0
+            Created = ([datetime]'2024-01-01').AddMinutes($i)
+            Score = [math]::Round(($i * 1.137) % 1000, 3)
+            Owner = 'owner{0}@example.test' -f ($i % 250)
+            TicketCount = $i % 17
+            Notes = 'Quoted, comma, and ""escape"" row {0}' -f $i
+        }
+    }
+}
+
+function New-ExcelBenchmarkCsvMultilineRows {
+    param([int] $Count)
+
+    for ($i = 1; $i -le $Count; $i++) {
+        [pscustomobject]@{
+            Id = $i
+            Name = 'Server-{0:000000}' -f $i
+            Department = 'Department-{0}' -f ($i % 25)
+            Region = @('NA', 'EU', 'APAC', 'LATAM')[$i % 4]
+            IsEnabled = ($i % 3) -ne 0
+            Created = ([datetime]'2024-01-01').AddMinutes($i)
+            Score = [math]::Round(($i * 1.137) % 1000, 3)
+            Owner = 'owner{0}@example.test' -f ($i % 250)
+            TicketCount = $i % 17
+            Notes = "Line 1 for row $i`r`nLine 2 with comma, quote "" and row $i"
+        }
     }
 }
 
@@ -138,6 +185,7 @@ function Get-ExcelBenchmarkColumnCount {
 
     switch ($Profile) {
         WideObjects { 40 }
+        CsvWideObjects { 40 }
         DataTable { 6 }
         DataSet { 6 }
         default { 10 }
@@ -176,10 +224,10 @@ function Initialize-ExcelBenchmarkInput {
 
     switch ([string]$Case.OperationKey) {
         ReadCsvSource {
-            $Run.Payload | Export-Csv -Path $Run.SourcePath -NoTypeInformation -Encoding utf8
+            $Run.Payload | Export-Csv -Path $Run.SourcePath -NoTypeInformation -Encoding utf8 -UseQuotes AsNeeded
         }
         CsvToExcel {
-            $Run.Payload | Export-Csv -Path $Run.SourcePath -NoTypeInformation -Encoding utf8
+            $Run.Payload | Export-Csv -Path $Run.SourcePath -NoTypeInformation -Encoding utf8 -UseQuotes AsNeeded
         }
         ReadFullSheet { New-ExcelBenchmarkDefaultWorkbook -Engine $Case.Engine -Run $Run }
         ReadRange { New-ExcelBenchmarkDefaultWorkbook -Engine $Case.Engine -Run $Run }

--- a/Sources/PSWriteOffice/Cmdlets/Csv/ConvertToOfficeCsvCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Csv/ConvertToOfficeCsvCommand.cs
@@ -168,6 +168,7 @@ public sealed class ConvertToOfficeCsvCommand : PSCmdlet
         }
 
         var options = CreateSaveOptions();
+        _objectProjector.UseCsvCulture(options.Culture);
         _lineWriter = new CsvPowerShellLineWriter(this, options.Delimiter, options.QuoteMode);
         _csvWriter = new CsvObjectWriter(_lineWriter, options);
         return _csvWriter;

--- a/Sources/PSWriteOffice/Cmdlets/Csv/CsvPowerShellObjectProjector.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Csv/CsvPowerShellObjectProjector.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using OfficeIMO.CSV;
 using PSWriteOffice.Services;
@@ -10,13 +11,25 @@ internal sealed class CsvPowerShellObjectProjector
 {
     private string[]? _columns;
     private object?[]? _values;
+    private string?[]? _textValues;
+    private PowerShellObjectNormalizerOptions _normalizerOptions = PowerShellObjectNormalizerOptions.Default;
     private bool _validateColumns;
 
     public void Reset()
     {
         _columns = null;
         _values = null;
+        _textValues = null;
         _validateColumns = false;
+    }
+
+    public void UseCsvCulture(CultureInfo culture)
+    {
+        _normalizerOptions = new PowerShellObjectNormalizerOptions
+        {
+            Culture = culture ?? CultureInfo.InvariantCulture,
+            FormatScalarValuesAsText = true
+        };
     }
 
     public void UseColumns(IReadOnlyList<string> columns, bool validateColumns)
@@ -28,6 +41,7 @@ internal sealed class CsvPowerShellObjectProjector
 
         _columns = columns.ToArray();
         _values = new object?[_columns.Length];
+        _textValues = new string?[_columns.Length];
         _validateColumns = validateColumns;
     }
 
@@ -56,24 +70,65 @@ internal sealed class CsvPowerShellObjectProjector
         if (_columns != null &&
             _values != null)
         {
+            if (_validateColumns)
+            {
+                ValidateFirstRowColumns(value, _columns);
+            }
+
+            if (_textValues != null &&
+                PowerShellObjectNormalizer.TryProjectPSObjectTextIntoKnownColumns(value, _columns, _textValues, _normalizerOptions))
+            {
+                WriteProjectedTextRow(writer, _columns, _textValues);
+                return;
+            }
+
+            if (PowerShellObjectNormalizer.TryProjectPSObjectIntoKnownColumns(value, _columns, _values, _normalizerOptions))
+            {
+                WriteProjectedRow(writer, _columns, _values);
+                return;
+            }
+
             if (!TryProjectIntoExistingColumns(value, _columns, _values))
             {
                 Array.Clear(_values, 0, _values.Length);
             }
 
-            writer.WriteRow(_columns, _values);
+            WriteProjectedRow(writer, _columns, _values);
             return;
         }
 
-        if (PowerShellObjectNormalizer.TryProjectItem(value, null, out var columns, out var values))
+        if (PowerShellObjectNormalizer.TryProjectItem(value, null, out var columns, out var values, _normalizerOptions))
         {
             _columns = columns;
             _values = new object?[columns.Length];
+            _textValues = new string?[columns.Length];
             writer.WriteRow(_columns, values);
             return;
         }
 
         writer.WriteObject(PowerShellObjectNormalizer.NormalizeItem(value));
+    }
+
+    private static void WriteProjectedTextRow(CsvObjectWriter writer, string[] columns, string?[] values)
+    {
+        if (writer.HasRows)
+        {
+            writer.WriteTrustedTextRow(values);
+            return;
+        }
+
+        writer.WriteRow(columns, values);
+    }
+
+    private static void WriteProjectedRow(CsvObjectWriter writer, string[] columns, object?[] values)
+    {
+        if (writer.HasRows)
+        {
+            writer.WriteTrustedRow(values);
+            return;
+        }
+
+        writer.WriteRow(columns, values);
     }
 
     private bool TryProjectIntoExistingColumns(object? value, string[] columns, object?[] values)
@@ -83,7 +138,7 @@ internal sealed class CsvPowerShellObjectProjector
             ValidateFirstRowColumns(value, columns);
         }
 
-        return PowerShellObjectNormalizer.TryProjectItemInto(value, columns, values);
+        return PowerShellObjectNormalizer.TryProjectItemInto(value, columns, values, _normalizerOptions);
     }
 
     private static void ValidateFirstRowColumns(object? value, IReadOnlyList<string> columns)
@@ -102,7 +157,7 @@ internal sealed class CsvPowerShellObjectProjector
     private static bool TryGetProjectableColumns(object? value, IReadOnlyList<string> columns, out string? missingColumn)
     {
         missingColumn = null;
-        if (!PowerShellObjectNormalizer.TryProjectItem(value, null, out var sourceColumns, out _))
+        if (!PowerShellObjectNormalizer.TryProjectItem(value, null, out var sourceColumns, out _, PowerShellObjectNormalizerOptions.Default))
         {
             return false;
         }

--- a/Sources/PSWriteOffice/Cmdlets/Csv/CsvPowerShellRowWriter.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Csv/CsvPowerShellRowWriter.cs
@@ -52,11 +52,10 @@ internal sealed class CsvPowerShellRowWriter
     {
         var outputHeader = GetOutputHeader(header);
         var headerCount = outputHeader.Length;
-        var rowCount = row.Count;
-        var valueCount = rowCount < headerCount ? rowCount : headerCount;
 
         if (asHashtable)
         {
+            var valueCount = GetValueCount(row, headerCount);
             var rowValues = new Dictionary<string, object?>(valueCount, StringComparer.OrdinalIgnoreCase);
             AddHashtableValues(rowValues, outputHeader, row, valueCount);
 
@@ -64,12 +63,65 @@ internal sealed class CsvPowerShellRowWriter
             return;
         }
 
-        var psObj = PowerShellObjectFactory.Create(valueCount);
+        WriteObjectRow(cmdlet, outputHeader, row, headerCount);
+    }
+
+    private void WriteObjectRow(PSCmdlet cmdlet, string[] header, IReadOnlyList<string> row, int headerCount)
+    {
+        var valueCount = GetValueCount(row, headerCount);
+        var psObj = PowerShellObjectFactory.Create(headerCount);
         var prevalidated = _prevalidatedOutputProperties;
-        AddNoteProperties(psObj, outputHeader, row, valueCount, prevalidated);
+
+        if (row is List<string> list)
+        {
+            for (var i = 0; i < valueCount; i++)
+            {
+                psObj.Properties.Add(new PSNoteProperty(header[i], list[i]), prevalidated);
+            }
+
+            if (valueCount < headerCount)
+            {
+                AddMissingNoteProperties(psObj, header, valueCount, headerCount, prevalidated);
+            }
+
+            cmdlet.WriteObject(psObj);
+            return;
+        }
+
+        if (row is string[] array)
+        {
+            for (var i = 0; i < valueCount; i++)
+            {
+                psObj.Properties.Add(new PSNoteProperty(header[i], array[i]), prevalidated);
+            }
+
+            if (valueCount < headerCount)
+            {
+                AddMissingNoteProperties(psObj, header, valueCount, headerCount, prevalidated);
+            }
+
+            cmdlet.WriteObject(psObj);
+            return;
+        }
+
+        for (var i = 0; i < valueCount; i++)
+        {
+            psObj.Properties.Add(new PSNoteProperty(header[i], row[i]), prevalidated);
+        }
+
+        if (valueCount < headerCount)
+        {
+            AddMissingNoteProperties(psObj, header, valueCount, headerCount, prevalidated);
+        }
 
         cmdlet.WriteObject(psObj);
     }
+
+    private static int GetValueCount(IReadOnlyCollection<string> row, int headerCount) =>
+        row.Count < headerCount ? row.Count : headerCount;
+
+    private static int GetValueCount(IReadOnlyList<string> row, int headerCount) =>
+        row.Count < headerCount ? row.Count : headerCount;
 
     private static void AddHashtableValues(Dictionary<string, object?> rowValues, string[] header, IReadOnlyList<string> row, int valueCount)
     {
@@ -99,31 +151,11 @@ internal sealed class CsvPowerShellRowWriter
         }
     }
 
-    private static void AddNoteProperties(PSObject psObj, string[] header, IReadOnlyList<string> row, int valueCount, bool prevalidated)
+    private static void AddMissingNoteProperties(PSObject psObj, string[] header, int startIndex, int headerCount, bool prevalidated)
     {
-        if (row is List<string> list)
+        for (var i = startIndex; i < headerCount; i++)
         {
-            for (var i = 0; i < valueCount; i++)
-            {
-                psObj.Properties.Add(new PSNoteProperty(header[i], list[i]), prevalidated);
-            }
-
-            return;
-        }
-
-        if (row is string[] array)
-        {
-            for (var i = 0; i < valueCount; i++)
-            {
-                psObj.Properties.Add(new PSNoteProperty(header[i], array[i]), prevalidated);
-            }
-
-            return;
-        }
-
-        for (var i = 0; i < valueCount; i++)
-        {
-            psObj.Properties.Add(new PSNoteProperty(header[i], row[i]), prevalidated);
+            psObj.Properties.Add(new PSNoteProperty(header[i], null), prevalidated);
         }
     }
 

--- a/Sources/PSWriteOffice/Cmdlets/Csv/CsvPowerShellRowWriter.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Csv/CsvPowerShellRowWriter.cs
@@ -36,12 +36,18 @@ internal sealed class CsvPowerShellRowWriter
             }
 
             var outputHeader = GetOutputHeader(header);
-            var valueCount = outputHeader.Length < row.FieldCount ? outputHeader.Length : row.FieldCount;
-            var psObj = PowerShellObjectFactory.Create(valueCount);
+            var headerCount = outputHeader.Length;
+            var valueCount = headerCount < row.FieldCount ? headerCount : row.FieldCount;
+            var psObj = PowerShellObjectFactory.Create(headerCount);
             var prevalidated = _prevalidatedOutputProperties;
             for (var i = 0; i < valueCount; i++)
             {
                 psObj.Properties.Add(new PSNoteProperty(outputHeader[i], row[i]), prevalidated);
+            }
+
+            if (valueCount < headerCount)
+            {
+                AddMissingNoteProperties(psObj, outputHeader, valueCount, headerCount, prevalidated);
             }
 
             cmdlet.WriteObject(psObj);

--- a/Sources/PSWriteOffice/Cmdlets/Csv/ExportOfficeCsvCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Csv/ExportOfficeCsvCommand.cs
@@ -27,7 +27,7 @@ namespace PSWriteOffice.Cmdlets.Csv;
 [OutputType(typeof(FileInfo))]
 public sealed class ExportOfficeCsvCommand : PSCmdlet
 {
-    private const int StreamWriterBufferSize = 256 * 1024;
+    private const int StreamWriterBufferSize = 64 * 1024;
     private const string ParameterSetInputObjectPathDelimiter = "InputObjectPathDelimiter";
     private const string ParameterSetInputObjectPathCulture = "InputObjectPathCulture";
     private const string ParameterSetInputObjectLiteralPathDelimiter = "InputObjectLiteralPathDelimiter";
@@ -275,9 +275,11 @@ public sealed class ExportOfficeCsvCommand : PSCmdlet
         }
 
         var options = CreateSaveOptions();
+        _objectProjector.UseCsvCulture(options.Culture);
         if (Append.IsPresent)
         {
             options = CreateSaveOptions(includeHeader: !NoHeader.IsPresent && !_appendToExistingFile);
+            _objectProjector.UseCsvCulture(options.Culture);
             var appendHeader = GetEffectiveAppendHeader(firstValue);
             if (appendHeader is { Length: > 0 })
             {

--- a/Sources/PSWriteOffice/PSWriteOffice.csproj
+++ b/Sources/PSWriteOffice/PSWriteOffice.csproj
@@ -92,35 +92,35 @@
         <ProjectReference Include="$(OfficeIMORoot)\OfficeIMO.Rtf.Pdf\OfficeIMO.Rtf.Pdf.csproj" />
     </ItemGroup>
     <ItemGroup Condition="'$(UseOfficeIMOProjectReferences)' != 'true'">
-        <PackageReference Include="OfficeIMO.Drawing" Version="1.0.26" />
-        <PackageReference Include="OfficeIMO.Word" Version="1.0.73" />
-        <PackageReference Include="OfficeIMO.Word.Markdown" Version="1.0.48" />
-        <PackageReference Include="OfficeIMO.Excel" Version="0.6.52" />
-        <PackageReference Include="OfficeIMO.PowerPoint" Version="1.0.47" />
-        <PackageReference Include="OfficeIMO.Markdown" Version="0.6.39" />
-        <PackageReference Include="OfficeIMO.Markdown.Html" Version="0.1.39" />
-        <PackageReference Include="OfficeIMO.Pdf" Version="0.1.47" />
-        <PackageReference Include="OfficeIMO.Word.Pdf" Version="1.0.46" />
-        <PackageReference Include="OfficeIMO.Excel.Pdf" Version="1.0.12" />
-        <PackageReference Include="OfficeIMO.Markdown.Pdf" Version="1.0.12" />
-        <PackageReference Include="OfficeIMO.Html.Pdf" Version="1.0.10" />
-        <PackageReference Include="OfficeIMO.PowerPoint.Pdf" Version="1.0.12" />
-        <PackageReference Include="OfficeIMO.CSV" Version="0.1.52" />
-        <PackageReference Include="OfficeIMO.Word.Html" Version="1.0.46" />
-        <PackageReference Include="OfficeIMO.Reader" Version="0.1.47" />
-        <PackageReference Include="OfficeIMO.Reader.Pdf" Version="0.0.11" />
-        <PackageReference Include="OfficeIMO.Reader.Html" Version="0.0.30" />
-        <PackageReference Include="OfficeIMO.Reader.Csv" Version="0.0.30" />
-        <PackageReference Include="OfficeIMO.Reader.Json" Version="0.0.30" />
-        <PackageReference Include="OfficeIMO.Reader.Xml" Version="0.0.30" />
-        <PackageReference Include="OfficeIMO.Reader.Yaml" Version="0.0.9" />
-        <PackageReference Include="OfficeIMO.Reader.Zip" Version="0.0.30" />
-        <PackageReference Include="OfficeIMO.Reader.Epub" Version="0.0.30" />
-        <PackageReference Include="OfficeIMO.Reader.Visio" Version="0.0.11" />
-        <PackageReference Include="OfficeIMO.Reader.Rtf" Version="0.0.8" />
-        <PackageReference Include="OfficeIMO.Visio" Version="1.0.12" />
-        <PackageReference Include="OfficeIMO.Rtf" Version="0.1.7" />
-        <PackageReference Include="OfficeIMO.Word.Rtf" Version="0.1.7" />
-        <PackageReference Include="OfficeIMO.Rtf.Pdf" Version="0.1.7" />
+        <PackageReference Include="OfficeIMO.Drawing" Version="1.0.27" />
+        <PackageReference Include="OfficeIMO.Word" Version="1.0.74" />
+        <PackageReference Include="OfficeIMO.Word.Markdown" Version="1.0.49" />
+        <PackageReference Include="OfficeIMO.Excel" Version="0.6.53" />
+        <PackageReference Include="OfficeIMO.PowerPoint" Version="1.0.48" />
+        <PackageReference Include="OfficeIMO.Markdown" Version="0.6.40" />
+        <PackageReference Include="OfficeIMO.Markdown.Html" Version="0.1.40" />
+        <PackageReference Include="OfficeIMO.Pdf" Version="0.1.48" />
+        <PackageReference Include="OfficeIMO.Word.Pdf" Version="1.0.47" />
+        <PackageReference Include="OfficeIMO.Excel.Pdf" Version="1.0.13" />
+        <PackageReference Include="OfficeIMO.Markdown.Pdf" Version="1.0.13" />
+        <PackageReference Include="OfficeIMO.Html.Pdf" Version="1.0.11" />
+        <PackageReference Include="OfficeIMO.PowerPoint.Pdf" Version="1.0.13" />
+        <PackageReference Include="OfficeIMO.CSV" Version="0.1.53" />
+        <PackageReference Include="OfficeIMO.Word.Html" Version="1.0.47" />
+        <PackageReference Include="OfficeIMO.Reader" Version="0.1.48" />
+        <PackageReference Include="OfficeIMO.Reader.Pdf" Version="0.0.12" />
+        <PackageReference Include="OfficeIMO.Reader.Html" Version="0.0.31" />
+        <PackageReference Include="OfficeIMO.Reader.Csv" Version="0.0.31" />
+        <PackageReference Include="OfficeIMO.Reader.Json" Version="0.0.31" />
+        <PackageReference Include="OfficeIMO.Reader.Xml" Version="0.0.31" />
+        <PackageReference Include="OfficeIMO.Reader.Yaml" Version="0.0.10" />
+        <PackageReference Include="OfficeIMO.Reader.Zip" Version="0.0.31" />
+        <PackageReference Include="OfficeIMO.Reader.Epub" Version="0.0.31" />
+        <PackageReference Include="OfficeIMO.Reader.Visio" Version="0.0.12" />
+        <PackageReference Include="OfficeIMO.Reader.Rtf" Version="0.0.9" />
+        <PackageReference Include="OfficeIMO.Visio" Version="1.0.13" />
+        <PackageReference Include="OfficeIMO.Rtf" Version="0.1.8" />
+        <PackageReference Include="OfficeIMO.Word.Rtf" Version="0.1.8" />
+        <PackageReference Include="OfficeIMO.Rtf.Pdf" Version="0.1.8" />
     </ItemGroup>
 </Project>

--- a/Sources/PSWriteOffice/Services/PowerShellObjectNormalizer.cs
+++ b/Sources/PSWriteOffice/Services/PowerShellObjectNormalizer.cs
@@ -159,6 +159,203 @@ internal static class PowerShellObjectNormalizer
         return true;
     }
 
+    public static bool TryProjectPSObjectIntoKnownColumns(object? item, string[] columns, object?[] values, PowerShellObjectNormalizerOptions? options = null)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(columns);
+        ArgumentNullException.ThrowIfNull(values);
+#else
+        if (columns == null) throw new ArgumentNullException(nameof(columns));
+        if (values == null) throw new ArgumentNullException(nameof(values));
+#endif
+
+        if (values.Length != columns.Length)
+        {
+            throw new ArgumentException("The value buffer length must match the column count.", nameof(values));
+        }
+
+        options ??= PowerShellObjectNormalizerOptions.Default;
+
+        if (item == null || item is IDictionary)
+        {
+            return false;
+        }
+
+        if (item is not PSObject && item.GetType().FullName != "System.Management.Automation.PSCustomObject")
+        {
+            return false;
+        }
+
+        var ps = item as PSObject ?? PSObject.AsPSObject(item);
+        if (ps.BaseObject is IDictionary)
+        {
+            return false;
+        }
+
+        if (ps.BaseObject != null &&
+            IsScalarClrType(ps.BaseObject.GetType()) &&
+            !HasExportableExtendedProperties(ps))
+        {
+            return false;
+        }
+
+        if (TryProjectAlignedPSObject(ps, columns, values, options))
+        {
+            return true;
+        }
+
+        for (var i = 0; i < columns.Length; i++)
+        {
+            var property = ps.Properties[columns[i]];
+            if (property == null || !ShouldExportProperty(property))
+            {
+                values[i] = null;
+                continue;
+            }
+
+            try
+            {
+                values[i] = NormalizeCellValue(property.Value, options);
+            }
+            catch (Exception exception) when (exception is not PipelineStoppedException)
+            {
+                if (options.PropertyErrorAction == ActionPreference.Stop)
+                {
+                    throw new InvalidOperationException($"Unable to read PowerShell property '{property.Name}'.", exception);
+                }
+
+                options.PropertyErrorCallback?.Invoke(property.Name, exception);
+                values[i] = options.IncludeUnexportableProperties
+                    ? options.UnexportablePropertyValueFactory?.Invoke(property.Name, exception) ?? string.Empty
+                    : null;
+            }
+        }
+
+        return true;
+    }
+
+    public static bool TryProjectPSObjectTextIntoKnownColumns(object? item, string[] columns, string?[] values, PowerShellObjectNormalizerOptions? options = null)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(columns);
+        ArgumentNullException.ThrowIfNull(values);
+#else
+        if (columns == null) throw new ArgumentNullException(nameof(columns));
+        if (values == null) throw new ArgumentNullException(nameof(values));
+#endif
+
+        if (values.Length != columns.Length)
+        {
+            throw new ArgumentException("The value buffer length must match the column count.", nameof(values));
+        }
+
+        options ??= PowerShellObjectNormalizerOptions.Default;
+
+        if (item == null || item is IDictionary)
+        {
+            return false;
+        }
+
+        if (item is not PSObject && item.GetType().FullName != "System.Management.Automation.PSCustomObject")
+        {
+            return false;
+        }
+
+        var ps = item as PSObject ?? PSObject.AsPSObject(item);
+        if (ps.BaseObject is IDictionary)
+        {
+            return false;
+        }
+
+        if (ps.BaseObject != null &&
+            IsScalarClrType(ps.BaseObject.GetType()) &&
+            !HasExportableExtendedProperties(ps))
+        {
+            return false;
+        }
+
+        for (var i = 0; i < columns.Length; i++)
+        {
+            var property = ps.Properties[columns[i]];
+            if (property == null || !ShouldExportProperty(property))
+            {
+                values[i] = null;
+                continue;
+            }
+
+            try
+            {
+                values[i] = NormalizeCellValueToText(property.Value, options);
+            }
+            catch (Exception exception) when (exception is not PipelineStoppedException)
+            {
+                if (options.PropertyErrorAction == ActionPreference.Stop)
+                {
+                    throw new InvalidOperationException($"Unable to read PowerShell property '{property.Name}'.", exception);
+                }
+
+                options.PropertyErrorCallback?.Invoke(property.Name, exception);
+                values[i] = options.IncludeUnexportableProperties
+                    ? options.UnexportablePropertyValueFactory?.Invoke(property.Name, exception)?.ToString() ?? string.Empty
+                    : null;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryProjectAlignedPSObject(PSObject ps, string[] columns, object?[] values, PowerShellObjectNormalizerOptions options)
+    {
+        var index = 0;
+        foreach (var property in ps.Properties)
+        {
+            if (!ShouldExportProperty(property))
+            {
+                continue;
+            }
+
+            if (!IsAlignedColumn(property.Name, columns, index))
+            {
+                return false;
+            }
+
+            if (property.MemberType == PSMemberTypes.NoteProperty &&
+                TryGetFastCellValue(property.Value, options, out values[index]))
+            {
+                index++;
+                continue;
+            }
+
+            try
+            {
+                values[index] = NormalizeCellValue(property.Value, options);
+            }
+            catch (Exception exception) when (exception is not PipelineStoppedException)
+            {
+                if (options.PropertyErrorAction == ActionPreference.Stop)
+                {
+                    throw new InvalidOperationException($"Unable to read PowerShell property '{property.Name}'.", exception);
+                }
+
+                options.PropertyErrorCallback?.Invoke(property.Name, exception);
+                values[index] = options.IncludeUnexportableProperties
+                    ? options.UnexportablePropertyValueFactory?.Invoke(property.Name, exception) ?? string.Empty
+                    : null;
+            }
+
+            index++;
+        }
+
+        return index == columns.Length;
+    }
+
+    private static bool IsAlignedColumn(string propertyName, string[] columns, int index)
+    {
+        return index < columns.Length &&
+            (string.Equals(propertyName, columns[index], StringComparison.Ordinal) ||
+             string.Equals(propertyName, columns[index], StringComparison.OrdinalIgnoreCase));
+    }
+
     private static bool TryProjectScalar(object item, string[]? columns, out string[] projectedColumns, out object?[] values, PowerShellObjectNormalizerOptions options)
     {
         if (item is PSObject psObject && HasExportableExtendedProperties(psObject))
@@ -668,30 +865,9 @@ internal static class PowerShellObjectNormalizer
 
     private static object? NormalizeCellValue(object? value, PowerShellObjectNormalizerOptions options)
     {
-        if (value == null || value is string || !options.NormalizeCollectionValues)
+        if (TryGetFastCellValue(value, options, out var normalized))
         {
-            return value;
-        }
-
-        if (value is bool ||
-            value is char ||
-            value is byte ||
-            value is sbyte ||
-            value is short ||
-            value is ushort ||
-            value is int ||
-            value is uint ||
-            value is long ||
-            value is ulong ||
-            value is float ||
-            value is double ||
-            value is decimal ||
-            value is DateTime ||
-            value is DateTimeOffset ||
-            value is TimeSpan ||
-            value is Guid)
-        {
-            return value;
+            return normalized;
         }
 
         if (value is IDictionary)
@@ -711,6 +887,91 @@ internal static class PowerShellObjectNormalizer
         }
 
         return value;
+    }
+
+    private static string? NormalizeCellValueToText(object? value, PowerShellObjectNormalizerOptions options)
+    {
+        if (value == null)
+        {
+            return null;
+        }
+
+        if (value is string text)
+        {
+            return text;
+        }
+
+        if (value is bool boolValue)
+        {
+            return boolValue ? "True" : "False";
+        }
+
+        if (value is decimal or int or DateTime or double or long or DateTimeOffset or Guid or TimeSpan or float or byte or sbyte or short or ushort or uint or ulong)
+        {
+            return value is IFormattable formattable
+                ? formattable.ToString(null, options.Culture)
+                : value.ToString();
+        }
+
+        if (value is char charValue)
+        {
+            return charValue.ToString();
+        }
+
+        if (value is IDictionary)
+        {
+            return value.ToString();
+        }
+
+        if (options.NormalizeCollectionValues && value is IEnumerable enumerable)
+        {
+            var values = new List<string>();
+            foreach (var item in enumerable)
+            {
+                values.Add(ConvertValueToString(item));
+            }
+
+            return string.Join(options.CollectionSeparator, values);
+        }
+
+        return value is IFormattable fallbackFormattable
+            ? fallbackFormattable.ToString(null, options.Culture)
+            : value.ToString();
+    }
+
+    private static bool TryGetFastCellValue(object? value, PowerShellObjectNormalizerOptions options, out object? normalized)
+    {
+        normalized = value;
+        if (value == null || value is string || !options.NormalizeCollectionValues)
+        {
+            return true;
+        }
+
+        if (value is bool boolValue)
+        {
+            normalized = options.FormatScalarValuesAsText ? boolValue ? "True" : "False" : value;
+            return true;
+        }
+
+        if (value is decimal or int or DateTime or double or long or DateTimeOffset or Guid or TimeSpan or float or byte or sbyte or short or ushort or uint or ulong)
+        {
+            if (options.FormatScalarValuesAsText)
+            {
+                normalized = value is IFormattable formattable
+                    ? formattable.ToString(null, options.Culture)
+                    : value.ToString();
+            }
+
+            return true;
+        }
+
+        if (value is char charValue)
+        {
+            normalized = options.FormatScalarValuesAsText ? charValue.ToString() : value;
+            return true;
+        }
+
+        return false;
     }
 
     private static string ConvertValueToString(object? value)
@@ -814,4 +1075,8 @@ internal sealed class PowerShellObjectNormalizerOptions
     public bool NormalizeCollectionValues { get; set; } = true;
 
     public string CollectionSeparator { get; set; } = ", ";
+
+    public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
+
+    public bool FormatScalarValuesAsText { get; set; }
 }

--- a/Tests/Csv.Tests.ps1
+++ b/Tests/Csv.Tests.ps1
@@ -559,6 +559,20 @@ Describe 'CSV cmdlets' {
         $rows[1].Value | Should -Be '2'
     }
 
+    It 'keeps trailing missing header properties consistent across import modes' {
+        $path = Join-Path $TestDrive 'padded.csv'
+        Set-Content -LiteralPath $path -Value "Name,Value,Other`nAlpha,1" -Encoding UTF8
+
+        $streamed = @(Import-OfficeCsv -Path $path)
+        $inMemory = @(Import-OfficeCsv -Path $path -Mode InMemory)
+        $fromDocument = @(Get-OfficeCsv -Path $path | Import-OfficeCsv)
+
+        foreach ($row in @($streamed[0], $inMemory[0], $fromDocument[0])) {
+            $row.PSObject.Properties.Name | Should -Contain 'Other'
+            $row.Other | Should -BeNullOrEmpty
+        }
+    }
+
     It 'can enforce strict row width validation' {
         $path = Join-Path $TestDrive 'strict-uneven.csv'
         Set-Content -LiteralPath $path -Value "Name,Value`nAlpha" -Encoding UTF8


### PR DESCRIPTION
## Summary
- Consume the OfficeIMO.CSV fast-path APIs from PSWriteOffice CSV projection and row writing.
- Expand the dedicated CSV benchmark suite with mixed, quoted, multiline, and wide object profiles.
- Compare PSWriteOffice directly against native PowerShell `Export-Csv` / `Import-Csv` lanes.
- Bump PSWriteOffice OfficeIMO package references to the latest published OfficeIMO train, including `OfficeIMO.CSV` 0.1.53.
- Keep padded CSV row schemas consistent across streaming, in-memory, and document import paths.

## Validation
- `dotnet build .\Sources\PSWriteOffice\PSWriteOffice.csproj -c Release -p:OfficeIMORoot=C:\Support\GitHub\_missing-officeimo -v:minimal`
- `dotnet build .\Sources\PSWriteOffice\PSWriteOffice.csproj -c Release -v:minimal`
- `Invoke-Pester -Path .\Tests\Csv.Tests.ps1 -CI`
- `Invoke-Pester -Path .\Tests\Reader.Tests.ps1 -CI`
- `.\Benchmarks\Compare-CsvPerformance.ps1 -Suite Smoke -ListScenarios -OfficeIMORoot C:\Support\GitHub\_worktrees\OfficeIMO-csv-performance -SkipPSWriteOfficeBuild`
- `.\Benchmarks\Compare-CsvPerformance.ps1 -Suite Smoke -RowCount 1000 -Engine PSWriteOffice,NativeCsv -OfficeIMORoot C:\Support\GitHub\_worktrees\OfficeIMO-csv-performance -SkipPSWriteOfficeBuild`

## Dependency
The OfficeIMO.CSV fast-path work landed in EvotecIT/OfficeIMO#2031 and is now available through the published OfficeIMO package train. This PR validates both the published-package path and the local OfficeIMO source-reference path.