### PR TITLE
Improve async cmdlet pipeline handling

### DIFF
--- a/Sources/PSWriteOffice.Tests/AsyncPSCmdletTests.cs
+++ b/Sources/PSWriteOffice.Tests/AsyncPSCmdletTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using System.Threading.Tasks;
+using PSWriteOffice;
+
+namespace PSWriteOffice.Tests;
+
+public sealed class AsyncPSCmdletTests
+{
+    [Fact]
+    public void AsyncPSCmdlet_drains_worker_thread_writes_when_task_completes_synchronously()
+    {
+        var sessionState = InitialSessionState.CreateDefault();
+        sessionState.Commands.Add(new SessionStateCmdletEntry(
+            "Test-AsyncQueuedOutput",
+            typeof(TestAsyncQueuedOutputCommand),
+            helpFileName: null));
+
+        using var runspace = RunspaceFactory.CreateRunspace(sessionState);
+        runspace.Open();
+        using var powerShell = PowerShell.Create();
+        powerShell.Runspace = runspace;
+        powerShell.AddCommand("Test-AsyncQueuedOutput");
+
+        var result = powerShell.Invoke();
+
+        Assert.False(powerShell.HadErrors, string.Join(Environment.NewLine, powerShell.Streams.Error.Select(static error => error.ToString())));
+        var item = Assert.Single(result);
+        Assert.Equal("queued-output", item.BaseObject);
+    }
+}
+
+[Cmdlet(VerbsDiagnostic.Test, "AsyncQueuedOutput")]
+public sealed class TestAsyncQueuedOutputCommand : AsyncPSCmdlet
+{
+    protected override Task ProcessRecordAsync()
+        => Task.Run(() => WriteObject("queued-output"));
+}

--- a/Sources/PSWriteOffice.Tests/AsyncPSCmdletTests.cs
+++ b/Sources/PSWriteOffice.Tests/AsyncPSCmdletTests.cs
@@ -29,6 +29,28 @@ public sealed class AsyncPSCmdletTests
         var item = Assert.Single(result);
         Assert.Equal("queued-output", item.BaseObject);
     }
+
+    [Fact]
+    public void AsyncPSCmdlet_routes_helper_writes_through_async_pipeline_interface()
+    {
+        var sessionState = InitialSessionState.CreateDefault();
+        sessionState.Commands.Add(new SessionStateCmdletEntry(
+            "Test-AsyncHelperQueuedOutput",
+            typeof(TestAsyncHelperQueuedOutputCommand),
+            helpFileName: null));
+
+        using var runspace = RunspaceFactory.CreateRunspace(sessionState);
+        runspace.Open();
+        using var powerShell = PowerShell.Create();
+        powerShell.Runspace = runspace;
+        powerShell.AddCommand("Test-AsyncHelperQueuedOutput");
+
+        var result = powerShell.Invoke();
+
+        Assert.False(powerShell.HadErrors, string.Join(Environment.NewLine, powerShell.Streams.Error.Select(static error => error.ToString())));
+        var item = Assert.Single(result);
+        Assert.Equal("helper-output", item.BaseObject);
+    }
 }
 
 [Cmdlet(VerbsDiagnostic.Test, "AsyncQueuedOutput")]
@@ -36,4 +58,17 @@ public sealed class TestAsyncQueuedOutputCommand : AsyncPSCmdlet
 {
     protected override Task ProcessRecordAsync()
         => Task.Run(() => WriteObject("queued-output"));
+}
+
+[Cmdlet(VerbsDiagnostic.Test, "AsyncHelperQueuedOutput")]
+public sealed class TestAsyncHelperQueuedOutputCommand : AsyncPSCmdlet
+{
+    protected override Task ProcessRecordAsync()
+        => Task.Run(() => AsyncPipelineHelper.WriteOutput(this));
+}
+
+internal static class AsyncPipelineHelper
+{
+    public static void WriteOutput(IAsyncCmdletPipeline pipeline)
+        => pipeline.WriteObject("helper-output");
 }

--- a/Sources/PSWriteOffice.Tests/AsyncPSCmdletTests.cs
+++ b/Sources/PSWriteOffice.Tests/AsyncPSCmdletTests.cs
@@ -51,6 +51,29 @@ public sealed class AsyncPSCmdletTests
         var item = Assert.Single(result);
         Assert.Equal("helper-output", item.BaseObject);
     }
