### PR TITLE
Expose Office CSV parity options

### DIFF
--- a/Docs/ConvertFrom-OfficeCsv.md
+++ b/Docs/ConvertFrom-OfficeCsv.md
@@ -11,17 +11,17 @@ Converts CSV text to PSCustomObjects or dictionaries.
 ## SYNTAX
 ### TextDelimiter (Default)
 ```powershell
-ConvertFrom-OfficeCsv [-Text] <string> [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-Delimiter <char>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-AsHashtable] [<CommonParameters>]
+ConvertFrom-OfficeCsv [-Text] <string> [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-Delimiter <char>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-AsHashtable] [<CommonParameters>]
 ```
 
 ### TextCulture
 ```powershell
-ConvertFrom-OfficeCsv [-Text] <string> -UseCulture [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-AsHashtable] [<CommonParameters>]
+ConvertFrom-OfficeCsv [-Text] <string> -UseCulture [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-AsHashtable] [<CommonParameters>]
 ```
 
 ### TextDetect
 ```powershell
-ConvertFrom-OfficeCsv [-Text] <string> -DetectDelimiter [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-DelimiterCandidates <char[]>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-AsHashtable] [<CommonParameters>]
+ConvertFrom-OfficeCsv [-Text] <string> -DetectDelimiter [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-DelimiterCandidates <char[]>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-AsHashtable] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -125,6 +125,22 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -DateTimeFormats
+Additional date/time formats used by typed conversions and validation.
+
+```yaml
+Type: String[]
+Parameter Sets: TextDelimiter, TextCulture, TextDetect
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -Delimiter
 Field delimiter character.
 
@@ -173,6 +189,22 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -DuplicateHeaderBehavior
+Controls how duplicate header names are handled.
+
+```yaml
+Type: CsvDuplicateHeaderBehavior
+Parameter Sets: TextDelimiter, TextCulture, TextDetect
+Aliases: None
+Possible values: Preserve, Rename, Throw
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -Header
 Explicit header names to use; when provided, the first CSV record is treated as data.
 
@@ -213,6 +245,38 @@ Type: SwitchParameter
 Parameter Sets: TextDelimiter, TextCulture, TextDetect
 Aliases: None
 Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -NullValue
+Token that is materialized as null when converting rows.
+
+```yaml
+Type: String
+Parameter Sets: TextDelimiter, TextCulture, TextDetect
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -QuoteParsingMode
+Controls whether malformed quoted fields are parsed leniently or rejected.
+
+```yaml
+Type: CsvQuoteParsingMode
+Parameter Sets: TextDelimiter, TextCulture, TextDetect
+Aliases: None
+Possible values: Lenient, Strict
 
 Required: False
 Position: named
@@ -274,6 +338,22 @@ Number of parsed CSV records to skip before header discovery or data output.
 
 ```yaml
 Type: Int32
+Parameter Sets: TextDelimiter, TextCulture, TextDetect
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -StaticColumns
+Static columns appended to every converted row.
+
+```yaml
+Type: IDictionary
 Parameter Sets: TextDelimiter, TextCulture, TextDetect
 Aliases: None
 Possible values:

--- a/Docs/ConvertTo-OfficeCsv.md
+++ b/Docs/ConvertTo-OfficeCsv.md
@@ -11,22 +11,22 @@ Converts objects or a CSV document into CSV text.
 ## SYNTAX
 ### InputObjectDelimiter (Default)
 ```powershell