+
+    [Fact]
+    public async Task AsyncPSCmdlet_pumps_should_process_during_synchronous_worker_fan_out()
+    {
+        var sessionState = InitialSessionState.CreateDefault();
+        sessionState.Commands.Add(new SessionStateCmdletEntry(
+            "Test-AsyncSynchronousFanOut",
+            typeof(TestAsyncSynchronousFanOutCommand),
+            helpFileName: null));
+
+        using var runspace = RunspaceFactory.CreateRunspace(sessionState);
+        runspace.Open();
+        using var powerShell = PowerShell.Create();
+        powerShell.Runspace = runspace;
+        powerShell.AddCommand("Test-AsyncSynchronousFanOut");
+
+        var invokeTask = Task.Run(() => powerShell.Invoke());
+
+        var result = await invokeTask.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.False(powerShell.HadErrors, string.Join(Environment.NewLine, powerShell.Streams.Error.Select(static error => error.ToString())));
+        var item = Assert.Single(result);
+        Assert.Equal("fan-out-output", item.BaseObject);
+    }
 }
 
 [Cmdlet(VerbsDiagnostic.Test, "AsyncQueuedOutput")]
@@ -71,4 +94,22 @@ internal static class AsyncPipelineHelper
 {
     public static void WriteOutput(IAsyncCmdletPipeline pipeline)
         => pipeline.WriteObject("helper-output");
+}
+
+[Cmdlet(VerbsDiagnostic.Test, "AsyncSynchronousFanOut", SupportsShouldProcess = true)]
+public sealed class TestAsyncSynchronousFanOutCommand : AsyncPSCmdlet
+{
+    protected override Task ProcessRecordAsync()
+    {
+        var worker = Task.Run(() =>
+        {
+            if (ShouldProcess("fan-out-target", "write output"))
+            {
+                WriteObject("fan-out-output");
+            }
+        });
+
+        Task.WaitAll(worker);
+        return Task.CompletedTask;
+    }
 }

--- a/Sources/PSWriteOffice.Tests/PSWriteOffice.Tests.csproj
+++ b/Sources/PSWriteOffice.Tests/PSWriteOffice.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.14" PrivateAssets="all" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PSWriteOffice\PSWriteOffice.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Sources/PSWriteOffice.Tests/PSWriteOffice.Tests.csproj
+++ b/Sources/PSWriteOffice.Tests/PSWriteOffice.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.14" PrivateAssets="all" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>

--- a/Sources/PSWriteOffice.sln
+++ b/Sources/PSWriteOffice.sln
@@ -10,6 +10,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PSWriteOffice.TestingGround
 		{EEF3BFAD-C8A5-474C-BA52-5C20E66EF0F9} = {EEF3BFAD-C8A5-474C-BA52-5C20E66EF0F9}
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PSWriteOffice.Tests", "PSWriteOffice.Tests\PSWriteOffice.Tests.csproj", "{D2FC9AAC-27B5-4FC9-81F4-98DEBDF43D85}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,6 +26,10 @@ Global
 		{454D23ED-E33C-4933-A915-56065BA3A8F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{454D23ED-E33C-4933-A915-56065BA3A8F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{454D23ED-E33C-4933-A915-56065BA3A8F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D2FC9AAC-27B5-4FC9-81F4-98DEBDF43D85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D2FC9AAC-27B5-4FC9-81F4-98DEBDF43D85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D2FC9AAC-27B5-4FC9-81F4-98DEBDF43D85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D2FC9AAC-27B5-4FC9-81F4-98DEBDF43D85}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Sources/PSWriteOffice/Support/AsyncPSCmdlet.cs
+++ b/Sources/PSWriteOffice/Support/AsyncPSCmdlet.cs
@@ -9,7 +9,7 @@ namespace PSWriteOffice;
 /// Base class for cmdlets that await asynchronous engine work while routing PowerShell pipeline writes
 /// back through the synchronous cmdlet pipeline thread.
 /// </summary>
-public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
+public abstract class AsyncPSCmdlet : PSCmdlet, IAsyncCmdletPipeline, IDisposable {
     private enum PipelineType {
         Output,
         OutputEnumerate,
@@ -23,9 +23,22 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
         PromptForCredential
     }
 
+    private sealed class PipelineItem {
+        public PipelineItem(object? value, PipelineType type, BlockingCollection<object?>? replyPipe = null) {
+            Value = value;
+            Type = type;
+            ReplyPipe = replyPipe;
+        }
+
+        public object? Value { get; }
+
+        public PipelineType Type { get; }
+
+        public BlockingCollection<object?>? ReplyPipe { get; }
+    }
+
     private readonly CancellationTokenSource _cancelSource = new();
-    private BlockingCollection<(object? Value, PipelineType Type)>? _currentOutPipe;
-    private BlockingCollection<object?>? _currentReplyPipe;
+    private BlockingCollection<PipelineItem>? _currentOutPipe;
     private int _pipelineThreadId;
 
     /// <summary>Cancellation token triggered when PowerShell stops the cmdlet.</summary>
@@ -62,23 +75,25 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
     /// <summary>Thread-safe ShouldProcess bridge for asynchronous cmdlet code.</summary>
     public new bool ShouldProcess(string? target, string action) {
         ThrowIfStopped();
-        if (_currentOutPipe is null || _currentReplyPipe is null || IsPipelineThread) {
+        if (_currentOutPipe is null || IsPipelineThread) {
             return base.ShouldProcess(target ?? string.Empty, action);
         }
 
-        _currentOutPipe.Add(((target ?? string.Empty, action), PipelineType.ShouldProcess), CancelToken);
-        return (bool)_currentReplyPipe.Take(CancelToken)!;
+        using var replyPipe = new BlockingCollection<object?>(boundedCapacity: 1);
+        _currentOutPipe.Add(new PipelineItem((target ?? string.Empty, action), PipelineType.ShouldProcess, replyPipe), CancelToken);
+        return (bool)replyPipe.Take(CancelToken)!;
     }
 
     /// <summary>Thread-safe credential prompt bridge for asynchronous cmdlet code.</summary>
     public PSCredential? PromptForCredential(string caption, string message, string userName, string targetName) {
         ThrowIfStopped();
-        if (_currentOutPipe is null || _currentReplyPipe is null || IsPipelineThread) {
+        if (_currentOutPipe is null || IsPipelineThread) {
             return Host.UI.PromptForCredential(caption, message, userName, targetName);
         }
 
-        _currentOutPipe.Add(((caption, message, userName, targetName), PipelineType.PromptForCredential), CancelToken);
-        return (PSCredential?)_currentReplyPipe.Take(CancelToken);
+        using var replyPipe = new BlockingCollection<object?>(boundedCapacity: 1);
+        _currentOutPipe.Add(new PipelineItem((caption, message, userName, targetName), PipelineType.PromptForCredential, replyPipe), CancelToken);
+        return (PSCredential?)replyPipe.Take(CancelToken);
     }
 
     /// <summary>Thread-safe output bridge for asynchronous cmdlet code.</summary>
@@ -93,7 +108,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
             return;
         }
 
-        _currentOutPipe.Add((sendToPipeline, enumerateCollection ? PipelineType.OutputEnumerate : PipelineType.Output), CancelToken);
+        _currentOutPipe.Add(new PipelineItem(sendToPipeline, enumerateCollection ? PipelineType.OutputEnumerate : PipelineType.Output), CancelToken);
     }
 
     /// <summary>Thread-safe error bridge for asynchronous cmdlet code.</summary>
@@ -104,7 +119,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
             return;
         }
 
-        _currentOutPipe.Add((errorRecord, PipelineType.Error), CancelToken);
+        _currentOutPipe.Add(new PipelineItem(errorRecord, PipelineType.Error), CancelToken);
     }
 
     /// <summary>Thread-safe warning bridge for asynchronous cmdlet code.</summary>
@@ -115,7 +130,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
             return;
         }
 
-        _currentOutPipe.Add((message, PipelineType.Warning), CancelToken);
+        _currentOutPipe.Add(new PipelineItem(message, PipelineType.Warning), CancelToken);
     }
 
     /// <summary>Thread-safe verbose bridge for asynchronous cmdlet code.</summary>
@@ -126,7 +141,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
             return;
         }
 
-        _currentOutPipe.Add((message, PipelineType.Verbose), CancelToken);
+        _currentOutPipe.Add(new PipelineItem(message, PipelineType.Verbose), CancelToken);
     }
 
     /// <summary>Thread-safe debug bridge for asynchronous cmdlet code.</summary>
@@ -137,7 +152,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
             return;
         }
 
-        _currentOutPipe.Add((message, PipelineType.Debug), CancelToken);
+        _currentOutPipe.Add(new PipelineItem(message, PipelineType.Debug), CancelToken);
     }
 
     /// <summary>Thread-safe information bridge for asynchronous cmdlet code.</summary>