-ConvertTo-OfficeCsv [-InputObject <Object>] [-Delimiter <char>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [<CommonParameters>]
+ConvertTo-OfficeCsv [-InputObject <Object>] [-Delimiter <char>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-NullValue <string>] [-DateTimeFormat <string>] [-UseUtc] [<CommonParameters>]
 ```
 
 ### DocumentDelimiter
 ```powershell
-ConvertTo-OfficeCsv -Document <CsvDocument> [-Delimiter <char>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [<CommonParameters>]
+ConvertTo-OfficeCsv -Document <CsvDocument> [-Delimiter <char>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-NullValue <string>] [-DateTimeFormat <string>] [-UseUtc] [<CommonParameters>]
 ```
 
 ### DocumentCulture
 ```powershell
-ConvertTo-OfficeCsv -Document <CsvDocument> -UseCulture [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [<CommonParameters>]
+ConvertTo-OfficeCsv -Document <CsvDocument> -UseCulture [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-NullValue <string>] [-DateTimeFormat <string>] [-UseUtc] [<CommonParameters>]
 ```
 
 ### InputObjectCulture
 ```powershell
-ConvertTo-OfficeCsv -UseCulture [-InputObject <Object>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [<CommonParameters>]
+ConvertTo-OfficeCsv -UseCulture [-InputObject <Object>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-NullValue <string>] [-DateTimeFormat <string>] [-UseUtc] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -66,6 +66,22 @@ Culture used for value formatting.
 
 ```yaml
 Type: CultureInfo
+Parameter Sets: InputObjectDelimiter, DocumentDelimiter, DocumentCulture, InputObjectCulture
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -DateTimeFormat
+Date/time format used for DateTime and DateTimeOffset values.
+
+```yaml
+Type: String
 Parameter Sets: InputObjectDelimiter, DocumentDelimiter, DocumentCulture, InputObjectCulture
 Aliases: None
 Possible values:
@@ -173,6 +189,22 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -NullValue
+Token written for null values.
+
+```yaml
+Type: String
+Parameter Sets: InputObjectDelimiter, DocumentDelimiter, DocumentCulture, InputObjectCulture
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -QuoteFields
 Field names that should always be quoted when UseQuotes is AsNeeded.
 
@@ -213,6 +245,22 @@ Type: CsvQuoteMode
 Parameter Sets: InputObjectDelimiter, DocumentDelimiter, DocumentCulture, InputObjectCulture
 Aliases: None
 Possible values: AsNeeded, Always, Never
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -UseUtc
+Convert date/time values to UTC before formatting.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: InputObjectDelimiter, DocumentDelimiter, DocumentCulture, InputObjectCulture
+Aliases: None
+Possible values:
 
 Required: False
 Position: named

--- a/Docs/Export-OfficeCsv.md
+++ b/Docs/Export-OfficeCsv.md
@@ -11,42 +11,42 @@ Exports objects or a CSV document to a CSV file.
 ## SYNTAX
 ### InputObjectPathDelimiter (Default)
 ```powershell
-Export-OfficeCsv [-Path] <string> [-InputObject <Object>] [-Delimiter <char>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-PassThru] [-Append] [-NoClobber] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-OfficeCsv [-Path] <string> [-InputObject <Object>] [-Delimiter <char>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-NullValue <string>] [-DateTimeFormat <string>] [-UseUtc] [-CompressionType <CsvCompressionType>] [-CompressionLevel <CompressionLevel>] [-PassThru] [-Append] [-NoClobber] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### InputObjectPathCulture
 ```powershell
-Export-OfficeCsv [-Path] <string> -UseCulture [-InputObject <Object>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-PassThru] [-Append] [-NoClobber] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-OfficeCsv [-Path] <string> -UseCulture [-InputObject <Object>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-NullValue <string>] [-DateTimeFormat <string>] [-UseUtc] [-CompressionType <CsvCompressionType>] [-CompressionLevel <CompressionLevel>] [-PassThru] [-Append] [-NoClobber] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### InputObjectLiteralPathDelimiter
 ```powershell
-Export-OfficeCsv -LiteralPath <string> [-InputObject <Object>] [-Delimiter <char>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-PassThru] [-Append] [-NoClobber] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-OfficeCsv -LiteralPath <string> [-InputObject <Object>] [-Delimiter <char>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-NullValue <string>] [-DateTimeFormat <string>] [-UseUtc] [-CompressionType <CsvCompressionType>] [-CompressionLevel <CompressionLevel>] [-PassThru] [-Append] [-NoClobber] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### InputObjectLiteralPathCulture
 ```powershell
-Export-OfficeCsv -LiteralPath <string> -UseCulture [-InputObject <Object>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-PassThru] [-Append] [-NoClobber] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-OfficeCsv -LiteralPath <string> -UseCulture [-InputObject <Object>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-NullValue <string>] [-DateTimeFormat <string>] [-UseUtc] [-CompressionType <CsvCompressionType>] [-CompressionLevel <CompressionLevel>] [-PassThru] [-Append] [-NoClobber] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### DocumentPathDelimiter
 ```powershell
-Export-OfficeCsv [-Path] <string> -Document <CsvDocument> [-Delimiter <char>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-PassThru] [-Append] [-NoClobber] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-OfficeCsv [-Path] <string> -Document <CsvDocument> [-Delimiter <char>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-NullValue <string>] [-DateTimeFormat <string>] [-UseUtc] [-CompressionType <CsvCompressionType>] [-CompressionLevel <CompressionLevel>] [-PassThru] [-Append] [-NoClobber] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### DocumentPathCulture
 ```powershell
-Export-OfficeCsv [-Path] <string> -Document <CsvDocument> -UseCulture [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-PassThru] [-Append] [-NoClobber] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-OfficeCsv [-Path] <string> -Document <CsvDocument> -UseCulture [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-NullValue <string>] [-DateTimeFormat <string>] [-UseUtc] [-CompressionType <CsvCompressionType>] [-CompressionLevel <CompressionLevel>] [-PassThru] [-Append] [-NoClobber] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### DocumentLiteralPathDelimiter
 ```powershell
-Export-OfficeCsv -Document <CsvDocument> -LiteralPath <string> [-Delimiter <char>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-PassThru] [-Append] [-NoClobber] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-OfficeCsv -Document <CsvDocument> -LiteralPath <string> [-Delimiter <char>] [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-NullValue <string>] [-DateTimeFormat <string>] [-UseUtc] [-CompressionType <CsvCompressionType>] [-CompressionLevel <CompressionLevel>] [-PassThru] [-Append] [-NoClobber] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### DocumentLiteralPathCulture
 ```powershell
-Export-OfficeCsv -Document <CsvDocument> -LiteralPath <string> -UseCulture [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-PassThru] [-Append] [-NoClobber] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-OfficeCsv -Document <CsvDocument> -LiteralPath <string> -UseCulture [-NoHeader] [-NewLine <string>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-FormulaInjectionPolicy <CsvFormulaInjectionPolicy>] [-UseQuotes <CsvQuoteMode>] [-QuoteFields <string[]>] [-NullValue <string>] [-DateTimeFormat <string>] [-UseUtc] [-CompressionType <CsvCompressionType>] [-CompressionLevel <CompressionLevel>] [-PassThru] [-Append] [-NoClobber] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -86,11 +86,59 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -CompressionLevel
+Compression level used when writing compressed CSV files.
+
+```yaml
+Type: CompressionLevel
+Parameter Sets: InputObjectPathDelimiter, InputObjectPathCulture, InputObjectLiteralPathDelimiter, InputObjectLiteralPathCulture, DocumentPathDelimiter, DocumentPathCulture, DocumentLiteralPathDelimiter, DocumentLiteralPathCulture
+Aliases: None
+Possible values: Optimal, Fastest, NoCompression, SmallestSize
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -CompressionType
+Compression used when writing files. Auto infers from the file extension.
+
+```yaml
+Type: CsvCompressionType
+Parameter Sets: InputObjectPathDelimiter, InputObjectPathCulture, InputObjectLiteralPathDelimiter, InputObjectLiteralPathCulture, DocumentPathDelimiter, DocumentPathCulture, DocumentLiteralPathDelimiter, DocumentLiteralPathCulture
+Aliases: None
+Possible values: None, Auto, GZip, Deflate, Brotli, ZLib
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -Culture
 Culture used for value formatting.
 
 ```yaml
 Type: CultureInfo
+Parameter Sets: InputObjectPathDelimiter, InputObjectPathCulture, InputObjectLiteralPathDelimiter, InputObjectLiteralPathCulture, DocumentPathDelimiter, DocumentPathCulture, DocumentLiteralPathDelimiter, DocumentLiteralPathCulture
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -DateTimeFormat
+Date/time format used for DateTime and DateTimeOffset values.
+
+```yaml
+Type: String
 Parameter Sets: InputObjectPathDelimiter, InputObjectPathCulture, InputObjectLiteralPathDelimiter, InputObjectLiteralPathCulture, DocumentPathDelimiter, DocumentPathCulture, DocumentLiteralPathDelimiter, DocumentLiteralPathCulture
 Aliases: None
 Possible values:
@@ -262,6 +310,22 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -NullValue
+Token written for null values.
+
+```yaml
+Type: String
+Parameter Sets: InputObjectPathDelimiter, InputObjectPathCulture, InputObjectLiteralPathDelimiter, InputObjectLiteralPathCulture, DocumentPathDelimiter, DocumentPathCulture, DocumentLiteralPathDelimiter, DocumentLiteralPathCulture
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -PassThru
 Emit a FileInfo for the exported file.
 
@@ -334,6 +398,22 @@ Type: CsvQuoteMode
 Parameter Sets: InputObjectPathDelimiter, InputObjectPathCulture, InputObjectLiteralPathDelimiter, InputObjectLiteralPathCulture, DocumentPathDelimiter, DocumentPathCulture, DocumentLiteralPathDelimiter, DocumentLiteralPathCulture
 Aliases: None
 Possible values: AsNeeded, Always, Never
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -UseUtc
+Convert date/time values to UTC before formatting.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: InputObjectPathDelimiter, InputObjectPathCulture, InputObjectLiteralPathDelimiter, InputObjectLiteralPathCulture, DocumentPathDelimiter, DocumentPathCulture, DocumentLiteralPathDelimiter, DocumentLiteralPathCulture
+Aliases: None
+Possible values:
 
 Required: False
 Position: named

--- a/Docs/Get-OfficeCsv.md
+++ b/Docs/Get-OfficeCsv.md
@@ -11,47 +11,47 @@ Loads a CSV document from disk or parses CSV text.
 ## SYNTAX
 ### PathDelimiter (Default)
 ```powershell
-Get-OfficeCsv [-Path] <string[]> [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-Delimiter <char>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [<CommonParameters>]
+Get-OfficeCsv [-Path] <string[]> [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-Delimiter <char>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-CompressionType <CsvCompressionType>] [-MaxDecompressedBytes <long>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [<CommonParameters>]
 ```
 
 ### PathCulture
 ```powershell
-Get-OfficeCsv [-Path] <string[]> -UseCulture [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [<CommonParameters>]
+Get-OfficeCsv [-Path] <string[]> -UseCulture [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-CompressionType <CsvCompressionType>] [-MaxDecompressedBytes <long>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [<CommonParameters>]
 ```
 
 ### PathDetect
 ```powershell
-Get-OfficeCsv [-Path] <string[]> -DetectDelimiter [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-DelimiterCandidates <char[]>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [<CommonParameters>]
+Get-OfficeCsv [-Path] <string[]> -DetectDelimiter [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-DelimiterCandidates <char[]>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-CompressionType <CsvCompressionType>] [-MaxDecompressedBytes <long>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [<CommonParameters>]
 ```
 
 ### LiteralPathDelimiter
 ```powershell
-Get-OfficeCsv -LiteralPath <string[]> [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-Delimiter <char>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [<CommonParameters>]
+Get-OfficeCsv -LiteralPath <string[]> [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-Delimiter <char>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-CompressionType <CsvCompressionType>] [-MaxDecompressedBytes <long>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [<CommonParameters>]
 ```
 
 ### LiteralPathCulture
 ```powershell
-Get-OfficeCsv -LiteralPath <string[]> -UseCulture [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [<CommonParameters>]
+Get-OfficeCsv -LiteralPath <string[]> -UseCulture [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-CompressionType <CsvCompressionType>] [-MaxDecompressedBytes <long>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [<CommonParameters>]
 ```
 
 ### LiteralPathDetect
 ```powershell
-Get-OfficeCsv -LiteralPath <string[]> -DetectDelimiter [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-DelimiterCandidates <char[]>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [<CommonParameters>]
+Get-OfficeCsv -LiteralPath <string[]> -DetectDelimiter [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-DelimiterCandidates <char[]>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-CompressionType <CsvCompressionType>] [-MaxDecompressedBytes <long>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [<CommonParameters>]
 ```
 
 ### TextDelimiter
 ```powershell
-Get-OfficeCsv -Text <string> [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-Delimiter <char>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [<CommonParameters>]
+Get-OfficeCsv -Text <string> [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-Delimiter <char>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [<CommonParameters>]
 ```
 
 ### TextCulture
 ```powershell
-Get-OfficeCsv -Text <string> -UseCulture [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [<CommonParameters>]
+Get-OfficeCsv -Text <string> -UseCulture [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [<CommonParameters>]
 ```
 
 ### TextDetect
 ```powershell
-Get-OfficeCsv -Text <string> -DetectDelimiter [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-DelimiterCandidates <char[]>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [<CommonParameters>]
+Get-OfficeCsv -Text <string> -DetectDelimiter [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-DelimiterCandidates <char[]>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -130,11 +130,43 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -CompressionType
+Compression used when reading files. Auto infers from the file extension.
+
+```yaml
+Type: CsvCompressionType
+Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
+Aliases: None
+Possible values: None, Auto, GZip, Deflate, Brotli, ZLib
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -Culture
 Culture used for type conversions.
 
 ```yaml
 Type: CultureInfo
+Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect, TextDelimiter, TextCulture, TextDetect
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -DateTimeFormats
+Additional date/time formats used by typed conversions and validation.
+
+```yaml
+Type: String[]
 Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect, TextDelimiter, TextCulture, TextDetect
 Aliases: None
 Possible values:
@@ -194,6 +226,22 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -DuplicateHeaderBehavior
+Controls how duplicate header names are handled.
+
+```yaml
+Type: CsvDuplicateHeaderBehavior
+Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect, TextDelimiter, TextCulture, TextDetect
+Aliases: None
+Possible values: Preserve, Rename, Throw
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -Encoding
 Encoding used when reading the file.
 
@@ -242,6 +290,22 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: True
 ```
 
+### -MaxDecompressedBytes
+Maximum decompressed bytes to read from compressed CSV files.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -Mode
 Load mode controlling materialization.
 
@@ -274,19 +338,51 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -NullValue
+Token that is materialized as null when loading rows.
+
+```yaml
+Type: String
+Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect, TextDelimiter, TextCulture, TextDetect
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -Path
 Path to one or more CSV files. Wildcards are supported.
 
 ```yaml
 Type: String[]
 Parameter Sets: PathDelimiter, PathCulture, PathDetect
-Aliases: FilePath
+Aliases: FilePath, InputPath
 Possible values:
 
 Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByValue, ByPropertyName)
+Accept wildcard characters: True
+```
+
+### -QuoteParsingMode
+Controls whether malformed quoted fields are parsed leniently or rejected.
+
+```yaml
+Type: CsvQuoteParsingMode
+Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect, TextDelimiter, TextCulture, TextDetect
+Aliases: None
+Possible values: Lenient, Strict
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
@@ -343,6 +439,22 @@ Number of parsed CSV records to skip before header discovery or data output.
 
 ```yaml
 Type: Int32
+Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect, TextDelimiter, TextCulture, TextDetect
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -StaticColumns
+Static columns appended to every loaded row.
+
+```yaml
+Type: IDictionary
 Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect, TextDelimiter, TextCulture, TextDetect
 Aliases: None
 Possible values:

--- a/Docs/Import-OfficeCsv.md
+++ b/Docs/Import-OfficeCsv.md
@@ -16,7 +16,7 @@ Import-OfficeCsv [-Path] <string[]> [-NoHeader] [-Header <string[]>] [-SkipRows 
 
 ### Document
 ```powershell
-Import-OfficeCsv [-Document <CsvDocument>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-CompressionType <CsvCompressionType>] [-MaxDecompressedBytes <long>] [-AsHashtable] [-AsDataTable] [<CommonParameters>]
+Import-OfficeCsv [-Document <CsvDocument>] [-AsHashtable] [-AsDataTable] [<CommonParameters>]
 ```
 
 ### PathCulture
@@ -157,7 +157,7 @@ Compression used when reading files. Auto infers from the file extension.
 
 ```yaml
 Type: CsvCompressionType
-Parameter Sets: PathDelimiter, Document, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
+Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
 Aliases: None
 Possible values: None, Auto, GZip, Deflate, Brotli, ZLib
 
@@ -189,7 +189,7 @@ Additional date/time formats used by typed conversions and validation.
 
 ```yaml
 Type: String[]
-Parameter Sets: PathDelimiter, Document, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
+Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
 Aliases: None
 Possible values:
 
@@ -269,7 +269,7 @@ Controls how duplicate header names are handled.
 
 ```yaml
 Type: CsvDuplicateHeaderBehavior
-Parameter Sets: PathDelimiter, Document, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
+Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
 Aliases: None
 Possible values: Preserve, Rename, Throw
 
@@ -333,7 +333,7 @@ Maximum decompressed bytes to read from compressed CSV files.
 
 ```yaml
 Type: Nullable`1
-Parameter Sets: PathDelimiter, Document, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
+Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
 Aliases: None
 Possible values:
 
@@ -381,7 +381,7 @@ Token that is materialized as null when importing rows.
 
 ```yaml
 Type: String
-Parameter Sets: PathDelimiter, Document, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
+Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
 Aliases: None
 Possible values:
 
@@ -413,7 +413,7 @@ Controls whether malformed quoted fields are parsed leniently or rejected.
 
 ```yaml
 Type: CsvQuoteParsingMode
-Parameter Sets: PathDelimiter, Document, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
+Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
 Aliases: None
 Possible values: Lenient, Strict
 
@@ -493,7 +493,7 @@ Static columns appended to every imported row.
 
 ```yaml
 Type: IDictionary
-Parameter Sets: PathDelimiter, Document, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
+Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
 Aliases: None
 Possible values:
 

--- a/Docs/Import-OfficeCsv.md
+++ b/Docs/Import-OfficeCsv.md
@@ -11,37 +11,37 @@ Imports CSV rows as PSCustomObjects, dictionaries, or a DataTable.
 ## SYNTAX
 ### PathDelimiter (Default)
 ```powershell
-Import-OfficeCsv [-Path] <string[]> [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-Delimiter <char>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-AsHashtable] [-AsDataTable] [<CommonParameters>]
+Import-OfficeCsv [-Path] <string[]> [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-Delimiter <char>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-CompressionType <CsvCompressionType>] [-MaxDecompressedBytes <long>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-AsHashtable] [-AsDataTable] [<CommonParameters>]
 ```
 
 ### Document
 ```powershell
-Import-OfficeCsv [-Document <CsvDocument>] [-AsHashtable] [-AsDataTable] [<CommonParameters>]
+Import-OfficeCsv [-Document <CsvDocument>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-CompressionType <CsvCompressionType>] [-MaxDecompressedBytes <long>] [-AsHashtable] [-AsDataTable] [<CommonParameters>]
 ```
 
 ### PathCulture
 ```powershell
-Import-OfficeCsv [-Path] <string[]> -UseCulture [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-AsHashtable] [-AsDataTable] [<CommonParameters>]
+Import-OfficeCsv [-Path] <string[]> -UseCulture [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-CompressionType <CsvCompressionType>] [-MaxDecompressedBytes <long>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-AsHashtable] [-AsDataTable] [<CommonParameters>]
 ```
 
 ### PathDetect
 ```powershell
-Import-OfficeCsv [-Path] <string[]> -DetectDelimiter [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-DelimiterCandidates <char[]>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-AsHashtable] [-AsDataTable] [<CommonParameters>]
+Import-OfficeCsv [-Path] <string[]> -DetectDelimiter [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-DelimiterCandidates <char[]>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-CompressionType <CsvCompressionType>] [-MaxDecompressedBytes <long>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-AsHashtable] [-AsDataTable] [<CommonParameters>]
 ```
 
 ### LiteralPathDelimiter
 ```powershell
-Import-OfficeCsv -LiteralPath <string[]> [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-Delimiter <char>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-AsHashtable] [-AsDataTable] [<CommonParameters>]
+Import-OfficeCsv -LiteralPath <string[]> [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-Delimiter <char>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-CompressionType <CsvCompressionType>] [-MaxDecompressedBytes <long>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-AsHashtable] [-AsDataTable] [<CommonParameters>]
 ```
 
 ### LiteralPathCulture
 ```powershell
-Import-OfficeCsv -LiteralPath <string[]> -UseCulture [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-AsHashtable] [-AsDataTable] [<CommonParameters>]
+Import-OfficeCsv -LiteralPath <string[]> -UseCulture [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-CompressionType <CsvCompressionType>] [-MaxDecompressedBytes <long>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-AsHashtable] [-AsDataTable] [<CommonParameters>]
 ```
 
 ### LiteralPathDetect
 ```powershell
-Import-OfficeCsv -LiteralPath <string[]> -DetectDelimiter [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-DelimiterCandidates <char[]>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-AsHashtable] [-AsDataTable] [<CommonParameters>]
+Import-OfficeCsv -LiteralPath <string[]> -DetectDelimiter [-NoHeader] [-Header <string[]>] [-SkipRows <int>] [-DelimiterCandidates <char[]>] [-TrimWhitespace <bool>] [-AllowEmptyLines] [-SkipCommentRowsBeforeHeader <bool>] [-SkipCommentRows] [-CommentCharacter <char>] [-RecognizeW3CFieldsHeader <bool>] [-ColumnCountMismatchPolicy <CsvColumnCountMismatchPolicy>] [-DuplicateHeaderBehavior <CsvDuplicateHeaderBehavior>] [-NullValue <string>] [-DateTimeFormats <string[]>] [-QuoteParsingMode <CsvQuoteParsingMode>] [-StaticColumns <IDictionary>] [-CompressionType <CsvCompressionType>] [-MaxDecompressedBytes <long>] [-Mode <CsvLoadMode>] [-Culture <cultureinfo>] [-Encoding <Encoding>] [-AsHashtable] [-AsDataTable] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -152,12 +152,44 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -CompressionType
+Compression used when reading files. Auto infers from the file extension.
+
+```yaml
+Type: CsvCompressionType
+Parameter Sets: PathDelimiter, Document, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
+Aliases: None
+Possible values: None, Auto, GZip, Deflate, Brotli, ZLib
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -Culture
 Culture used for type conversions.
 
 ```yaml
 Type: CultureInfo
 Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -DateTimeFormats
+Additional date/time formats used by typed conversions and validation.
+
+```yaml
+Type: String[]
+Parameter Sets: PathDelimiter, Document, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
 Aliases: None
 Possible values:
 
@@ -232,6 +264,22 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: True
 ```
 
+### -DuplicateHeaderBehavior
+Controls how duplicate header names are handled.
+
+```yaml
+Type: CsvDuplicateHeaderBehavior
+Parameter Sets: PathDelimiter, Document, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
+Aliases: None
+Possible values: Preserve, Rename, Throw
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -Encoding
 Encoding used when reading the file.
 
@@ -280,6 +328,22 @@ Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: True
 ```
 
+### -MaxDecompressedBytes
+Maximum decompressed bytes to read from compressed CSV files.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: PathDelimiter, Document, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -Mode
 Load mode controlling materialization.
 
@@ -312,6 +376,22 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -NullValue
+Token that is materialized as null when importing rows.
+
+```yaml
+Type: String
+Parameter Sets: PathDelimiter, Document, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
 ### -Path
 Path to one or more CSV files. Wildcards are supported.
 
@@ -325,6 +405,22 @@ Required: True
 Position: 0
 Default value: None
 Accept pipeline input: True (ByValue, ByPropertyName)
+Accept wildcard characters: True
+```
+
+### -QuoteParsingMode
+Controls whether malformed quoted fields are parsed leniently or rejected.
+
+```yaml
+Type: CsvQuoteParsingMode
+Parameter Sets: PathDelimiter, Document, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
+Aliases: None
+Possible values: Lenient, Strict
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
@@ -382,6 +478,22 @@ Number of parsed CSV records to skip before header discovery or data output.
 ```yaml
 Type: Int32
 Parameter Sets: PathDelimiter, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -StaticColumns
+Static columns appended to every imported row.
+
+```yaml
+Type: IDictionary
+Parameter Sets: PathDelimiter, Document, PathCulture, PathDetect, LiteralPathDelimiter, LiteralPathCulture, LiteralPathDetect
 Aliases: None
 Possible values:
 

--- a/Sources/PSWriteOffice/Cmdlets/Csv/ConvertFromOfficeCsvCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Csv/ConvertFromOfficeCsvCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -97,6 +98,26 @@ public sealed class ConvertFromOfficeCsvCommand : PSCmdlet
     [Parameter]
     public CsvColumnCountMismatchPolicy ColumnCountMismatchPolicy { get; set; } = CsvColumnCountMismatchPolicy.PadMissingFieldsAndIgnoreExtraFields;
 
+    /// <summary>Controls how duplicate header names are handled.</summary>
+    [Parameter]
+    public CsvDuplicateHeaderBehavior DuplicateHeaderBehavior { get; set; } = CsvDuplicateHeaderBehavior.Rename;
+
+    /// <summary>Token that is materialized as null when converting rows.</summary>
+    [Parameter]
+    public string? NullValue { get; set; }
+
+    /// <summary>Additional date/time formats used by typed conversions and validation.</summary>
+    [Parameter]
+    public string[]? DateTimeFormats { get; set; }
+
+    /// <summary>Controls whether malformed quoted fields are parsed leniently or rejected.</summary>
+    [Parameter]
+    public CsvQuoteParsingMode QuoteParsingMode { get; set; } = CsvQuoteParsingMode.Lenient;
+
+    /// <summary>Static columns appended to every converted row.</summary>
+    [Parameter]
+    public IDictionary? StaticColumns { get; set; }
+
     /// <summary>Load mode controlling materialization.</summary>
     [Parameter]
     public CsvLoadMode Mode { get; set; } = CsvLoadMode.Stream;
@@ -136,7 +157,7 @@ public sealed class ConvertFromOfficeCsvCommand : PSCmdlet
         var csvText = _textInput.ToString();
 
         _rowWriter.Reset();
-        if (Mode == CsvLoadMode.Stream)
+        if (Mode == CsvLoadMode.Stream && !RequiresMaterializedRows())
         {
             using var reader = new StringReader(csvText);
             CsvDocument.ReadRowsReusable(reader, WriteRow, options);
@@ -182,6 +203,14 @@ public sealed class ConvertFromOfficeCsvCommand : PSCmdlet
             Mode = Mode
         };
 
+        CsvPowerShellOptionBuilder.ApplyTextLoadOptions(
+            options,
+            DuplicateHeaderBehavior,
+            NullValue,
+            DateTimeFormats,
+            QuoteParsingMode,
+            StaticColumns);
+
         if (Culture != null)
         {
             options.Culture = Culture;
@@ -189,6 +218,10 @@ public sealed class ConvertFromOfficeCsvCommand : PSCmdlet
 
         return options;
     }
+
+    private bool RequiresMaterializedRows() =>
+        NullValue != null ||
+        StaticColumns is { Count: > 0 };
 
     private void WriteRow(IReadOnlyList<string> header, IReadOnlyList<string> row)
     {

--- a/Sources/PSWriteOffice/Cmdlets/Csv/ConvertToOfficeCsvCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Csv/ConvertToOfficeCsvCommand.cs
@@ -85,6 +85,18 @@ public sealed class ConvertToOfficeCsvCommand : PSCmdlet
     [Parameter]
     public string[]? QuoteFields { get; set; }
 
+    /// <summary>Token written for null values.</summary>
+    [Parameter]
+    public string? NullValue { get; set; }
+
+    /// <summary>Date/time format used for DateTime and DateTimeOffset values.</summary>
+    [Parameter]
+    public string? DateTimeFormat { get; set; }
+
+    /// <summary>Convert date/time values to UTC before formatting.</summary>
+    [Parameter]
+    public SwitchParameter UseUtc { get; set; }
+
     /// <inheritdoc />
     protected override void BeginProcessing()
     {
@@ -168,7 +180,7 @@ public sealed class ConvertToOfficeCsvCommand : PSCmdlet
         }
 
         var options = CreateSaveOptions();
-        _objectProjector.UseCsvCulture(options.Culture);
+        _objectProjector.UseCsvOptions(options);
         _lineWriter = new CsvPowerShellLineWriter(this, options.Delimiter, options.QuoteMode);
         _csvWriter = new CsvObjectWriter(_lineWriter, options);
         return _csvWriter;
@@ -193,6 +205,14 @@ public sealed class ConvertToOfficeCsvCommand : PSCmdlet
             QuoteMode = UseQuotes,
             QuoteFields = QuoteFields
         };
+
+        CsvPowerShellOptionBuilder.ApplySaveOptions(
+            options,
+            NullValue,
+            DateTimeFormat,
+            UseUtc.IsPresent,
+            CsvCompressionType.None,
+            System.IO.Compression.CompressionLevel.Optimal);
 
         if (!string.IsNullOrEmpty(NewLine))
         {

--- a/Sources/PSWriteOffice/Cmdlets/Csv/CsvPowerShellObjectProjector.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Csv/CsvPowerShellObjectProjector.cs
@@ -12,6 +12,7 @@ internal sealed class CsvPowerShellObjectProjector
     private object?[]? _values;
     private string?[]? _textValues;
     private PowerShellObjectNormalizerOptions _normalizerOptions = PowerShellObjectNormalizerOptions.Default;
+    private bool _allowTrustedTextRows = true;
     private bool _validateColumns;
 
     public void Reset()
@@ -20,6 +21,7 @@ internal sealed class CsvPowerShellObjectProjector
         _values = null;
         _textValues = null;
         _validateColumns = false;
+        _allowTrustedTextRows = true;
     }
 
     public void UseCsvOptions(CsvSaveOptions options)
@@ -29,10 +31,11 @@ internal sealed class CsvPowerShellObjectProjector
             throw new ArgumentNullException(nameof(options));
         }
 
+        _allowTrustedTextRows = options.DateTimeFormat == null && !options.UseUtc;
         _normalizerOptions = new PowerShellObjectNormalizerOptions
         {
             Culture = options.Culture,
-            FormatScalarValuesAsText = options.DateTimeFormat == null && !options.UseUtc
+            FormatScalarValuesAsText = _allowTrustedTextRows
         };
     }
 
@@ -79,7 +82,8 @@ internal sealed class CsvPowerShellObjectProjector
                 ValidateFirstRowColumns(value, _columns);
             }
 
-            if (_textValues != null &&
+            if (_allowTrustedTextRows &&
+                _textValues != null &&
                 PowerShellObjectNormalizer.TryProjectPSObjectTextIntoKnownColumns(value, _columns, _textValues, _normalizerOptions))
             {
                 WriteProjectedTextRow(writer, _columns, _textValues);

--- a/Sources/PSWriteOffice/Cmdlets/Csv/CsvPowerShellObjectProjector.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Csv/CsvPowerShellObjectProjector.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using OfficeIMO.CSV;
 using PSWriteOffice.Services;
@@ -23,12 +22,17 @@ internal sealed class CsvPowerShellObjectProjector
         _validateColumns = false;
     }
 
-    public void UseCsvCulture(CultureInfo culture)
+    public void UseCsvOptions(CsvSaveOptions options)
     {
+        if (options == null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
         _normalizerOptions = new PowerShellObjectNormalizerOptions
         {
-            Culture = culture ?? CultureInfo.InvariantCulture,
-            FormatScalarValuesAsText = true
+            Culture = options.Culture,
+            FormatScalarValuesAsText = options.DateTimeFormat == null && !options.UseUtc
         };
     }
 

--- a/Sources/PSWriteOffice/Cmdlets/Csv/CsvPowerShellOptionBuilder.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Csv/CsvPowerShellOptionBuilder.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO.Compression;
+using OfficeIMO.CSV;
+
+namespace PSWriteOffice.Cmdlets.Csv;
+
+internal static class CsvPowerShellOptionBuilder
+{
+    public static void ApplyLoadOptions(
+        CsvLoadOptions options,
+        CsvDuplicateHeaderBehavior duplicateHeaderBehavior,
+        string? nullValue,
+        string[]? dateTimeFormats,
+        CsvQuoteParsingMode quoteParsingMode,
+        IDictionary? staticColumns,
+        CsvCompressionType compressionType,
+        long? maxDecompressedBytes)
+    {
+        options.DuplicateHeaderBehavior = duplicateHeaderBehavior;
+        options.NullValue = nullValue;
+        options.DateTimeFormats = dateTimeFormats;
+        options.QuoteParsingMode = quoteParsingMode;
+        options.StaticColumns = ToStaticColumnDictionary(staticColumns);
+        options.CompressionType = compressionType;
+        options.MaxDecompressedBytes = maxDecompressedBytes;
+    }
+
+    public static void ApplyTextLoadOptions(
+        CsvLoadOptions options,
+        CsvDuplicateHeaderBehavior duplicateHeaderBehavior,
+        string? nullValue,
+        string[]? dateTimeFormats,
+        CsvQuoteParsingMode quoteParsingMode,
+        IDictionary? staticColumns)
+    {
+        options.DuplicateHeaderBehavior = duplicateHeaderBehavior;
+        options.NullValue = nullValue;
+        options.DateTimeFormats = dateTimeFormats;
+        options.QuoteParsingMode = quoteParsingMode;
+        options.StaticColumns = ToStaticColumnDictionary(staticColumns);
+    }
+
+    public static void ApplySaveOptions(
+        CsvSaveOptions options,
+        string? nullValue,
+        string? dateTimeFormat,
+        bool useUtc,
+        CsvCompressionType compressionType,
+        CompressionLevel compressionLevel)
+    {
+        options.NullValue = nullValue;
+        options.DateTimeFormat = dateTimeFormat;
+        options.UseUtc = useUtc;
+        options.CompressionType = compressionType;
+        options.CompressionLevel = compressionLevel;
+    }
+
+    private static IReadOnlyDictionary<string, object?>? ToStaticColumnDictionary(IDictionary? source)
+    {
+        if (source == null || source.Count == 0)
+        {
+            return null;
+        }
+
+        var result = new Dictionary<string, object?>(source.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (DictionaryEntry entry in source)
+        {
+            if (entry.Key == null)
+            {
+                throw new ArgumentException("Static column names cannot be null.", nameof(source));
+            }
+
+            var name = entry.Key.ToString();
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Static column names cannot be empty.", nameof(source));
+            }
+
+            result[name] = entry.Value;
+        }
+
+        return result;
+    }
+}

--- a/Sources/PSWriteOffice/Cmdlets/Csv/ExportOfficeCsvCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Csv/ExportOfficeCsvCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Management.Automation;
 using System.Text;
@@ -116,6 +117,26 @@ public sealed class ExportOfficeCsvCommand : PSCmdlet
     /// <summary>Field names that should always be quoted when <see cref="UseQuotes"/> is AsNeeded.</summary>
     [Parameter]
     public string[]? QuoteFields { get; set; }
+
+    /// <summary>Token written for null values.</summary>
+    [Parameter]
+    public string? NullValue { get; set; }
+
+    /// <summary>Date/time format used for DateTime and DateTimeOffset values.</summary>
+    [Parameter]
+    public string? DateTimeFormat { get; set; }
+
+    /// <summary>Convert date/time values to UTC before formatting.</summary>
+    [Parameter]
+    public SwitchParameter UseUtc { get; set; }
+
+    /// <summary>Compression used when writing files. Auto infers from the file extension.</summary>
+    [Parameter]
+    public CsvCompressionType CompressionType { get; set; } = CsvCompressionType.Auto;
+
+    /// <summary>Compression level used when writing compressed CSV files.</summary>
+    [Parameter]
+    public CompressionLevel CompressionLevel { get; set; } = CompressionLevel.Optimal;
 
     /// <summary>Emit a <see cref="FileInfo"/> for the exported file.</summary>
     [Parameter]
@@ -275,11 +296,11 @@ public sealed class ExportOfficeCsvCommand : PSCmdlet
         }
 
         var options = CreateSaveOptions();
-        _objectProjector.UseCsvCulture(options.Culture);
+        _objectProjector.UseCsvOptions(options);
         if (Append.IsPresent)
         {
             options = CreateSaveOptions(includeHeader: !NoHeader.IsPresent && !_appendToExistingFile);
-            _objectProjector.UseCsvCulture(options.Culture);
+            _objectProjector.UseCsvOptions(options);
             var appendHeader = GetEffectiveAppendHeader(firstValue);
             if (appendHeader is { Length: > 0 })
             {
@@ -325,6 +346,17 @@ public sealed class ExportOfficeCsvCommand : PSCmdlet
 
         var needsFileState = Append.IsPresent || NoClobber.IsPresent || Force.IsPresent;
         var fileExists = needsFileState && File.Exists(_resolvedPath);
+        if (Append.IsPresent && CsvFile.ResolveCompression(CompressionType, _resolvedPath) != CsvCompressionType.None)
+        {
+            WriteError(new ErrorRecord(
+                new NotSupportedException("Appending to compressed CSV files is not supported."),
+                "CsvCompressedAppendNotSupported",
+                ErrorCategory.NotImplemented,
+                _resolvedPath));
+            _skipOutput = true;
+            return false;
+        }
+
         if (fileExists && NoClobber.IsPresent && !Append.IsPresent)
         {
             WriteError(new ErrorRecord(
@@ -394,6 +426,14 @@ public sealed class ExportOfficeCsvCommand : PSCmdlet
             QuoteFields = QuoteFields
         };
 
+        CsvPowerShellOptionBuilder.ApplySaveOptions(
+            options,
+            NullValue,
+            DateTimeFormat,
+            UseUtc.IsPresent,
+            CompressionType,
+            CompressionLevel);
+
         if (!string.IsNullOrEmpty(NewLine))
         {
             options.NewLine = NewLine!;
@@ -430,18 +470,23 @@ public sealed class ExportOfficeCsvCommand : PSCmdlet
 
     private string? GetTargetPathForErrors() => IsLiteralPathParameterSet() ? LiteralPath : Path;
 
-    private StreamWriter CreateTextWriter(bool append, CsvSaveOptions options)
+    private TextWriter CreateTextWriter(bool append, CsvSaveOptions options)
     {
-        var encoding = ResolveOutputEncoding(append, options);
         var appendToContent = append && _appendToExistingFile;
-        var mode = appendToContent ? FileMode.Append : FileMode.Create;
+        var compressionType = CsvFile.ResolveCompression(options.CompressionType, _resolvedPath!);
+        if (append && compressionType != CsvCompressionType.None)
+        {
+            throw new NotSupportedException("Appending to compressed CSV files is not supported.");
+        }
+
+        var encoding = ResolveOutputEncoding(append, options);
+        options.Encoding = encoding;
         if (appendToContent)
         {
             EnsureAppendStartsOnNewRecord(_resolvedPath!, options);
         }
 
-        var stream = new FileStream(_resolvedPath!, mode, FileAccess.Write, FileShare.Read, StreamWriterBufferSize, FileOptions.SequentialScan);
-        return new StreamWriter(stream, encoding, bufferSize: StreamWriterBufferSize);
+        return CsvFile.CreateTextWriter(_resolvedPath!, options, append: appendToContent, bufferSize: StreamWriterBufferSize);
     }
 
     private Encoding ResolveOutputEncoding(bool append, CsvSaveOptions options) =>

--- a/Sources/PSWriteOffice/Cmdlets/Csv/ExportOfficeCsvCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Csv/ExportOfficeCsvCommand.cs
@@ -346,7 +346,8 @@ public sealed class ExportOfficeCsvCommand : PSCmdlet
 
         var needsFileState = Append.IsPresent || NoClobber.IsPresent || Force.IsPresent;
         var fileExists = needsFileState && File.Exists(_resolvedPath);
-        if (Append.IsPresent && CsvFile.ResolveCompression(CompressionType, _resolvedPath) != CsvCompressionType.None)
+        var appendTargetHasBytes = Append.IsPresent && fileExists && new FileInfo(_resolvedPath).Length > 0;
+        if (appendTargetHasBytes && CsvFile.ResolveCompression(CompressionType, _resolvedPath) != CsvCompressionType.None)
         {
             WriteError(new ErrorRecord(
                 new NotSupportedException("Appending to compressed CSV files is not supported."),
@@ -383,7 +384,6 @@ public sealed class ExportOfficeCsvCommand : PSCmdlet
             }
         }
 
-        var appendTargetHasBytes = Append.IsPresent && fileExists && new FileInfo(_resolvedPath).Length > 0;
         _appendEncoding = appendTargetHasBytes && Encoding == null
             ? TryDetectEncodingFromBom(_resolvedPath)
             : null;
@@ -474,7 +474,7 @@ public sealed class ExportOfficeCsvCommand : PSCmdlet
     {
         var appendToContent = append && _appendToExistingFile;
         var compressionType = CsvFile.ResolveCompression(options.CompressionType, _resolvedPath!);
-        if (append && compressionType != CsvCompressionType.None)
+        if (appendToContent && compressionType != CsvCompressionType.None)
         {
             throw new NotSupportedException("Appending to compressed CSV files is not supported.");
         }

--- a/Sources/PSWriteOffice/Cmdlets/Csv/GetOfficeCsvCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Csv/GetOfficeCsvCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -127,6 +128,45 @@ public sealed class GetOfficeCsvCommand : PSCmdlet
     [Parameter]
     public CsvColumnCountMismatchPolicy ColumnCountMismatchPolicy { get; set; } = CsvColumnCountMismatchPolicy.PadMissingFieldsAndIgnoreExtraFields;
 
+    /// <summary>Controls how duplicate header names are handled.</summary>
+    [Parameter]
+    public CsvDuplicateHeaderBehavior DuplicateHeaderBehavior { get; set; } = CsvDuplicateHeaderBehavior.Rename;
+
+    /// <summary>Token that is materialized as null when loading rows.</summary>
+    [Parameter]
+    public string? NullValue { get; set; }
+
+    /// <summary>Additional date/time formats used by typed conversions and validation.</summary>
+    [Parameter]
+    public string[]? DateTimeFormats { get; set; }
+
+    /// <summary>Controls whether malformed quoted fields are parsed leniently or rejected.</summary>
+    [Parameter]
+    public CsvQuoteParsingMode QuoteParsingMode { get; set; } = CsvQuoteParsingMode.Lenient;
+
+    /// <summary>Static columns appended to every loaded row.</summary>
+    [Parameter]
+    public IDictionary? StaticColumns { get; set; }
+
+    /// <summary>Compression used when reading files. Auto infers from the file extension.</summary>
+    [Parameter(ParameterSetName = ParameterSetPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetPathDetect)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDetect)]
+    public CsvCompressionType CompressionType { get; set; } = CsvCompressionType.Auto;
+
+    /// <summary>Maximum decompressed bytes to read from compressed CSV files.</summary>
+    [Parameter(ParameterSetName = ParameterSetPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetPathDetect)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDetect)]
+    [ValidateRange(0, long.MaxValue)]
+    public long? MaxDecompressedBytes { get; set; }
+
     /// <summary>Load mode controlling materialization.</summary>
     [Parameter]
     public CsvLoadMode Mode { get; set; } = CsvLoadMode.InMemory;
@@ -178,6 +218,29 @@ public sealed class GetOfficeCsvCommand : PSCmdlet
             Mode = Mode
         };
 
+        if (IsTextParameterSet())
+        {
+            CsvPowerShellOptionBuilder.ApplyTextLoadOptions(
+                options,
+                DuplicateHeaderBehavior,
+                NullValue,
+                DateTimeFormats,
+                QuoteParsingMode,
+                StaticColumns);
+        }
+        else
+        {
+            CsvPowerShellOptionBuilder.ApplyLoadOptions(
+                options,
+                DuplicateHeaderBehavior,
+                NullValue,
+                DateTimeFormats,
+                QuoteParsingMode,
+                StaticColumns,
+                CompressionType,
+                MaxDecompressedBytes);
+        }
+
         if (Culture != null)
         {
             options.Culture = Culture;
@@ -227,6 +290,11 @@ public sealed class GetOfficeCsvCommand : PSCmdlet
         string.Equals(ParameterSetName, ParameterSetLiteralPathDelimiter, StringComparison.OrdinalIgnoreCase) ||
         string.Equals(ParameterSetName, ParameterSetLiteralPathCulture, StringComparison.OrdinalIgnoreCase) ||
         string.Equals(ParameterSetName, ParameterSetLiteralPathDetect, StringComparison.OrdinalIgnoreCase);
+
+    private bool IsTextParameterSet() =>
+        string.Equals(ParameterSetName, ParameterSetTextDelimiter, StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(ParameterSetName, ParameterSetTextCulture, StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(ParameterSetName, ParameterSetTextDetect, StringComparison.OrdinalIgnoreCase);
 
     private IEnumerable<string> ResolveInputPaths()
     {

--- a/Sources/PSWriteOffice/Cmdlets/Csv/ImportOfficeCsvCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Csv/ImportOfficeCsvCommand.cs
@@ -174,31 +174,66 @@ public sealed class ImportOfficeCsvCommand : PSCmdlet
     public CsvColumnCountMismatchPolicy ColumnCountMismatchPolicy { get; set; } = CsvColumnCountMismatchPolicy.PadMissingFieldsAndIgnoreExtraFields;
 
     /// <summary>Controls how duplicate header names are handled.</summary>
-    [Parameter]
+    [Parameter(ParameterSetName = ParameterSetPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetPathDetect)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDetect)]
     public CsvDuplicateHeaderBehavior DuplicateHeaderBehavior { get; set; } = CsvDuplicateHeaderBehavior.Rename;
 
     /// <summary>Token that is materialized as null when importing rows.</summary>
-    [Parameter]
+    [Parameter(ParameterSetName = ParameterSetPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetPathDetect)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDetect)]
     public string? NullValue { get; set; }
 
     /// <summary>Additional date/time formats used by typed conversions and validation.</summary>
-    [Parameter]
+    [Parameter(ParameterSetName = ParameterSetPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetPathDetect)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDetect)]
     public string[]? DateTimeFormats { get; set; }
 
     /// <summary>Controls whether malformed quoted fields are parsed leniently or rejected.</summary>
-    [Parameter]
+    [Parameter(ParameterSetName = ParameterSetPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetPathDetect)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDetect)]
     public CsvQuoteParsingMode QuoteParsingMode { get; set; } = CsvQuoteParsingMode.Lenient;
 
     /// <summary>Static columns appended to every imported row.</summary>
-    [Parameter]
+    [Parameter(ParameterSetName = ParameterSetPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetPathDetect)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDetect)]
     public IDictionary? StaticColumns { get; set; }
 
     /// <summary>Compression used when reading files. Auto infers from the file extension.</summary>
-    [Parameter]
+    [Parameter(ParameterSetName = ParameterSetPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetPathDetect)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDetect)]
     public CsvCompressionType CompressionType { get; set; } = CsvCompressionType.Auto;
 
     /// <summary>Maximum decompressed bytes to read from compressed CSV files.</summary>
-    [Parameter]
+    [Parameter(ParameterSetName = ParameterSetPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetPathDetect)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDelimiter)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathCulture)]
+    [Parameter(ParameterSetName = ParameterSetLiteralPathDetect)]
     [ValidateRange(0, long.MaxValue)]
     public long? MaxDecompressedBytes { get; set; }
 

--- a/Sources/PSWriteOffice/Cmdlets/Csv/ImportOfficeCsvCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Csv/ImportOfficeCsvCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
@@ -172,6 +173,35 @@ public sealed class ImportOfficeCsvCommand : PSCmdlet
     [Parameter(ParameterSetName = ParameterSetLiteralPathDetect)]
     public CsvColumnCountMismatchPolicy ColumnCountMismatchPolicy { get; set; } = CsvColumnCountMismatchPolicy.PadMissingFieldsAndIgnoreExtraFields;
 
+    /// <summary>Controls how duplicate header names are handled.</summary>
+    [Parameter]
+    public CsvDuplicateHeaderBehavior DuplicateHeaderBehavior { get; set; } = CsvDuplicateHeaderBehavior.Rename;
+
+    /// <summary>Token that is materialized as null when importing rows.</summary>
+    [Parameter]
+    public string? NullValue { get; set; }
+
+    /// <summary>Additional date/time formats used by typed conversions and validation.</summary>
+    [Parameter]
+    public string[]? DateTimeFormats { get; set; }
+
+    /// <summary>Controls whether malformed quoted fields are parsed leniently or rejected.</summary>
+    [Parameter]
+    public CsvQuoteParsingMode QuoteParsingMode { get; set; } = CsvQuoteParsingMode.Lenient;
+
+    /// <summary>Static columns appended to every imported row.</summary>
+    [Parameter]
+    public IDictionary? StaticColumns { get; set; }
+
+    /// <summary>Compression used when reading files. Auto infers from the file extension.</summary>
+    [Parameter]
+    public CsvCompressionType CompressionType { get; set; } = CsvCompressionType.Auto;
+
+    /// <summary>Maximum decompressed bytes to read from compressed CSV files.</summary>
+    [Parameter]
+    [ValidateRange(0, long.MaxValue)]
+    public long? MaxDecompressedBytes { get; set; }
+
     /// <summary>Load mode controlling materialization.</summary>
     [Parameter(ParameterSetName = ParameterSetPathDelimiter)]
     [Parameter(ParameterSetName = ParameterSetPathCulture)]
@@ -237,7 +267,7 @@ public sealed class ImportOfficeCsvCommand : PSCmdlet
                     throw new FileNotFoundException($"File '{resolved}' was not found.", resolved);
                 }
 
-                if (Mode == CsvLoadMode.Stream && !_asDataTable)
+                if (Mode == CsvLoadMode.Stream && !RequiresMaterializedRows())
                 {
                     _rowWriter.Reset();
                     CsvDocument.ReadRowsReusable(resolved, WriteRow, options);
@@ -294,6 +324,11 @@ public sealed class ImportOfficeCsvCommand : PSCmdlet
 
         WriteObject(PSObject.AsPSObject(table), enumerateCollection: false);
     }
+
+    private bool RequiresMaterializedRows() =>
+        _asDataTable ||
+        NullValue != null ||
+        StaticColumns is { Count: > 0 };
 
     private void ApplyCultureDelimiter()
     {
@@ -363,6 +398,16 @@ public sealed class ImportOfficeCsvCommand : PSCmdlet
             ColumnCountMismatchPolicy = ColumnCountMismatchPolicy,
             Mode = Mode
         };
+
+        CsvPowerShellOptionBuilder.ApplyLoadOptions(
+            options,
+            DuplicateHeaderBehavior,
+            NullValue,
+            DateTimeFormats,
+            QuoteParsingMode,
+            StaticColumns,
+            CompressionType,
+            MaxDecompressedBytes);
 
         if (Culture != null)
         {

--- a/Tests/Csv.Tests.ps1
+++ b/Tests/Csv.Tests.ps1
@@ -25,6 +25,16 @@ Describe 'CSV cmdlets' {
         (Get-Command Get-OfficeCsv).Parameters.Keys | Should -Contain 'NoHeader'
         (Get-Command Import-OfficeCsv).Parameters.Keys | Should -Contain 'NoHeader'
         (Get-Command Import-OfficeCsv).Parameters.Keys | Should -Contain 'AsDataTable'
+        (Get-Command Import-OfficeCsv).Parameters.Keys | Should -Contain 'DuplicateHeaderBehavior'
+        (Get-Command Import-OfficeCsv).Parameters.Keys | Should -Contain 'NullValue'
+        (Get-Command Import-OfficeCsv).Parameters.Keys | Should -Contain 'DateTimeFormats'
+        (Get-Command Import-OfficeCsv).Parameters.Keys | Should -Contain 'QuoteParsingMode'
+        (Get-Command Import-OfficeCsv).Parameters.Keys | Should -Contain 'StaticColumns'
+        (Get-Command Import-OfficeCsv).Parameters.Keys | Should -Contain 'CompressionType'
+        (Get-Command Export-OfficeCsv).Parameters.Keys | Should -Contain 'NullValue'
+        (Get-Command Export-OfficeCsv).Parameters.Keys | Should -Contain 'DateTimeFormat'
+        (Get-Command Export-OfficeCsv).Parameters.Keys | Should -Contain 'UseUtc'
+        (Get-Command Export-OfficeCsv).Parameters.Keys | Should -Contain 'CompressionType'
 
         (Get-Command ConvertTo-OfficeCsv).Parameters.Keys | Should -Not -Contain 'IncludeHeader'
         (Get-Command Export-OfficeCsv).Parameters.Keys | Should -Not -Contain 'IncludeHeader'
@@ -58,6 +68,53 @@ Describe 'CSV cmdlets' {
         $data = Import-OfficeCsv -Path $path
         $data.Count | Should -Be 2
         $data[0].Region | Should -Be 'NA'
+    }
+
+    It 'uses configured null tokens and date formats when converting and exporting rows' {
+        $row = [pscustomobject]@{
+            Name = 'Alpha'
+            Created = [datetime]::SpecifyKind([datetime]'2026-07-07T13:45:00', [System.DateTimeKind]::Utc)
+            Value = $null
+        }
+
+        $csvText = @($row | ConvertTo-OfficeCsv -NullValue '<null>' -DateTimeFormat 'yyyyMMdd-HHmm' -UseUtc)
+        $csvText[1] | Should -Be 'Alpha,20260707-1345,<null>'
+
+        $path = Join-Path $TestDrive 'formatted.csv'
+        $row | Export-OfficeCsv -Path $path -NullValue '<null>' -DateTimeFormat 'yyyyMMdd-HHmm' -UseUtc
+
+        (Get-Content -LiteralPath $path)[1] | Should -Be 'Alpha,20260707-1345,<null>'
+    }
+
+    It 'imports duplicate headers, null tokens, static columns, and strict quote settings through OfficeIMO options' {
+        $path = Join-Path $TestDrive 'parity.csv'
+        Set-Content -LiteralPath $path -Value "Name,Name,Value`nAlpha,Beta,<null>" -Encoding UTF8
+
+        $row = Import-OfficeCsv -Path $path -NullValue '<null>' -StaticColumns @{ SourceFile = 'parity.csv' }
+
+        $row.Name | Should -Be 'Alpha'
+        $row.Name_2 | Should -Be 'Beta'
+        $row.Value | Should -BeNullOrEmpty
+        $row.SourceFile | Should -Be 'parity.csv'
+
+        { Import-OfficeCsv -Path $path -DuplicateHeaderBehavior Throw -ErrorAction Stop } |
+            Should -Throw '*duplicate*'
+
+        { ConvertFrom-OfficeCsv -Text "Name,Value`nAlpha,`"one`"two" -QuoteParsingMode Strict -ErrorAction Stop } |
+            Should -Throw '*quoted*'
+    }
+
+    It 'round-trips compressed CSV files through PSWriteOffice cmdlets' {
+        $path = Join-Path $TestDrive 'compressed.csv.gz'
+
+        [pscustomobject]@{ Name = 'Alpha'; Value = 1 } |
+            Export-OfficeCsv -Path $path -CompressionType GZip
+
+        Test-Path -LiteralPath $path | Should -BeTrue
+
+        $row = Import-OfficeCsv -Path $path -CompressionType GZip
+        $row.Name | Should -Be 'Alpha'
+        $row.Value | Should -Be '1'
     }
 
     It 'imports CSV rows as a DataTable for database workflows' {
@@ -536,18 +593,26 @@ Describe 'CSV cmdlets' {
         $data[1].Value | Should -Be '2'
     }
 
-    It 'rejects duplicate object headers before using the optimized output path' {
+    It 'renames duplicate object headers by default and can reject them in strict mode' {
         $path = Join-Path $TestDrive 'duplicate-header.csv'
         Set-Content -LiteralPath $path -Value "Name,Name`nAlpha,1" -Encoding UTF8
 
-        { Import-OfficeCsv -Path $path -ErrorAction Stop } | Should -Throw
+        $row = Import-OfficeCsv -Path $path
+
+        $row.Name | Should -Be 'Alpha'
+        $row.Name_2 | Should -Be '1'
+        { Import-OfficeCsv -Path $path -DuplicateHeaderBehavior Throw -ErrorAction Stop } | Should -Throw '*duplicate*'
     }
 
-    It 'rejects duplicate hashtable headers instead of overwriting values' {
+    It 'renames duplicate hashtable headers by default and can reject them in strict mode' {
         $path = Join-Path $TestDrive 'duplicate-hashtable-header.csv'
         Set-Content -LiteralPath $path -Value "Name,Name`nAlpha,1" -Encoding UTF8
 
-        { Import-OfficeCsv -Path $path -AsHashtable -ErrorAction Stop } | Should -Throw
+        $row = Import-OfficeCsv -Path $path -AsHashtable
+
+        $row['Name'] | Should -Be 'Alpha'
+        $row['Name_2'] | Should -Be '1'
+        { Import-OfficeCsv -Path $path -AsHashtable -DuplicateHeaderBehavior Throw -ErrorAction Stop } | Should -Throw '*duplicate*'
     }
 
     It 'supports NoHeader when reading CSV data and documents' {

--- a/Tests/Csv.Tests.ps1
+++ b/Tests/Csv.Tests.ps1
@@ -71,19 +71,28 @@ Describe 'CSV cmdlets' {
     }
 
     It 'uses configured null tokens and date formats when converting and exporting rows' {
-        $row = [pscustomobject]@{
-            Name = 'Alpha'
-            Created = [datetime]::SpecifyKind([datetime]'2026-07-07T13:45:00', [System.DateTimeKind]::Utc)
-            Value = $null
-        }
+        $rows = @(
+            [pscustomobject]@{
+                Name = 'Alpha'
+                Created = [datetime]::SpecifyKind([datetime]'2026-07-07T13:45:00', [System.DateTimeKind]::Utc)
+                Value = $null
+            }
+            [pscustomobject]@{
+                Name = 'Beta'
+                Created = [datetime]::SpecifyKind([datetime]'2026-07-07T14:15:00', [System.DateTimeKind]::Utc)
+                Value = $null
+            }
+        )
 
-        $csvText = @($row | ConvertTo-OfficeCsv -NullValue '<null>' -DateTimeFormat 'yyyyMMdd-HHmm' -UseUtc)
+        $csvText = @($rows | ConvertTo-OfficeCsv -NullValue '<null>' -DateTimeFormat 'yyyyMMdd-HHmm' -UseUtc)
         $csvText[1] | Should -Be 'Alpha,20260707-1345,<null>'
+        $csvText[2] | Should -Be 'Beta,20260707-1415,<null>'
 
         $path = Join-Path $TestDrive 'formatted.csv'
-        $row | Export-OfficeCsv -Path $path -NullValue '<null>' -DateTimeFormat 'yyyyMMdd-HHmm' -UseUtc
+        $rows | Export-OfficeCsv -Path $path -NullValue '<null>' -DateTimeFormat 'yyyyMMdd-HHmm' -UseUtc
 
         (Get-Content -LiteralPath $path)[1] | Should -Be 'Alpha,20260707-1345,<null>'
+        (Get-Content -LiteralPath $path)[2] | Should -Be 'Beta,20260707-1415,<null>'
     }
 
     It 'imports duplicate headers, null tokens, static columns, and strict quote settings through OfficeIMO options' {
@@ -115,6 +124,25 @@ Describe 'CSV cmdlets' {
         $row = Import-OfficeCsv -Path $path -CompressionType GZip
         $row.Name | Should -Be 'Alpha'
         $row.Value | Should -Be '1'
+    }
+
+    It 'allows append to create a compressed CSV file when the target has no content' {
+        $path = Join-Path $TestDrive 'append-create.csv.gz'
+
+        [pscustomobject]@{ Name = 'Alpha'; Value = 1 } |
+            Export-OfficeCsv -Path $path -CompressionType GZip -Append
+
+        $row = Import-OfficeCsv -Path $path -CompressionType GZip
+        $row.Name | Should -Be 'Alpha'
+        $row.Value | Should -Be '1'
+    }
+
+    It 'keeps load-time options on file import parameter sets' {
+        $parameterSets = (Get-Command Import-OfficeCsv).Parameters['NullValue'].ParameterSets.Keys
+
+        $parameterSets | Should -Contain 'PathDelimiter'
+        $parameterSets | Should -Contain 'LiteralPathDelimiter'
+        $parameterSets | Should -Not -Contain 'Document'
     }
 
     It 'imports CSV rows as a DataTable for database workflows' {


### PR DESCRIPTION
## Summary
- expose OfficeIMO.CSV parity options through the PSWriteOffice CSV cmdlets
- add compressed CSV import/export, null/date/UTC formatting, duplicate-header behavior, quote parsing, static columns, and decompression limits
- refresh CSV command help and expand CSV tests around the new options

## Notes
- This PR is intentionally a thin PowerShell surface over the OfficeIMO.CSV feature work merged in EvotecIT/OfficeIMO#2041.
- EvotecIT/OfficeIMO#2042 merged the OfficeIMO.CSV version bump to 0.1.54, but NuGet still lists 0.1.53 as the latest package. PSWriteOffice CI is expected to fail until OfficeIMO.CSV 0.1.54 is published and this PR pins it.
- The Codex review findings around DateTime formatting, file-only import options, and compressed append-create behavior were addressed in commit 29b4f1c.

## Validation
- dotnet build .\Sources\PSWriteOffice\PSWriteOffice.csproj -c Release /p:OfficeIMORoot=<OfficeIMO source with #2041/#2042>
- Invoke-Pester -Path .\Tests\Csv.Tests.ps1 -Output Detailed
- .\Build\Build-Module.ps1 -RunMode Build with OfficeIMORoot pointing at the updated OfficeIMO source