@@ -148,7 +163,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
             return;
         }
 
-        _currentOutPipe.Add((informationRecord, PipelineType.Information), CancelToken);
+        _currentOutPipe.Add(new PipelineItem(informationRecord, PipelineType.Information), CancelToken);
     }
 
     /// <summary>Thread-safe progress bridge for asynchronous cmdlet code.</summary>
@@ -159,7 +174,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
             return;
         }
 
-        _currentOutPipe.Add((progressRecord, PipelineType.Progress), CancelToken);
+        _currentOutPipe.Add(new PipelineItem(progressRecord, PipelineType.Progress), CancelToken);
     }
 
     /// <summary>Throws when PowerShell has requested cancellation.</summary>
@@ -180,16 +195,13 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
         => _pipelineThreadId != 0 && Environment.CurrentManagedThreadId == _pipelineThreadId;
 
     private void RunBlockInAsync(Func<Task> task) {
-        using var outPipe = new BlockingCollection<(object? Value, PipelineType Type)>();
-        using var replyPipe = new BlockingCollection<object?>();
+        using var outPipe = new BlockingCollection<PipelineItem>();
         Task blockTask;
 
         void ClearPipes() {
             _currentOutPipe = null;
-            _currentReplyPipe = null;
             _pipelineThreadId = 0;
             CompleteAddingIfNeeded(outPipe);
-            CompleteAddingIfNeeded(replyPipe);
         }
 
         static void CompleteAddingIfNeeded<T>(BlockingCollection<T> pipe) {
@@ -198,7 +210,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
             }
         }
 
-        void PumpItem((object? Value, PipelineType Type) item) {
+        void PumpItem(PipelineItem item) {
             switch (item.Type) {
                 case PipelineType.Output:
                     base.WriteObject(item.Value);
@@ -226,11 +238,11 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
                     break;
                 case PipelineType.ShouldProcess:
                     var should = ((string Target, string Action))item.Value!;
-                    replyPipe.Add(base.ShouldProcess(should.Target, should.Action), CancelToken);
+                    item.ReplyPipe!.Add(base.ShouldProcess(should.Target, should.Action), CancelToken);
                     break;
                 case PipelineType.PromptForCredential:
                     var prompt = ((string Caption, string Message, string UserName, string TargetName))item.Value!;
-                    replyPipe.Add(
+                    item.ReplyPipe!.Add(
                         Host.UI.PromptForCredential(prompt.Caption, prompt.Message, prompt.UserName, prompt.TargetName),
                         CancelToken);
                     break;
@@ -245,7 +257,6 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
 
         _pipelineThreadId = Environment.CurrentManagedThreadId;
         _currentOutPipe = outPipe;
-        _currentReplyPipe = replyPipe;
 
         try {
             blockTask = task();

--- a/Sources/PSWriteOffice/Support/AsyncPSCmdlet.cs
+++ b/Sources/PSWriteOffice/Support/AsyncPSCmdlet.cs
@@ -6,12 +6,10 @@ using System.Threading.Tasks;
 
 namespace PSWriteOffice;
 /// <summary>
-/// Base class for asynchronous PowerShell cmdlets.
+/// Base class for cmdlets that await asynchronous engine work while routing PowerShell pipeline writes
+/// back through the synchronous cmdlet pipeline thread.
 /// </summary>
 public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
-    /// <summary>
-    /// Types of pipeline messages handled by <see cref="AsyncPSCmdlet"/>.
-    /// </summary>
     private enum PipelineType {
         Output,
         OutputEnumerate,
@@ -21,189 +19,150 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
         Debug,
         Information,
         Progress,
+        ShouldProcess,
+        PromptForCredential
     }
 
-    private CancellationTokenSource _cancelSource = new();
+    private readonly CancellationTokenSource _cancelSource = new();
+    private BlockingCollection<(object? Value, PipelineType Type)>? _currentOutPipe;
+    private BlockingCollection<object?>? _currentReplyPipe;
+    private int _pipelineThreadId;
 
-    private BlockingCollection<(object?, PipelineType)>? _currentPipe;
+    /// <summary>Cancellation token triggered when PowerShell stops the cmdlet.</summary>
+    protected internal CancellationToken CancelToken => _cancelSource.Token;
 
-    /// <summary>
-    /// Gets the cancellation token for the cmdlet execution.
-    /// </summary>
-    protected CancellationToken CancelToken { get => _cancelSource.Token; }
-
-    /// <summary>
-    /// Invoked when the cmdlet begins execution.
-    /// Runs <see cref="BeginProcessingAsync"/> within the asynchronous pipeline.
-    /// </summary>
+    /// <inheritdoc />
     protected override void BeginProcessing()
         => RunBlockInAsync(BeginProcessingAsync);
 
-    /// <summary>
-    /// Performs initialization logic for the cmdlet.
-    /// </summary>
-    /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
+    /// <summary>Asynchronous begin hook.</summary>
     protected virtual Task BeginProcessingAsync()
         => Task.CompletedTask;
 
-    /// <summary>
-    /// Processes input records synchronously and dispatches <see cref="ProcessRecordAsync"/>.
-    /// </summary>
+    /// <inheritdoc />
     protected override void ProcessRecord()
         => RunBlockInAsync(ProcessRecordAsync);
 
-    /// <summary>
-    /// Executes the main cmdlet logic.
-    /// </summary>
-    /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
+    /// <summary>Asynchronous process-record hook.</summary>
     protected virtual Task ProcessRecordAsync()
         => Task.CompletedTask;
 
-    /// <summary>
-    /// Invoked once when processing has completed.
-    /// Runs <see cref="EndProcessingAsync"/> within the asynchronous pipeline.
-    /// </summary>
+    /// <inheritdoc />
     protected override void EndProcessing()
         => RunBlockInAsync(EndProcessingAsync);
 
-    /// <summary>
-    /// Performs cleanup logic for the cmdlet.
-    /// </summary>
-    /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
+    /// <summary>Asynchronous end hook.</summary>
     protected virtual Task EndProcessingAsync()
         => Task.CompletedTask;
 
-    /// <summary>
-    /// Requests cancellation of the cmdlet execution.
-    /// </summary>
+    /// <inheritdoc />
     protected override void StopProcessing()
-        => _cancelSource?.Cancel();
+        => _cancelSource.Cancel();
 
-    private void RunBlockInAsync(Func<Task> task) {
-        using BlockingCollection<(object?, PipelineType)> pipe = new();
-        Task blockTask = Task.Run(async () => {
-            try {
-                _currentPipe = pipe;
-                await task();
-            } finally {
-                _currentPipe = null;
-                pipe.CompleteAdding();
-            }
-        });
-
-        foreach ((object? data, PipelineType pipelineType) in pipe.GetConsumingEnumerable()) {
-            switch (pipelineType) {
-                case PipelineType.Output:
-                    base.WriteObject(data);
-                    break;
-
-                case PipelineType.OutputEnumerate:
-                    base.WriteObject(data, true);
-                    break;
-
-                case PipelineType.Error:
-                    base.WriteError((ErrorRecord)data!);
-                    break;
-
-                case PipelineType.Warning:
-                    base.WriteWarning((string)data!);
-                    break;
-
-                case PipelineType.Verbose:
-                    base.WriteVerbose((string)data!);
-                    break;
-
-                case PipelineType.Debug:
-                    base.WriteDebug((string)data!);
-                    break;
-
-                case PipelineType.Information:
-                    base.WriteInformation((InformationRecord)data!);
-                    break;
-
-                case PipelineType.Progress:
-                    base.WriteProgress((ProgressRecord)data!);
-                    break;
-            }
+    /// <summary>Thread-safe ShouldProcess bridge for asynchronous cmdlet code.</summary>
+    public new bool ShouldProcess(string? target, string action) {
+        ThrowIfStopped();
+        if (_currentOutPipe is null || _currentReplyPipe is null || IsPipelineThread) {
+            return base.ShouldProcess(target ?? string.Empty, action);
         }
 
-        blockTask.GetAwaiter().GetResult();
+        _currentOutPipe.Add(((target ?? string.Empty, action), PipelineType.ShouldProcess), CancelToken);
+        return (bool)_currentReplyPipe.Take(CancelToken)!;
     }
 
-    /// <summary>
-    /// Writes an object to the pipeline.
-    /// </summary>
-    /// <param name="sendToPipeline">Object to write.</param>
-    public new void WriteObject(object? sendToPipeline) => WriteObject(sendToPipeline, false);
+    /// <summary>Thread-safe credential prompt bridge for asynchronous cmdlet code.</summary>
+    public PSCredential? PromptForCredential(string caption, string message, string userName, string targetName) {
+        ThrowIfStopped();
+        if (_currentOutPipe is null || _currentReplyPipe is null || IsPipelineThread) {
+            return Host.UI.PromptForCredential(caption, message, userName, targetName);
+        }
 
-    /// <summary>
-    /// Writes an object to the pipeline with optional enumeration.
-    /// </summary>
-    /// <param name="sendToPipeline">Object to write.</param>
-    /// <param name="enumerateCollection">True to enumerate collections.</param>
+        _currentOutPipe.Add(((caption, message, userName, targetName), PipelineType.PromptForCredential), CancelToken);
+        return (PSCredential?)_currentReplyPipe.Take(CancelToken);
+    }
+
+    /// <summary>Thread-safe output bridge for asynchronous cmdlet code.</summary>
+    public new void WriteObject(object? sendToPipeline)
+        => WriteObject(sendToPipeline, false);
+
+    /// <summary>Thread-safe output bridge for asynchronous cmdlet code.</summary>
     public new void WriteObject(object? sendToPipeline, bool enumerateCollection) {
         ThrowIfStopped();
-        _currentPipe?.Add(
-            (sendToPipeline, enumerateCollection ? PipelineType.OutputEnumerate : PipelineType.Output));
+        if (_currentOutPipe is null || IsPipelineThread) {
+            base.WriteObject(sendToPipeline, enumerateCollection);
+            return;
+        }
+
+        _currentOutPipe.Add((sendToPipeline, enumerateCollection ? PipelineType.OutputEnumerate : PipelineType.Output), CancelToken);
     }
 
-    /// <summary>
-    /// Writes an error record to the pipeline.
-    /// </summary>
-    /// <param name="errorRecord">The error record.</param>
+    /// <summary>Thread-safe error bridge for asynchronous cmdlet code.</summary>
     public new void WriteError(ErrorRecord errorRecord) {
         ThrowIfStopped();
-        _currentPipe?.Add((errorRecord, PipelineType.Error));
+        if (_currentOutPipe is null || IsPipelineThread) {
+            base.WriteError(errorRecord);
+            return;
+        }
+
+        _currentOutPipe.Add((errorRecord, PipelineType.Error), CancelToken);
     }
 
-    /// <summary>
-    /// Writes a warning message to the pipeline.
-    /// </summary>
-    /// <param name="message">The warning message.</param>
+    /// <summary>Thread-safe warning bridge for asynchronous cmdlet code.</summary>
     public new void WriteWarning(string message) {
         ThrowIfStopped();
-        _currentPipe?.Add((message, PipelineType.Warning));
+        if (_currentOutPipe is null || IsPipelineThread) {
+            base.WriteWarning(message);
+            return;
+        }
+
+        _currentOutPipe.Add((message, PipelineType.Warning), CancelToken);
     }
 
-    /// <summary>
-    /// Writes a verbose message to the pipeline.
-    /// </summary>
-    /// <param name="message">The verbose message.</param>
+    /// <summary>Thread-safe verbose bridge for asynchronous cmdlet code.</summary>
     public new void WriteVerbose(string message) {
         ThrowIfStopped();
-        _currentPipe?.Add((message, PipelineType.Verbose));
+        if (_currentOutPipe is null || IsPipelineThread) {
+            base.WriteVerbose(message);
+            return;
+        }
+
+        _currentOutPipe.Add((message, PipelineType.Verbose), CancelToken);
     }
 
-    /// <summary>
-    /// Writes a debug message to the pipeline.
-    /// </summary>
-    /// <param name="message">The debug message.</param>
+    /// <summary>Thread-safe debug bridge for asynchronous cmdlet code.</summary>
     public new void WriteDebug(string message) {
         ThrowIfStopped();
-        _currentPipe?.Add((message, PipelineType.Debug));
+        if (_currentOutPipe is null || IsPipelineThread) {
+            base.WriteDebug(message);
+            return;
+        }
+
+        _currentOutPipe.Add((message, PipelineType.Debug), CancelToken);
     }
 
-    /// <summary>
-    /// Writes an information record to the pipeline.
-    /// </summary>
-    /// <param name="informationRecord">The information record.</param>
+    /// <summary>Thread-safe information bridge for asynchronous cmdlet code.</summary>
     public new void WriteInformation(InformationRecord informationRecord) {
         ThrowIfStopped();
-        _currentPipe?.Add((informationRecord, PipelineType.Information));
+        if (_currentOutPipe is null || IsPipelineThread) {
+            base.WriteInformation(informationRecord);
+            return;
+        }
+
+        _currentOutPipe.Add((informationRecord, PipelineType.Information), CancelToken);
     }
 
-    /// <summary>
-    /// Writes a progress record to the pipeline.
-    /// </summary>
-    /// <param name="progressRecord">The progress record.</param>
+    /// <summary>Thread-safe progress bridge for asynchronous cmdlet code.</summary>
     public new void WriteProgress(ProgressRecord progressRecord) {
         ThrowIfStopped();
-        _currentPipe?.Add((progressRecord, PipelineType.Progress));
+        if (_currentOutPipe is null || IsPipelineThread) {
+            base.WriteProgress(progressRecord);
+            return;
+        }
+
+        _currentOutPipe.Add((progressRecord, PipelineType.Progress), CancelToken);
     }
 
-    /// <summary>
-    /// Throws if the cmdlet execution has been stopped.
-    /// </summary>
+    /// <summary>Throws when PowerShell has requested cancellation.</summary>
     internal void ThrowIfStopped() {
         if (_cancelSource.IsCancellationRequested) {
             throw new PipelineStoppedException();
@@ -214,6 +173,116 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
     /// Disposes managed resources.
     /// </summary>
     public void Dispose() {
-        _cancelSource?.Dispose();
+        _cancelSource.Dispose();
+    }
+
+    private bool IsPipelineThread
+        => _pipelineThreadId != 0 && Environment.CurrentManagedThreadId == _pipelineThreadId;
+
+    private void RunBlockInAsync(Func<Task> task) {
+        using var outPipe = new BlockingCollection<(object? Value, PipelineType Type)>();
+        using var replyPipe = new BlockingCollection<object?>();
+        Task blockTask;
+
+        void ClearPipes() {
+            _currentOutPipe = null;
+            _currentReplyPipe = null;
+            _pipelineThreadId = 0;
+            CompleteAddingIfNeeded(outPipe);
+            CompleteAddingIfNeeded(replyPipe);
+        }
+
+        static void CompleteAddingIfNeeded<T>(BlockingCollection<T> pipe) {
+            if (!pipe.IsAddingCompleted) {
+                pipe.CompleteAdding();
+            }
+        }
+
+        void PumpItem((object? Value, PipelineType Type) item) {
+            switch (item.Type) {
+                case PipelineType.Output:
+                    base.WriteObject(item.Value);
+                    break;
+                case PipelineType.OutputEnumerate:
+                    base.WriteObject(item.Value, true);
+                    break;
+                case PipelineType.Error:
+                    base.WriteError((ErrorRecord)item.Value!);
+                    break;
+                case PipelineType.Warning:
+                    base.WriteWarning((string)item.Value!);
+                    break;
+                case PipelineType.Verbose:
+                    base.WriteVerbose((string)item.Value!);
+                    break;
+                case PipelineType.Debug:
+                    base.WriteDebug((string)item.Value!);
+                    break;
+                case PipelineType.Information:
+                    base.WriteInformation((InformationRecord)item.Value!);
+                    break;
+                case PipelineType.Progress:
+                    base.WriteProgress((ProgressRecord)item.Value!);
+                    break;
+                case PipelineType.ShouldProcess:
+                    var should = ((string Target, string Action))item.Value!;
+                    replyPipe.Add(base.ShouldProcess(should.Target, should.Action), CancelToken);
+                    break;
+                case PipelineType.PromptForCredential:
+                    var prompt = ((string Caption, string Message, string UserName, string TargetName))item.Value!;
+                    replyPipe.Add(
+                        Host.UI.PromptForCredential(prompt.Caption, prompt.Message, prompt.UserName, prompt.TargetName),
+                        CancelToken);
+                    break;
+            }
+        }
+
+        void PumpQueuedItems() {
+            while (outPipe.TryTake(out var item)) {
+                PumpItem(item);
+            }
+        }
+
+        _pipelineThreadId = Environment.CurrentManagedThreadId;
+        _currentOutPipe = outPipe;
+        _currentReplyPipe = replyPipe;
+
+        try {
+            blockTask = task();
+        } catch {
+            ClearPipes();
+            throw;
+        }
+
+        if (blockTask.IsCompleted) {
+            CompleteAddingIfNeeded(outPipe);
+            PumpQueuedItems();
+            ClearPipes();
+            blockTask.GetAwaiter().GetResult();
+            return;
+        }
+
+        _ = blockTask.ContinueWith(
+            _ => ClearPipes(),
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        try {
+            foreach (var item in outPipe.GetConsumingEnumerable(CancelToken)) {
+                PumpItem(item);
+            }
+        } catch {
+            _cancelSource.Cancel();
+            CompleteAddingIfNeeded(outPipe);
+            try {
+                blockTask.GetAwaiter().GetResult();
+            } catch (Exception ex) when (ex is OperationCanceledException or PipelineStoppedException) {
+            }
+
+            throw;
+        }
+
+        blockTask.GetAwaiter().GetResult();
     }
 }

--- a/Sources/PSWriteOffice/Support/AsyncPSCmdlet.cs
+++ b/Sources/PSWriteOffice/Support/AsyncPSCmdlet.cs
@@ -249,29 +249,10 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IAsyncCmdletPipeline, IDisposabl
             }
         }
 
-        void PumpQueuedItems() {
-            while (outPipe.TryTake(out var item)) {
-                PumpItem(item);
-            }
-        }
-
         _pipelineThreadId = Environment.CurrentManagedThreadId;
         _currentOutPipe = outPipe;
 
-        try {
-            blockTask = task();
-        } catch {
-            ClearPipes();
-            throw;
-        }
-
-        if (blockTask.IsCompleted) {
-            CompleteAddingIfNeeded(outPipe);
-            PumpQueuedItems();
-            ClearPipes();
-            blockTask.GetAwaiter().GetResult();
-            return;
-        }
+        blockTask = Task.Run(task, CancelToken);
 
         _ = blockTask.ContinueWith(
             _ => ClearPipes(),

--- a/Sources/PSWriteOffice/Support/IAsyncCmdletPipeline.cs
+++ b/Sources/PSWriteOffice/Support/IAsyncCmdletPipeline.cs
@@ -1,0 +1,38 @@
+using System.Management.Automation;
+
+namespace PSWriteOffice;
+
+/// <summary>
+/// Provides async-safe access to PowerShell pipeline operations.
+/// </summary>
+public interface IAsyncCmdletPipeline {
+    /// <summary>Writes an object to the PowerShell output pipeline.</summary>
+    void WriteObject(object? sendToPipeline);
+
+    /// <summary>Writes an object to the PowerShell output pipeline.</summary>
+    void WriteObject(object? sendToPipeline, bool enumerateCollection);
+
+    /// <summary>Writes an error record to the PowerShell error stream.</summary>
+    void WriteError(ErrorRecord errorRecord);
+
+    /// <summary>Writes a warning message to the PowerShell warning stream.</summary>
+    void WriteWarning(string message);
+
+    /// <summary>Writes a verbose message to the PowerShell verbose stream.</summary>
+    void WriteVerbose(string message);
+
+    /// <summary>Writes a debug message to the PowerShell debug stream.</summary>
+    void WriteDebug(string message);
+
+    /// <summary>Writes an information record to the PowerShell information stream.</summary>
+    void WriteInformation(InformationRecord informationRecord);
+
+    /// <summary>Writes a progress record to the PowerShell progress stream.</summary>
+    void WriteProgress(ProgressRecord progressRecord);
+
+    /// <summary>Runs ShouldProcess on the PowerShell pipeline thread.</summary>
+    bool ShouldProcess(string? target, string action);
+
+    /// <summary>Prompts for credentials on the PowerShell pipeline thread.</summary>
+    PSCredential? PromptForCredential(string caption, string message, string userName, string targetName);
+}


### PR DESCRIPTION
## Summary
- upgrade `AsyncPSCmdlet` so async command work routes output, progress, errors, `ShouldProcess`, and credential prompts back through the PowerShell pipeline thread
- use per-request replies for confirmation and credential prompts so concurrent worker calls cannot consume another request's response
- add `IAsyncCmdletPipeline` for helpers that need async-safe pipeline writes without erasing the bridge behind `PSCmdlet`
- keep the pipeline pump active while async hooks run, including synchronous worker fan-out that waits on `ShouldProcess`
- add xUnit runspace regressions for worker-thread output, helper dispatch, and synchronous fan-out

## Validation
- `dotnet test .\Sources\PSWriteOffice.sln -c Debug`
- `dotnet test .\Sources\PSWriteOffice.sln -c Debug --collect:"XPlat Code Coverage"`