### PR TITLE
Make Office performance comparisons source-first and correctness-validated

### DIFF
--- a/Benchmarks/Benchmark.ResultValidation.ps1
+++ b/Benchmarks/Benchmark.ResultValidation.ps1
@@ -1,0 +1,72 @@
+function Resolve-BenchmarkRequestedRowCount {
+    [CmdletBinding()]
+    param(
+        [object[]] $RowCount,
+
+        [Parameter(Mandatory)]
+        [string] $Suite
+    )
+
+    $values = if ($RowCount -and $RowCount.Count -gt 0) {
+        $RowCount
+    } else {
+        Get-ExcelBenchmarkDefaultRowCount -Suite $Suite
+    }
+
+    $resolved = foreach ($value in @($values)) {
+        foreach ($part in ([string]$value -split ',')) {
+            $text = $part.Trim()
+            $parsed = 0
+            if ([string]::IsNullOrWhiteSpace($text) -or
+                -not [int]::TryParse(
+                    $text,
+                    [Globalization.NumberStyles]::Integer,
+                    [Globalization.CultureInfo]::InvariantCulture,
+                    [ref]$parsed)) {
+                throw "RowCount must be an integer. Value: '$text'."
+            }
+            if ($parsed -le 0) {
+                throw "RowCount must be greater than zero. Value: $parsed"
+            }
+            $parsed
+        }
+    }
+
+    @($resolved | Select-Object -Unique)
+}
+
+function Assert-BenchmarkRequestedLaneCompletion {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object[]] $Summary,
+
+        [Parameter(Mandatory)]
+        [object[]] $ExpectedRun,
+
+        [Parameter(Mandatory)]
+        [int[]] $RowCount
+    )
+
+    foreach ($expected in $ExpectedRun) {
+        $scenario = [string]$expected.Case.Name
+        foreach ($expectedRowCount in $RowCount) {
+            $actualRows = @($Summary | Where-Object {
+                $actualRowCount = if ($_.Variables -and $_.Variables.ContainsKey('RowCount')) {
+                    [string]$_.Variables['RowCount']
+                } else {
+                    $null
+                }
+
+                $_.Engine -eq $expected.Engine -and
+                $_.Scenario -eq $scenario -and
+                $actualRowCount -eq [string]$expectedRowCount
+            })
+
+            if ($actualRows.Count -eq 0 -or
+                @($actualRows | Where-Object Status -NE 'Succeeded').Count -gt 0) {
+                throw "Requested benchmark lane '$($expected.Engine) / $scenario / $expectedRowCount rows' did not complete successfully."
+            }
+        }
+    }
+}

--- a/Benchmarks/Compare-CsvPerformance.ps1
+++ b/Benchmarks/Compare-CsvPerformance.ps1
@@ -65,11 +65,15 @@ $Scenario = @(
 
 $requiresPSWriteOffice = -not $ListScenarios.IsPresent -and (@($Engine) -contains 'PSWriteOffice')
 if ($requiresPSWriteOffice) {
-    if (-not [string]::IsNullOrWhiteSpace($OfficeIMORoot)) {
-        $env:OfficeIMORoot = $OfficeIMORoot
-    } elseif (-not $env:OfficeIMORoot) {
-        $env:OfficeIMORoot = Join-Path $repoRoot '.missing-officeimo'
+    if ([string]::IsNullOrWhiteSpace($OfficeIMORoot)) {
+        $OfficeIMORoot = $env:OfficeIMORoot
     }
+    if ([string]::IsNullOrWhiteSpace($OfficeIMORoot)) {
+        throw 'OfficeIMORoot is required for PSWriteOffice performance comparisons. Benchmarks must build against the current OfficeIMO source tree, not a published package.'
+    }
+
+    $OfficeIMORoot = (Resolve-Path -LiteralPath $OfficeIMORoot -ErrorAction Stop).Path
+    $env:OfficeIMORoot = $OfficeIMORoot
 
     if (-not $SkipPSWriteOfficeBuild.IsPresent) {
         & dotnet build $projectPath -c $PSWriteOfficeConfiguration -v:minimal

--- a/Benchmarks/Compare-CsvPerformance.ps1
+++ b/Benchmarks/Compare-CsvPerformance.ps1
@@ -39,7 +39,7 @@ $benchmarkHelperPath = Join-Path $PSScriptRoot 'Excel\excel-performance.helpers.
 $resultValidationHelperPath = Join-Path $PSScriptRoot 'Benchmark.ResultValidation.ps1'
 $officeIMOSourceHelperPath = Join-Path $PSScriptRoot 'OfficeIMO.Source.ps1'
 
-Import-Module PSPublishModule -Force -ErrorAction Stop
+Import-Module PSPublishModule -MinimumVersion 3.0.64 -Force -ErrorAction Stop
 if (-not (Get-Command Invoke-BenchmarkSuite -ErrorAction SilentlyContinue)) {
     throw 'The imported PSPublishModule does not expose Invoke-BenchmarkSuite.'
 }

--- a/Benchmarks/Compare-CsvPerformance.ps1
+++ b/Benchmarks/Compare-CsvPerformance.ps1
@@ -35,12 +35,16 @@ $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
 $specPath = Join-Path $PSScriptRoot 'Csv\csv-performance.benchmark.ps1'
 $projectPath = Join-Path $repoRoot 'Sources\PSWriteOffice\PSWriteOffice.csproj'
 $moduleManifest = Join-Path $repoRoot 'PSWriteOffice.psd1'
+$benchmarkHelperPath = Join-Path $PSScriptRoot 'Excel\excel-performance.helpers.ps1'
+$resultValidationHelperPath = Join-Path $PSScriptRoot 'Benchmark.ResultValidation.ps1'
 $officeIMOSourceHelperPath = Join-Path $PSScriptRoot 'OfficeIMO.Source.ps1'
 
 Import-Module PSPublishModule -Force -ErrorAction Stop
 if (-not (Get-Command Invoke-BenchmarkSuite -ErrorAction SilentlyContinue)) {
     throw 'The imported PSPublishModule does not expose Invoke-BenchmarkSuite.'
 }
+. $benchmarkHelperPath
+. $resultValidationHelperPath
 . $officeIMOSourceHelperPath
 
 $Engine = @(
@@ -64,6 +68,41 @@ $Scenario = @(
         }
     }
 ) | Select-Object -Unique
+
+$expectedRowCounts = @(Resolve-BenchmarkRequestedRowCount -RowCount $RowCount -Suite $Suite)
+$selectedCases = @(
+    Get-CsvBenchmarkCase -Suite $Suite | Where-Object {
+        -not $Scenario -or $Scenario.Count -eq 0 -or @($Scenario) -contains [string]$_.Name
+    }
+)
+$selectedRuns = @(
+    foreach ($engineName in @($Engine)) {
+        foreach ($case in $selectedCases) {
+            if (Test-CsvBenchmarkEngineSupport -Engine $engineName -Case $case) {
+                [pscustomobject]@{ Engine = $engineName; Case = $case }
+            }
+        }
+    }
+)
+$unsupportedRuns = @(
+    foreach ($engineName in @($Engine)) {
+        foreach ($case in $selectedCases) {
+            if (-not (Test-CsvBenchmarkEngineSupport -Engine $engineName -Case $case)) {
+                [pscustomobject]@{ Engine = $engineName; Case = $case }
+            }
+        }
+    }
+)
+if (-not $ListScenarios.IsPresent -and $selectedRuns.Count -eq 0) {
+    throw "Requested CSV benchmark lanes are unsupported for engines '$($Engine -join ', ')' and scenarios '$($Scenario -join ', ')'."
+}
+if (-not $ListScenarios.IsPresent -and
+    $PSBoundParameters.ContainsKey('Engine') -and
+    $PSBoundParameters.ContainsKey('Scenario') -and
+    $unsupportedRuns.Count -gt 0) {
+    $unsupportedDescriptions = $unsupportedRuns | ForEach-Object { "$($_.Engine) / $($_.Case.Name)" }
+    throw "Requested CSV benchmark lane(s) are unsupported: $($unsupportedDescriptions -join ', ')."
+}
 
 $requiresPSWriteOffice = -not $ListScenarios.IsPresent -and (@($Engine) -contains 'PSWriteOffice')
 if ($requiresPSWriteOffice) {
@@ -125,6 +164,24 @@ if ($ListScenarios.IsPresent) {
 }
 
 $result = Invoke-BenchmarkSuite @invokeSplat
+$failedRows = @($result.Summary | Where-Object { $_.FailureCount -gt 0 -or $_.Status -eq 'Failed' })
+if ($failedRows.Count -gt 0) {
+    $failedDescriptions = $failedRows | ForEach-Object {
+        $reasons = if ($_.FailureReasons -and $_.FailureReasons.Keys.Count -gt 0) {
+            $_.FailureReasons.Keys -join ' | '
+        } else {
+            'No failure reason was recorded.'
+        }
+        "$($_.Engine) $($_.Scenario): $reasons"
+    }
+    throw "Benchmark run $($result.RunId) had failed lane(s): $($failedDescriptions -join '; ')"
+}
+
+Assert-BenchmarkRequestedLaneCompletion `
+    -Summary @($result.Summary) `
+    -ExpectedRun $selectedRuns `
+    -RowCount $expectedRowCounts
+
 $summaryPath = $result.Artifacts['summary.csv']
 if ($summaryPath -and $UpdateReadme.IsPresent) {
     & (Join-Path $PSScriptRoot 'Update-PerformanceBenchmarkReadme.ps1') `

--- a/Benchmarks/Compare-CsvPerformance.ps1
+++ b/Benchmarks/Compare-CsvPerformance.ps1
@@ -35,11 +35,13 @@ $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
 $specPath = Join-Path $PSScriptRoot 'Csv\csv-performance.benchmark.ps1'
 $projectPath = Join-Path $repoRoot 'Sources\PSWriteOffice\PSWriteOffice.csproj'
 $moduleManifest = Join-Path $repoRoot 'PSWriteOffice.psd1'
+$officeIMOSourceHelperPath = Join-Path $PSScriptRoot 'OfficeIMO.Source.ps1'
 
 Import-Module PSPublishModule -Force -ErrorAction Stop
 if (-not (Get-Command Invoke-BenchmarkSuite -ErrorAction SilentlyContinue)) {
     throw 'The imported PSPublishModule does not expose Invoke-BenchmarkSuite.'
 }
+. $officeIMOSourceHelperPath
 
 $Engine = @(
     foreach ($engineName in @($Engine)) {
@@ -72,11 +74,12 @@ if ($requiresPSWriteOffice) {
         throw 'OfficeIMORoot is required for PSWriteOffice performance comparisons. Benchmarks must build against the current OfficeIMO source tree, not a published package.'
     }
 
-    $OfficeIMORoot = (Resolve-Path -LiteralPath $OfficeIMORoot -ErrorAction Stop).Path
+    $OfficeIMORoot = Resolve-OfficeIMOSourceRoot -Path $OfficeIMORoot
     $env:OfficeIMORoot = $OfficeIMORoot
+    $env:UseOfficeIMOProjectReferences = 'true'
 
     if (-not $SkipPSWriteOfficeBuild.IsPresent) {
-        & dotnet build $projectPath -c $PSWriteOfficeConfiguration -v:minimal
+        & dotnet build $projectPath -c $PSWriteOfficeConfiguration -v:minimal "-p:OfficeIMORoot=$OfficeIMORoot" '-p:UseOfficeIMOProjectReferences=true'
         if ($LASTEXITCODE -ne 0) {
             throw "dotnet build failed for PSWriteOffice ($PSWriteOfficeConfiguration)."
         }

--- a/Benchmarks/Compare-ExcelPerformance.ps1
+++ b/Benchmarks/Compare-ExcelPerformance.ps1
@@ -40,6 +40,7 @@ $specPath = Join-Path $PSScriptRoot 'Excel\excel-performance.benchmark.ps1'
 $projectPath = Join-Path $repoRoot 'Sources\PSWriteOffice\PSWriteOffice.csproj'
 $moduleManifest = Join-Path $repoRoot 'PSWriteOffice.psd1'
 $benchmarkHelperPath = Join-Path $PSScriptRoot 'Excel\excel-performance.helpers.ps1'
+$officeIMOSourceHelperPath = Join-Path $PSScriptRoot 'OfficeIMO.Source.ps1'
 
 Import-Module PSPublishModule -Force -ErrorAction Stop
 if (-not (Get-Command Invoke-BenchmarkSuite -ErrorAction SilentlyContinue)) {
@@ -69,6 +70,7 @@ $Scenario = @(
 ) | Select-Object -Unique
 
 . $benchmarkHelperPath
+. $officeIMOSourceHelperPath
 $selectedCases = @(
     Get-ExcelBenchmarkCase -Suite $Suite | Where-Object {
         -not $Scenario -or $Scenario.Count -eq 0 -or @($Scenario) -contains [string]$_.Name
@@ -83,6 +85,25 @@ $selectedRuns = @(
         }
     }
 )
+$unsupportedRuns = @(
+    foreach ($engineName in @($Engine)) {
+        foreach ($case in $selectedCases) {
+            if (-not (Test-ExcelBenchmarkEngineCaseSupport -Engine $engineName -Case $case)) {
+                [pscustomobject]@{ Engine = $engineName; Case = $case }
+            }
+        }
+    }
+)
+if (-not $ListScenarios.IsPresent -and $selectedRuns.Count -eq 0) {
+    throw "Requested Excel benchmark lanes are unsupported for engines '$($Engine -join ', ')' and scenarios '$($Scenario -join ', ')'."
+}
+if (-not $ListScenarios.IsPresent -and
+    $PSBoundParameters.ContainsKey('Engine') -and
+    $PSBoundParameters.ContainsKey('Scenario') -and
+    $unsupportedRuns.Count -gt 0) {
+    $unsupportedDescriptions = $unsupportedRuns | ForEach-Object { "$($_.Engine) / $($_.Case.Name)" }
+    throw "Requested Excel benchmark lane(s) are unsupported: $($unsupportedDescriptions -join ', ')."
+}
 
 $requiresExcelFast = -not $ListScenarios.IsPresent -and
     [bool]($selectedRuns | Where-Object Engine -EQ 'ExcelFast' | Select-Object -First 1)
@@ -129,11 +150,12 @@ if ($requiresPSWriteOffice) {
         throw 'OfficeIMORoot is required for PSWriteOffice performance comparisons. Benchmarks must build against the current OfficeIMO source tree, not a published package.'
     }
 
-    $OfficeIMORoot = (Resolve-Path -LiteralPath $OfficeIMORoot -ErrorAction Stop).Path
+    $OfficeIMORoot = Resolve-OfficeIMOSourceRoot -Path $OfficeIMORoot
     $env:OfficeIMORoot = $OfficeIMORoot
+    $env:UseOfficeIMOProjectReferences = 'true'
 
     if (-not $SkipPSWriteOfficeBuild.IsPresent) {
-        & dotnet build $projectPath -c $PSWriteOfficeConfiguration -v:minimal
+        & dotnet build $projectPath -c $PSWriteOfficeConfiguration -v:minimal "-p:OfficeIMORoot=$OfficeIMORoot" '-p:UseOfficeIMOProjectReferences=true'
         if ($LASTEXITCODE -ne 0) {
             throw "dotnet build failed for PSWriteOffice ($PSWriteOfficeConfiguration)."
         }

--- a/Benchmarks/Compare-ExcelPerformance.ps1
+++ b/Benchmarks/Compare-ExcelPerformance.ps1
@@ -40,6 +40,7 @@ $specPath = Join-Path $PSScriptRoot 'Excel\excel-performance.benchmark.ps1'
 $projectPath = Join-Path $repoRoot 'Sources\PSWriteOffice\PSWriteOffice.csproj'
 $moduleManifest = Join-Path $repoRoot 'PSWriteOffice.psd1'
 $benchmarkHelperPath = Join-Path $PSScriptRoot 'Excel\excel-performance.helpers.ps1'
+$resultValidationHelperPath = Join-Path $PSScriptRoot 'Benchmark.ResultValidation.ps1'
 $officeIMOSourceHelperPath = Join-Path $PSScriptRoot 'OfficeIMO.Source.ps1'
 
 Import-Module PSPublishModule -Force -ErrorAction Stop
@@ -70,7 +71,9 @@ $Scenario = @(
 ) | Select-Object -Unique
 
 . $benchmarkHelperPath
+. $resultValidationHelperPath
 . $officeIMOSourceHelperPath
+$expectedRowCounts = @(Resolve-BenchmarkRequestedRowCount -RowCount $RowCount -Suite $Suite)
 $selectedCases = @(
     Get-ExcelBenchmarkCase -Suite $Suite | Where-Object {
         -not $Scenario -or $Scenario.Count -eq 0 -or @($Scenario) -contains [string]$_.Name
@@ -217,14 +220,10 @@ if ($failedRows.Count -gt 0) {
     throw "Benchmark run $($result.RunId) had failed lane(s): $($failedDescriptions -join '; ')"
 }
 
-foreach ($expectedRun in $selectedRuns) {
-    $actual = $result.Summary | Where-Object {
-        $_.Engine -eq $expectedRun.Engine -and $_.Scenario -eq $expectedRun.Case.Name
-    } | Select-Object -First 1
-    if ($null -eq $actual -or $actual.Status -ne 'Succeeded') {
-        throw "Requested benchmark lane '$($expectedRun.Engine) / $($expectedRun.Case.Name)' did not complete successfully."
-    }
-}
+Assert-BenchmarkRequestedLaneCompletion `
+    -Summary @($result.Summary) `
+    -ExpectedRun $selectedRuns `
+    -RowCount $expectedRowCounts
 
 $summaryPath = $result.Artifacts['summary.csv']
 if ($summaryPath -and $UpdateReadme.IsPresent) {

--- a/Benchmarks/Compare-ExcelPerformance.ps1
+++ b/Benchmarks/Compare-ExcelPerformance.ps1
@@ -102,12 +102,7 @@ if ($requiresExcelFast) {
         }
         Import-Module ExcelFast -Force -ErrorAction Stop
     } catch {
-        Write-Warning "Skipping ExcelFast benchmark lanes because ExcelFast could not be prepared. $($_.Exception.Message)"
-        $Engine = @($Engine | Where-Object { $_ -ne 'ExcelFast' })
-        $selectedRuns = @($selectedRuns | Where-Object Engine -NE 'ExcelFast')
-        if ($Engine.Count -eq 0) {
-            throw 'No benchmark engines remain after ExcelFast availability checks.'
-        }
+        throw "ExcelFast was requested but could not be prepared. The comparison cannot continue without the requested competitor lane. $($_.Exception.Message)"
     }
 }
 
@@ -127,11 +122,15 @@ $requiresPSWriteOffice = -not $ListScenarios.IsPresent -and [bool](
     } | Select-Object -First 1
 )
 if ($requiresPSWriteOffice) {
-    if (-not [string]::IsNullOrWhiteSpace($OfficeIMORoot)) {
-        $env:OfficeIMORoot = $OfficeIMORoot
-    } elseif (-not $env:OfficeIMORoot) {
-        $env:OfficeIMORoot = Join-Path $repoRoot '.missing-officeimo'
+    if ([string]::IsNullOrWhiteSpace($OfficeIMORoot)) {
+        $OfficeIMORoot = $env:OfficeIMORoot
     }
+    if ([string]::IsNullOrWhiteSpace($OfficeIMORoot)) {
+        throw 'OfficeIMORoot is required for PSWriteOffice performance comparisons. Benchmarks must build against the current OfficeIMO source tree, not a published package.'
+    }
+
+    $OfficeIMORoot = (Resolve-Path -LiteralPath $OfficeIMORoot -ErrorAction Stop).Path
+    $env:OfficeIMORoot = $OfficeIMORoot
 
     if (-not $SkipPSWriteOfficeBuild.IsPresent) {
         & dotnet build $projectPath -c $PSWriteOfficeConfiguration -v:minimal
@@ -183,6 +182,28 @@ if ($ListScenarios.IsPresent) {
 }
 
 $result = Invoke-BenchmarkSuite @invokeSplat
+$failedRows = @($result.Summary | Where-Object { $_.FailureCount -gt 0 -or $_.Status -eq 'Failed' })
+if ($failedRows.Count -gt 0) {
+    $failedDescriptions = $failedRows | ForEach-Object {
+        $reasons = if ($_.FailureReasons -and $_.FailureReasons.Keys.Count -gt 0) {
+            $_.FailureReasons.Keys -join ' | '
+        } else {
+            'No failure reason was recorded.'
+        }
+        "$($_.Engine) $($_.Scenario): $reasons"
+    }
+    throw "Benchmark run $($result.RunId) had failed lane(s): $($failedDescriptions -join '; ')"
+}
+
+foreach ($expectedRun in $selectedRuns) {
+    $actual = $result.Summary | Where-Object {
+        $_.Engine -eq $expectedRun.Engine -and $_.Scenario -eq $expectedRun.Case.Name
+    } | Select-Object -First 1
+    if ($null -eq $actual -or $actual.Status -ne 'Succeeded') {
+        throw "Requested benchmark lane '$($expectedRun.Engine) / $($expectedRun.Case.Name)' did not complete successfully."
+    }
+}
+
 $summaryPath = $result.Artifacts['summary.csv']
 if ($summaryPath -and $UpdateReadme.IsPresent) {
     & (Join-Path $PSScriptRoot 'Update-PerformanceBenchmarkReadme.ps1') `

--- a/Benchmarks/Compare-ExcelPerformance.ps1
+++ b/Benchmarks/Compare-ExcelPerformance.ps1
@@ -43,7 +43,7 @@ $benchmarkHelperPath = Join-Path $PSScriptRoot 'Excel\excel-performance.helpers.
 $resultValidationHelperPath = Join-Path $PSScriptRoot 'Benchmark.ResultValidation.ps1'
 $officeIMOSourceHelperPath = Join-Path $PSScriptRoot 'OfficeIMO.Source.ps1'
 
-Import-Module PSPublishModule -Force -ErrorAction Stop
+Import-Module PSPublishModule -MinimumVersion 3.0.64 -Force -ErrorAction Stop
 if (-not (Get-Command Invoke-BenchmarkSuite -ErrorAction SilentlyContinue)) {
     throw 'The imported PSPublishModule does not expose Invoke-BenchmarkSuite.'
 }

--- a/Benchmarks/Csv/csv-performance.benchmark.ps1
+++ b/Benchmarks/Csv/csv-performance.benchmark.ps1
@@ -73,6 +73,6 @@ benchmark 'csv-performance' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\C
         [double] $case.RowCount / ($run.DurationMs / 1000)
     }
 
-    comparison Engine -Baseline PSWriteOffice -Metric MedianMs
+    comparison Engine -Baseline PSWriteOffice -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
     artifacts Json, Csv, Markdown
 }

--- a/Benchmarks/Csv/csv-performance.benchmark.ps1
+++ b/Benchmarks/Csv/csv-performance.benchmark.ps1
@@ -5,7 +5,7 @@ $suiteName = input Suite Standard
 $rowCounts = Assert-ExcelBenchmarkRowCount -RowCount (inputInt RowCount (Get-ExcelBenchmarkDefaultRowCount -Suite $suiteName))
 
 benchmark 'csv-performance' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\CsvPerformance') {
-    policy -Warmup 1 -Iterations (Get-ExcelBenchmarkIterationCount -Suite $suiteName) -Order Rotated -OutlierMode None
+    policy -Warmup (Get-ExcelBenchmarkWarmupCount -Suite $suiteName) -Iterations (Get-CsvBenchmarkIterationCount -Suite $suiteName) -Order GroupedRotated -MemoryCleanup BeforeIteration -OutlierMode None
     profile Current -Cleanup KeepOnFailure
     caseSource (Get-CsvBenchmarkCase -Suite $suiteName)
     axis RowCount $rowCounts

--- a/Benchmarks/Excel/excel-performance.benchmark.ps1
+++ b/Benchmarks/Excel/excel-performance.benchmark.ps1
@@ -8,7 +8,7 @@ $skipImportExcelInstall = inputBool SkipImportExcelInstall false
 $skipExcelFastInstall = inputBool SkipExcelFastInstall false
 
 benchmark 'excel-performance' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\ExcelPerformance') {
-    policy -Warmup 1 -Iterations (Get-ExcelBenchmarkIterationCount -Suite $suiteName) -Order Rotated -OutlierMode None
+    policy -Warmup (Get-ExcelBenchmarkWarmupCount -Suite $suiteName) -Iterations (Get-ExcelBenchmarkIterationCount -Suite $suiteName) -Order GroupedRotated -MemoryCleanup BeforeIteration -OutlierMode None
     profile Current -Cleanup KeepOnFailure
     caseSource (Get-ExcelBenchmarkCase -Suite $suiteName)
     axis RowCount $rowCounts

--- a/Benchmarks/Excel/excel-performance.benchmark.ps1
+++ b/Benchmarks/Excel/excel-performance.benchmark.ps1
@@ -44,7 +44,7 @@ benchmark 'excel-performance' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks
     skip {
         param($case)
 
-        -not (Test-ExcelBenchmarkEngineSupport -Engine $case.Engine -Case $case)
+        return ([string] $case.SupportedEngines -split ',') -notcontains [string] $case.Engine
     }
 
     engine PSWriteOffice {
@@ -74,6 +74,6 @@ benchmark 'excel-performance' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks
         Test-ExcelBenchmarkOutput -Case $case -Run $run
     }
 
-    comparison Engine -Baseline PSWriteOffice -Metric MedianMs
+    comparison Engine -Baseline PSWriteOffice -Metric MedianMs -TieTolerance 0.05
     artifacts Json, Csv, Markdown
 }

--- a/Benchmarks/Excel/excel-performance.benchmark.ps1
+++ b/Benchmarks/Excel/excel-performance.benchmark.ps1
@@ -74,6 +74,6 @@ benchmark 'excel-performance' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks
         Test-ExcelBenchmarkOutput -Case $case -Run $run
     }
 
-    comparison Engine -Baseline PSWriteOffice -Metric MedianMs -TieTolerance 0.05
+    comparison Engine -Baseline PSWriteOffice -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
     artifacts Json, Csv, Markdown
 }

--- a/Benchmarks/Excel/excel-performance.core.ps1
+++ b/Benchmarks/Excel/excel-performance.core.ps1
@@ -34,10 +34,36 @@ function Get-ExcelBenchmarkIterationCount {
     param([string] $Suite)
 
     switch ($Suite) {
-        Smoke { 1 }
-        Standard { 3 }
+        Smoke { 5 }
+        Standard { 5 }
         Large { 3 }
         Full { 5 }
+        SuperLarge { 3 }
+        default { 5 }
+    }
+}
+
+function Get-CsvBenchmarkIterationCount {
+    param([string] $Suite)
+
+    switch ($Suite) {
+        Smoke { 25 }
+        Standard { 25 }
+        Large { 11 }
+        Full { 25 }
+        SuperLarge { 7 }
+        default { 25 }
+    }
+}
+
+function Get-ExcelBenchmarkWarmupCount {
+    param([string] $Suite)
+
+    switch ($Suite) {
+        Smoke { 3 }
+        Standard { 3 }
+        Large { 2 }
+        Full { 2 }
         SuperLarge { 1 }
         default { 3 }
     }

--- a/Benchmarks/Excel/excel-performance.core.ps1
+++ b/Benchmarks/Excel/excel-performance.core.ps1
@@ -65,6 +65,15 @@ function New-ExcelBenchmarkCase {
         [bool] $ValidateWorkbook = $true
     )
 
+    $supportedEngines = @('PSWriteOffice')
+    if ($OperationKey -notin @('WriteCsv', 'ReadCsvSource', 'ReadUsedRangeDataTable', 'ReadTableMetadata', 'ReadNamedRangeMetadata') -and
+        $Name -ne 'dataset-worksheets') {
+        $supportedEngines += 'ImportExcel'
+    }
+    if ($Name -in @('text-objects-default', 'import-default-full', 'import-default-range', 'read-no-header-range')) {
+        $supportedEngines += 'ExcelFast'
+    }
+
     [pscustomobject]@{
         Name = $Name
         Label = $Label
@@ -73,6 +82,7 @@ function New-ExcelBenchmarkCase {
         DataProfile = $Profile
         FileExtension = $FileExtension
         ValidateWorkbook = $ValidateWorkbook
+        SupportedEngines = $supportedEngines -join ','
     }
 }
 
@@ -91,6 +101,7 @@ function Get-ExcelBenchmarkCase {
         New-ExcelBenchmarkCase -Name csv-to-excel -Label 'Create workbook from CSV source' -Suites $workflow -OperationKey CsvToExcel -Profile MixedObjects
         New-ExcelBenchmarkCase -Name objects-table -Label 'Export objects as table' -Suites $table -OperationKey WriteWorkbook -Profile MixedObjects
         New-ExcelBenchmarkCase -Name objects-default -Label 'Export objects default' -Suites $basic -OperationKey WriteWorkbook -Profile MixedObjects
+        New-ExcelBenchmarkCase -Name text-objects-default -Label 'Export text-only objects default' -Suites $basic -OperationKey WriteWorkbook -Profile TextObjects
         New-ExcelBenchmarkCase -Name objects-no-table -Label 'Export objects without a table' -Suites $scale -OperationKey WriteWorkbook -Profile MixedObjects
         New-ExcelBenchmarkCase -Name objects-table-autofit -Label 'Export objects as autofit table' -Suites $standard -OperationKey WriteWorkbook -Profile MixedObjects
         New-ExcelBenchmarkCase -Name objects-title-freeze -Label 'Export objects with title and frozen header' -Suites $workflow -OperationKey WriteWorkbook -Profile MixedObjects
@@ -152,45 +163,7 @@ function Test-ExcelBenchmarkEngineCaseSupport {
         [object] $Case
     )
 
-    $operation = [string]$Case.OperationKey
-    $name = if ($Case.PSObject.Properties['Scenario']) {
-        [string]$Case.Scenario
-    } else {
-        ''
-    }
-    if ($name.Length -eq 0 -and $Case.PSObject.Properties['Name']) {
-        $name = [string]$Case.Name
-    }
-
-    switch ($Engine) {
-        PSWriteOffice { return $true }
-        ImportExcel {
-            return $operation -notin @('WriteCsv', 'ReadCsvSource', 'ReadUsedRangeDataTable', 'ReadTableMetadata', 'ReadNamedRangeMetadata') -and
-                $name -ne 'dataset-worksheets'
-        }
-        ExcelFast {
-            return $name -in @('objects-default', 'wide-objects-default', 'import-default-full', 'import-default-range', 'read-no-header-range')
-        }
-        NativeCsv { return $false }
-        default { return $false }
-    }
-}
-
-function Test-ExcelBenchmarkEngineSupport {
-    param(
-        [Parameter(Mandatory)]
-        [string] $Engine,
-
-        [Parameter(Mandatory)]
-        [object] $Case
-    )
-
-    if (-not (Test-ExcelBenchmarkEngineCaseSupport -Engine $Engine -Case $Case)) {
-        return $false
-    }
-
-    return $Engine -ne 'ExcelFast' -or
-        [bool](Get-Module -ListAvailable ExcelFast | Sort-Object Version -Descending | Select-Object -First 1)
+    return ([string]$Case.SupportedEngines -split ',') -contains $Engine
 }
 
 function Test-CsvBenchmarkEngineSupport {

--- a/Benchmarks/Excel/excel-performance.data.ps1
+++ b/Benchmarks/Excel/excel-performance.data.ps1
@@ -8,6 +8,9 @@ function Get-ExcelBenchmarkData {
         MixedObjects {
             [pscustomobject]@{ Data = @(New-ExcelBenchmarkRows -Count $Count); ColumnCount = 10; WorksheetName = 'Data' }
         }
+        TextObjects {
+            [pscustomobject]@{ Data = @(New-ExcelBenchmarkTextRows -Count $Count); ColumnCount = 10; WorksheetName = 'Data' }
+        }
         WideObjects {
             [pscustomobject]@{ Data = @(New-ExcelBenchmarkWideRows -Count $Count); ColumnCount = 40; WorksheetName = 'Data' }
         }
@@ -71,6 +74,25 @@ function New-ExcelBenchmarkRows {
             Score = [math]::Round(($i * 1.137) % 1000, 3)
             Owner = 'owner{0}@example.test' -f ($i % 250)
             TicketCount = $i % 17
+            Notes = 'Benchmark row {0}' -f $i
+        }
+    }
+}
+
+function New-ExcelBenchmarkTextRows {
+    param([int] $Count)
+
+    for ($i = 1; $i -le $Count; $i++) {
+        [pscustomobject]@{
+            Id = $i.ToString([Globalization.CultureInfo]::InvariantCulture)
+            Name = 'Server-{0:000000}' -f $i
+            Department = 'Department-{0}' -f ($i % 25)
+            Region = @('NA', 'EU', 'APAC', 'LATAM')[$i % 4]
+            IsEnabled = if (($i % 3) -ne 0) { 'true' } else { 'false' }
+            Created = ([datetime]'2024-01-01').AddMinutes($i).ToString('O', [Globalization.CultureInfo]::InvariantCulture)
+            Score = ([math]::Round(($i * 1.137) % 1000, 3)).ToString([Globalization.CultureInfo]::InvariantCulture)
+            Owner = 'owner{0}@example.test' -f ($i % 250)
+            TicketCount = ($i % 17).ToString([Globalization.CultureInfo]::InvariantCulture)
             Notes = 'Benchmark row {0}' -f $i
         }
     }

--- a/Benchmarks/Excel/excel-performance.operations.ps1
+++ b/Benchmarks/Excel/excel-performance.operations.ps1
@@ -345,7 +345,21 @@ function Invoke-ExcelBenchmarkObjectsDefault {
     switch ($Engine) {
         PSWriteOffice { $Run.Payload | Export-OfficeExcel -Path $Run.Path -WorksheetName $Run.WorksheetName }
         ImportExcel { $Run.Payload | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName }
-        ExcelFast { Export-Workbook -Destination $Run.Path -InputObject $Run.Payload -SheetName $Run.WorksheetName -Force }
+        ExcelFast {
+            Export-Workbook -Destination $Run.Path -InputObject $Run.Payload -SheetName $Run.WorksheetName -Force
+
+            # ExcelFast 0.0.1-alpha16 writes an empty drawing element inside sheetData,
+            # which is not valid Open XML. Keep its own normalization cost in the timed
+            # operation so the comparison only accepts a standards-valid workbook.
+            $workbook = Get-Workbook -Path $Run.Path
+            try {
+                Save-Workbook -Workbook $workbook -Force
+            } finally {
+                if ($workbook -is [IDisposable]) {
+                    $workbook.Dispose()
+                }
+            }
+        }
     }
 }
 

--- a/Benchmarks/Excel/excel-performance.operations.ps1
+++ b/Benchmarks/Excel/excel-performance.operations.ps1
@@ -311,6 +311,7 @@ function Invoke-ExcelBenchmarkWriteWorkbook {
     switch ([string]$Case.Scenario) {
         objects-table { Invoke-ExcelBenchmarkObjectsTable -Engine $Engine -Run $Run }
         objects-default { Invoke-ExcelBenchmarkObjectsDefault -Engine $Engine -Run $Run }
+        text-objects-default { Invoke-ExcelBenchmarkObjectsDefault -Engine $Engine -Run $Run }
         objects-no-table { Invoke-ExcelBenchmarkObjectsNoTable -Engine $Engine -Run $Run }
         objects-table-autofit { Invoke-ExcelBenchmarkObjectsTableAutofit -Engine $Engine -Run $Run }
         objects-title-freeze { Invoke-ExcelBenchmarkObjectsTitleFreeze -Engine $Engine -Run $Run }

--- a/Benchmarks/Excel/excel-performance.validation.ps1
+++ b/Benchmarks/Excel/excel-performance.validation.ps1
@@ -312,8 +312,10 @@ function Test-CsvBenchmarkValueEquivalent {
         return $false
     }
 
-    if ($Expected -is [byte] -or $Expected -is [sbyte] -or $Expected -is [short] -or $Expected -is [ushort] -or
-        $Expected -is [int] -or $Expected -is [uint] -or $Expected -is [long] -or $Expected -is [ulong]) {
+    if ($Expected -is [System.Byte] -or $Expected -is [System.SByte] -or
+        $Expected -is [System.Int16] -or $Expected -is [System.UInt16] -or
+        $Expected -is [System.Int32] -or $Expected -is [System.UInt32] -or
+        $Expected -is [System.Int64] -or $Expected -is [System.UInt64]) {
         foreach ($culture in $cultures) {
             $parsed = [decimal]::Zero
             if ([decimal]::TryParse($actualText, [Globalization.NumberStyles]::Integer, $culture, [ref]$parsed) -and

--- a/Benchmarks/Excel/excel-performance.validation.ps1
+++ b/Benchmarks/Excel/excel-performance.validation.ps1
@@ -183,12 +183,174 @@ function Test-CsvBenchmarkOutput {
     assertPath $path
     $actualRows = if ($Case.OperationKey -eq 'WriteCsvGZip') {
         $table = ConvertFrom-NativeGZipCsvToDataTable -Path $path
-        if ($table -and $table.Rows) { [int]$table.Rows.Count } else { 0 }
+        if ($table -and $table.Rows) { @($table.Select()) } else { @() }
     } else {
-        @(Import-Csv -Path $path).Count
+        @(Import-Csv -Path $path)
     }
-    assertValue $actualRows $expectedRows -Message "Expected $expectedRows rows in '$path'."
-    $Run.RowsProcessed = [int]$actualRows
+    assertValue $actualRows.Count $expectedRows -Message "Expected $expectedRows rows in '$path'."
+    Test-CsvBenchmarkTabularValues -Case $Case -Run $Run -ActualRows $actualRows
+    $Run.RowsProcessed = [int]$actualRows.Count
+}
+
+function Test-CsvBenchmarkTabularValues {
+    param([object] $Case, [object] $Run, [object[]] $ActualRows)
+
+    $expectedRows = if ($Run.Payload -is [Data.DataTable]) {
+        @($Run.Payload.Select())
+    } else {
+        @($Run.Payload)
+    }
+
+    assertValue $ActualRows.Count $expectedRows.Count -Message "Expected '$($Case.Scenario)' to preserve every CSV data row."
+    if ($expectedRows.Count -eq 0) {
+        return
+    }
+
+    $expectedColumns = @(Get-CsvBenchmarkColumnNames -Row $expectedRows[0])
+    $actualColumns = @(Get-CsvBenchmarkColumnNames -Row $ActualRows[0])
+    assertValue ($actualColumns -join [char]31) ($expectedColumns -join [char]31) -Message "Expected '$($Case.Scenario)' to preserve the CSV header and column order."
+
+    for ($rowIndex = 0; $rowIndex -lt $expectedRows.Count; $rowIndex++) {
+        $expectedRow = $expectedRows[$rowIndex]
+        $actualRow = $ActualRows[$rowIndex]
+        foreach ($column in $expectedColumns) {
+            $expectedValue = Get-CsvBenchmarkCellValue -Row $expectedRow -Column $column
+            $actualValue = Get-CsvBenchmarkCellValue -Row $actualRow -Column $column
+            if (-not (Test-CsvBenchmarkValueEquivalent -Expected $expectedValue -Actual $actualValue)) {
+                throw "Expected '$($Case.Scenario)' row $rowIndex column '$column' to preserve value '$expectedValue'; actual value was '$actualValue'."
+            }
+        }
+    }
+}
+
+function Get-CsvBenchmarkColumnNames {
+    param([object] $Row)
+
+    if ($Row -is [Data.DataRow]) {
+        return @($Row.Table.Columns | ForEach-Object { [string]$_.ColumnName })
+    }
+
+    return @($Row.PSObject.Properties | ForEach-Object { [string]$_.Name })
+}
+
+function Get-CsvBenchmarkCellValue {
+    param([object] $Row, [string] $Column)
+
+    if ($Row -is [Data.DataRow]) {
+        return $Row[$Column]
+    }
+
+    return $Row.PSObject.Properties[$Column].Value
+}
+
+function Test-CsvBenchmarkValueEquivalent {
+    param([AllowNull()][object] $Expected, [AllowNull()][object] $Actual)
+
+    if ($Expected -is [Management.Automation.PSObject]) {
+        $Expected = $Expected.PSObject.BaseObject
+    }
+    if ($Actual -is [Management.Automation.PSObject]) {
+        $Actual = $Actual.PSObject.BaseObject
+    }
+
+    if ($null -eq $Expected -or $Expected -is [DBNull]) {
+        return $null -eq $Actual -or $Actual -is [DBNull] -or [string]::IsNullOrEmpty([string]$Actual)
+    }
+
+    if ($Expected -is [string]) {
+        return ([string]$Actual) -ceq $Expected
+    }
+
+    $actualText = [string]$Actual
+    if ($Expected -is [bool]) {
+        $parsed = $false
+        return [bool]::TryParse($actualText, [ref]$parsed) -and $parsed -eq $Expected
+    }
+
+    if ($Expected -is [guid]) {
+        $parsed = [guid]::Empty
+        return [guid]::TryParse($actualText, [ref]$parsed) -and $parsed -eq $Expected
+    }
+
+    $currentCulture = [Globalization.CultureInfo]::CurrentCulture
+    $invariantCulture = [Globalization.CultureInfo]::InvariantCulture
+    $cultures = if ($currentCulture.Name -eq $invariantCulture.Name) {
+        @($invariantCulture)
+    } else {
+        @($currentCulture, $invariantCulture)
+    }
+
+    if ($Expected -is [datetime]) {
+        foreach ($culture in $cultures) {
+            $parsed = [datetime]::MinValue
+            if ([datetime]::TryParse($actualText, $culture, [Globalization.DateTimeStyles]::AllowWhiteSpaces, [ref]$parsed) -and
+                $parsed.Ticks -eq $Expected.Ticks) {
+                return $true
+            }
+        }
+        return $false
+    }
+
+    if ($Expected -is [datetimeoffset]) {
+        foreach ($culture in $cultures) {
+            $parsed = [datetimeoffset]::MinValue
+            if ([datetimeoffset]::TryParse($actualText, $culture, [Globalization.DateTimeStyles]::AllowWhiteSpaces, [ref]$parsed) -and
+                $parsed.UtcTicks -eq $Expected.UtcTicks) {
+                return $true
+            }
+        }
+        return $false
+    }
+
+    if ($Expected -is [timespan]) {
+        foreach ($culture in $cultures) {
+            $parsed = [timespan]::Zero
+            if ([timespan]::TryParse($actualText, $culture, [ref]$parsed) -and $parsed -eq $Expected) {
+                return $true
+            }
+        }
+        return $false
+    }
+
+    if ($Expected -is [byte] -or $Expected -is [sbyte] -or $Expected -is [short] -or $Expected -is [ushort] -or
+        $Expected -is [int] -or $Expected -is [uint] -or $Expected -is [long] -or $Expected -is [ulong]) {
+        foreach ($culture in $cultures) {
+            $parsed = [decimal]::Zero
+            if ([decimal]::TryParse($actualText, [Globalization.NumberStyles]::Integer, $culture, [ref]$parsed) -and
+                $parsed -eq [decimal]$Expected) {
+                return $true
+            }
+        }
+        return $false
+    }
+
+    if ($Expected -is [decimal]) {
+        foreach ($culture in $cultures) {
+            $parsed = [decimal]::Zero
+            if ([decimal]::TryParse($actualText, [Globalization.NumberStyles]::Number, $culture, [ref]$parsed) -and
+                $parsed -eq $Expected) {
+                return $true
+            }
+        }
+        return $false
+    }
+
+    if ($Expected -is [double] -or $Expected -is [single]) {
+        $expectedNumber = [double]$Expected
+        $tolerance = [math]::Max(1e-10, [math]::Abs($expectedNumber) * 1e-12)
+        foreach ($culture in $cultures) {
+            $parsed = 0.0
+            $style = [Globalization.NumberStyles]::Float -bor [Globalization.NumberStyles]::AllowThousands
+            if ([double]::TryParse($actualText, $style, $culture, [ref]$parsed) -and
+                [math]::Abs($parsed - $expectedNumber) -le $tolerance) {
+                return $true
+            }
+        }
+        return $false
+    }
+
+    $expectedText = [string]$Expected
+    return $actualText -ceq $expectedText
 }
 
 function Test-ExcelBenchmarkOpenXml {

--- a/Benchmarks/Excel/excel-performance.validation.ps1
+++ b/Benchmarks/Excel/excel-performance.validation.ps1
@@ -103,6 +103,61 @@ function Test-ExcelBenchmarkOutput {
         Close-OfficeExcel -Document $document
     }
     Test-ExcelBenchmarkOpenXml -Path $Run.Path
+
+    if ([string]$Case.Scenario -in @('objects-default', 'text-objects-default', 'wide-objects-default')) {
+        Test-ExcelBenchmarkTabularValues -Case $Case -Run $Run
+    }
+}
+
+function Test-ExcelBenchmarkTabularValues {
+    param([object] $Case, [object] $Run)
+
+    $actualRows = @(Import-OfficeExcel -Path $Run.Path -WorksheetName $Run.WorksheetName)
+    $expectedRows = @($Run.Payload)
+    assertValue $actualRows.Count $expectedRows.Count -Message "Expected '$($Case.Scenario)' to preserve every data row."
+    if ($expectedRows.Count -eq 0) {
+        return
+    }
+
+    $lastIndex = $expectedRows.Count - 1
+    $middleIndex = [int] [Math]::Floor($lastIndex / 2)
+    $indexes = @(0, $middleIndex, $lastIndex) | Select-Object -Unique
+    foreach ($index in $indexes) {
+        $expected = $expectedRows[$index]
+        $actual = $actualRows[$index]
+        foreach ($property in $expected.PSObject.Properties) {
+            $expectedValue = ConvertTo-ExcelBenchmarkComparableValue -Value $property.Value
+            $actualProperty = $actual.PSObject.Properties[$property.Name]
+            if ($null -eq $actualProperty) {
+                throw "Expected '$($Case.Scenario)' row $index to contain column '$($property.Name)'."
+            }
+
+            $actualValue = ConvertTo-ExcelBenchmarkComparableValue -Value $actualProperty.Value
+            assertValue $actualValue $expectedValue -Message "Expected '$($Case.Scenario)' row $index column '$($property.Name)' to preserve its value."
+        }
+    }
+}
+
+function ConvertTo-ExcelBenchmarkComparableValue {
+    param([AllowNull()][object] $Value)
+
+    if ($null -eq $Value -or $Value -is [DBNull]) {
+        return '<null>'
+    }
+    if ($Value -is [datetime]) {
+        return $Value.ToString('O', [Globalization.CultureInfo]::InvariantCulture)
+    }
+    if ($Value -is [bool]) {
+        return $Value.ToString().ToLowerInvariant()
+    }
+    if ($Value -is [double] -or $Value -is [single]) {
+        return ([Math]::Round([double] $Value, 10)).ToString('G17', [Globalization.CultureInfo]::InvariantCulture)
+    }
+    if ($Value -is [IFormattable]) {
+        return $Value.ToString($null, [Globalization.CultureInfo]::InvariantCulture)
+    }
+
+    return [string] $Value
 }
 
 function Test-CsvBenchmarkOutput {

--- a/Benchmarks/OfficeIMO.Source.ps1
+++ b/Benchmarks/OfficeIMO.Source.ps1
@@ -1,0 +1,26 @@
+function Resolve-OfficeIMOSourceRoot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string] $Path
+    )
+
+    $resolvedRoot = (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+    $requiredSourceFiles = @(
+        'OfficeIMO.sln',
+        'OfficeIMO.CSV/OfficeIMO.CSV.csproj',
+        'OfficeIMO.Excel/OfficeIMO.Excel.csproj'
+    )
+    $missingSourceFiles = @(
+        foreach ($relativePath in $requiredSourceFiles) {
+            if (-not (Test-Path -LiteralPath (Join-Path $resolvedRoot $relativePath) -PathType Leaf)) {
+                $relativePath
+            }
+        }
+    )
+    if ($missingSourceFiles.Count -gt 0) {
+        throw "OfficeIMORoot '$resolvedRoot' is not a complete OfficeIMO source root. Missing: $($missingSourceFiles -join ', ')."
+    }
+
+    $resolvedRoot
+}

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -17,6 +17,20 @@ Every read comparison uses the same PSWriteOffice-produced workbook shape for
 the selected row count. The competing readers do not benchmark files created by
 their own writers.
 
+The current ExcelFast 0.0.1-alpha16 writer places an empty drawing element in an
+invalid worksheet position. Its write lane therefore includes ExcelFast's own
+`Get-Workbook` and `Save-Workbook` normalization inside the timed operation.
+This keeps ExcelFast in the comparison without reporting malformed-workbook
+speed as a valid result.
+
+Runs that include PSWriteOffice build directly against a complete OfficeIMO
+source checkout. With sibling PSWriteOffice and OfficeIMO checkouts, set the
+source root once for the current shell:
+
+```powershell
+$env:OfficeIMORoot = (Resolve-Path ..\OfficeIMO).Path
+```
+
 ```powershell
 pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 -Suite Smoke
 ```
@@ -37,78 +51,81 @@ pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-Excel
 <!-- BENCHMARK:ExcelComparison:START -->
 | Scenario | Rows | PSWriteOffice | ExcelFast | ImportExcel | Result |
 | --- | ---: | ---: | ---: | ---: | --- |
-| append-existing-table | 1000 | 74.8 ms (1.00x) | Skipped | 344.6 ms (4.61x slower) | PSWriteOffice fastest |
-| append-existing-table | 5000 | 443.0 ms (1.00x) | Skipped | 1.16 s (2.61x slower) | PSWriteOffice fastest |
-| append-existing-table | 10000 | 931.8 ms (1.00x) | Skipped | 2.47 s (2.65x slower) | PSWriteOffice fastest |
-| chart-only-workbook | 1000 | 113.8 ms (1.00x) | Skipped | 422.5 ms (3.71x slower) | PSWriteOffice fastest |
-| chart-only-workbook | 5000 | 626.1 ms (1.00x) | Skipped | 1.09 s (1.74x slower) | PSWriteOffice fastest |
-| chart-only-workbook | 10000 | 1.34 s (1.00x) | Skipped | 2.24 s (1.68x slower) | PSWriteOffice fastest |
-| csv-to-excel | 1000 | 78.4 ms (1.00x) | Skipped | 440.0 ms (5.61x slower) | PSWriteOffice fastest |
-| csv-to-excel | 5000 | 406.9 ms (1.00x) | Skipped | 1.86 s (4.58x slower) | PSWriteOffice fastest |
-| csv-to-excel | 10000 | 737.4 ms (1.00x) | Skipped | 3.52 s (4.78x slower) | PSWriteOffice fastest |
-| datatable-default | 1000 | 22.4 ms (1.00x) | Skipped | 254.1 ms (11.36x slower) | PSWriteOffice fastest |
-| datatable-default | 5000 | 31.7 ms (1.00x) | Skipped | 819.9 ms (25.88x slower) | PSWriteOffice fastest |
-| datatable-default | 10000 | 47.2 ms (1.00x) | Skipped | 1.47 s (31.26x slower) | PSWriteOffice fastest |
-| import-default-full | 1000 | 26.4 ms (1.00x) | 45.1 ms (1.71x slower) | 125.2 ms (4.74x slower) | PSWriteOffice fastest |
-| import-default-full | 5000 | 117.0 ms (1.00x) | 331.9 ms (2.84x slower) | 321.9 ms (2.75x slower) | PSWriteOffice fastest |
-| import-default-full | 10000 | 286.4 ms (1.00x) | 391.2 ms (1.37x slower) | 453.8 ms (1.58x slower) | PSWriteOffice fastest |
-| import-default-range | 1000 | 16.3 ms (1.00x) | 34.6 ms (2.13x slower) | 100.4 ms (6.17x slower) | PSWriteOffice fastest |
-| import-default-range | 5000 | 75.5 ms (1.00x) | 239.8 ms (3.18x slower) | 237.6 ms (3.15x slower) | PSWriteOffice fastest |
-| import-default-range | 10000 | 231.5 ms (1.00x) | 357.8 ms (1.55x slower) | 415.2 ms (1.79x slower) | PSWriteOffice fastest |
-| many-small-sheets | 1000 | 120.1 ms (1.00x) | Skipped | 310.3 ms (2.58x slower) | PSWriteOffice fastest |
-| many-small-sheets | 5000 | 496.2 ms (1.00x) | Skipped | 1.10 s (2.22x slower) | PSWriteOffice fastest |
-| many-small-sheets | 10000 | 976.4 ms (1.00x) | Skipped | 2.13 s (2.18x slower) | PSWriteOffice fastest |
-| multi-sheet-regions | 1000 | 150.2 ms (1.00x) | Skipped | 406.6 ms (2.71x slower) | PSWriteOffice fastest |
-| multi-sheet-regions | 5000 | 505.7 ms (1.00x) | Skipped | 1.12 s (2.22x slower) | PSWriteOffice fastest |
-| multi-sheet-regions | 10000 | 955.5 ms (1.00x) | Skipped | 2.13 s (2.23x slower) | PSWriteOffice fastest |
-| named-range-workbook | 1000 | 59.9 ms (1.00x) | Skipped | 271.3 ms (4.53x slower) | PSWriteOffice fastest |
-| named-range-workbook | 5000 | 405.0 ms (1.00x) | Skipped | 1.05 s (2.60x slower) | PSWriteOffice fastest |
-| named-range-workbook | 10000 | 922.9 ms (1.00x) | Skipped | 2.10 s (2.28x slower) | PSWriteOffice fastest |
-| objects-default | 1000 | 80.8 ms (1.00x) | 131.6 ms (1.63x slower) | 300.6 ms (3.72x slower) | PSWriteOffice fastest |
-| objects-default | 5000 | 101.7 ms (1.00x) | 177.9 ms (1.75x slower) | 1.01 s (9.94x slower) | PSWriteOffice fastest |
-| objects-default | 10000 | 304.6 ms (1.00x) | 367.5 ms (1.21x slower) | 2.52 s (8.27x slower) | PSWriteOffice fastest |
-| objects-no-table | 1000 | 31.1 ms (1.00x) | Skipped | 315.8 ms (10.16x slower) | PSWriteOffice fastest |
-| objects-no-table | 5000 | 102.5 ms (1.00x) | Skipped | 1.16 s (11.27x slower) | PSWriteOffice fastest |
-| objects-no-table | 10000 | 469.5 ms (1.00x) | Skipped | 2.26 s (4.81x slower) | PSWriteOffice fastest |
-| objects-table | 1000 | 33.2 ms (1.00x) | Skipped | 310.1 ms (9.33x slower) | PSWriteOffice fastest |
-| objects-table | 5000 | 106.6 ms (1.00x) | Skipped | 1.02 s (9.55x slower) | PSWriteOffice fastest |
-| objects-table | 10000 | 301.2 ms (1.00x) | Skipped | 2.03 s (6.73x slower) | PSWriteOffice fastest |
-| objects-table-autofit | 1000 | 43.1 ms (1.00x) | Skipped | 336.4 ms (7.80x slower) | PSWriteOffice fastest |
-| objects-table-autofit | 5000 | 129.1 ms (1.00x) | Skipped | 1.28 s (9.93x slower) | PSWriteOffice fastest |
-| objects-table-autofit | 10000 | 341.0 ms (1.00x) | Skipped | 2.30 s (6.75x slower) | PSWriteOffice fastest |
-| objects-title-freeze | 1000 | 100.9 ms (1.00x) | Skipped | 360.5 ms (3.57x slower) | PSWriteOffice fastest |
-| objects-title-freeze | 5000 | 721.8 ms (1.00x) | Skipped | 1.18 s (1.63x slower) | PSWriteOffice fastest |
-| objects-title-freeze | 10000 | 1.05 s (1.00x) | Skipped | 2.07 s (1.97x slower) | PSWriteOffice fastest |
-| pivot-only-workbook | 1000 | 115.8 ms (1.00x) | Skipped | 387.2 ms (3.34x slower) | PSWriteOffice fastest |
-| pivot-only-workbook | 5000 | 392.5 ms (1.00x) | Skipped | 1.46 s (3.71x slower) | PSWriteOffice fastest |
-| pivot-only-workbook | 10000 | 737.3 ms (1.00x) | Skipped | 2.50 s (3.40x slower) | PSWriteOffice fastest |
-| read-named-range-metadata | 1000 | 10.8 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
-| read-named-range-metadata | 5000 | 60.7 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
-| read-named-range-metadata | 10000 | 13.4 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
-| read-no-header-range | 1000 | 21.7 ms (1.00x) | 30.7 ms (1.42x slower) | 92.6 ms (4.27x slower) | PSWriteOffice fastest |
-| read-no-header-range | 5000 | 87.4 ms (1.00x) | 285.0 ms (3.26x slower) | 251.1 ms (2.87x slower) | PSWriteOffice fastest |
-| read-no-header-range | 10000 | 215.5 ms (1.00x) | 311.1 ms (1.44x slower) | 475.3 ms (2.21x slower) | PSWriteOffice fastest |
-| read-table-metadata | 1000 | 23.6 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
-| read-table-metadata | 5000 | 12.2 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
-| read-table-metadata | 10000 | 23.1 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
-| read-used-range-datatable | 1000 | 18.2 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
-| read-used-range-datatable | 5000 | 97.3 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
-| read-used-range-datatable | 10000 | 145.0 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
-| report-workbook | 1000 | 119.4 ms (1.00x) | Skipped | 358.8 ms (3.00x slower) | PSWriteOffice fastest |
-| report-workbook | 5000 | 571.1 ms (1.00x) | Skipped | 1.27 s (2.23x slower) | PSWriteOffice fastest |
-| report-workbook | 10000 | 1.48 s (1.00x) | Skipped | 2.10 s (1.41x slower) | PSWriteOffice fastest |
-| summary-formulas | 1000 | 62.0 ms (1.00x) | Skipped | 263.0 ms (4.24x slower) | PSWriteOffice fastest |
-| summary-formulas | 5000 | 354.7 ms (1.00x) | Skipped | 943.4 ms (2.66x slower) | PSWriteOffice fastest |
-| summary-formulas | 10000 | 743.6 ms (1.00x) | Skipped | 1.72 s (2.31x slower) | PSWriteOffice fastest |
-| update-existing-workbook | 1000 | 218.3 ms (1.00x) | Skipped | 458.1 ms (2.10x slower) | PSWriteOffice fastest |
-| update-existing-workbook | 5000 | 906.7 ms (1.00x) | Skipped | 1.33 s (1.47x slower) | PSWriteOffice fastest |
-| update-existing-workbook | 10000 | 1.57 s (1.00x) | Skipped | 2.14 s (1.36x slower) | PSWriteOffice fastest |
-| wide-objects-default | 1000 | 77.4 ms (1.00x) | 176.2 ms (2.28x slower) | 242.0 ms (3.13x slower) | PSWriteOffice fastest |
-| wide-objects-default | 5000 | 312.6 ms (1.00x) | 345.8 ms (1.11x slower) | 1.03 s (3.29x slower) | PSWriteOffice fastest |
-| wide-objects-default | 10000 | 497.9 ms (1.00x) | 680.7 ms (1.37x slower) | 1.66 s (3.33x slower) | PSWriteOffice fastest |
-| workbook-package-merge | 1000 | 180.5 ms (1.00x) | Skipped | 608.7 ms (3.37x slower) | PSWriteOffice fastest |
-| workbook-package-merge | 5000 | 1.34 s (1.00x) | Skipped | 1.46 s (1.09x slower) | PSWriteOffice fastest |
-| workbook-package-merge | 10000 | 1.46 s (1.00x) | Skipped | 2.90 s (1.98x slower) | PSWriteOffice fastest |
+| append-existing-table | 1000 | 100.2 ms (1.00x) | Skipped | 340.0 ms (3.39x slower) | PSWriteOffice fastest |
+| append-existing-table | 5000 | 323.2 ms (1.00x) | Skipped | 1.14 s (3.52x slower) | PSWriteOffice fastest |
+| append-existing-table | 10000 | 741.3 ms (1.00x) | Skipped | 2.17 s (2.93x slower) | PSWriteOffice fastest |
+| chart-only-workbook | 1000 | 91.0 ms (1.00x) | Skipped | 285.2 ms (3.13x slower) | PSWriteOffice fastest |
+| chart-only-workbook | 5000 | 348.1 ms (1.00x) | Skipped | 1.07 s (3.09x slower) | PSWriteOffice fastest |
+| chart-only-workbook | 10000 | 949.7 ms (1.00x) | Skipped | 2.01 s (2.12x slower) | PSWriteOffice fastest |
+| csv-to-excel | 1000 | 73.4 ms (1.00x) | Skipped | 422.1 ms (5.75x slower) | PSWriteOffice fastest |
+| csv-to-excel | 5000 | 270.0 ms (1.00x) | Skipped | 1.65 s (6.12x slower) | PSWriteOffice fastest |
+| csv-to-excel | 10000 | 571.4 ms (1.00x) | Skipped | 3.40 s (5.95x slower) | PSWriteOffice fastest |
+| datatable-default | 1000 | 21.0 ms (1.00x) | Skipped | 263.1 ms (12.52x slower) | PSWriteOffice fastest |
+| datatable-default | 5000 | 27.1 ms (1.00x) | Skipped | 777.1 ms (28.62x slower) | PSWriteOffice fastest |
+| datatable-default | 10000 | 36.1 ms (1.00x) | Skipped | 1.50 s (41.72x slower) | PSWriteOffice fastest |
+| import-default-full | 1000 | 20.7 ms (1.00x) | 42.6 ms (2.06x slower) | 121.5 ms (5.86x slower) | PSWriteOffice fastest |
+| import-default-full | 5000 | 96.4 ms (1.00x) | 106.3 ms (1.10x slower) | 276.7 ms (2.87x slower) | PSWriteOffice fastest |
+| import-default-full | 10000 | 189.6 ms (1.00x) | 226.6 ms (1.19x slower) | 520.5 ms (2.75x slower) | PSWriteOffice fastest |
+| import-default-range | 1000 | 18.0 ms (1.00x) | 48.2 ms (2.67x slower) | 125.0 ms (6.93x slower) | PSWriteOffice fastest |
+| import-default-range | 5000 | 74.1 ms (1.00x) | 115.6 ms (1.56x slower) | 276.7 ms (3.73x slower) | PSWriteOffice fastest |
+| import-default-range | 10000 | 110.7 ms (1.00x) | 224.6 ms (2.03x slower) | 399.2 ms (3.61x slower) | PSWriteOffice fastest |
+| many-small-sheets | 1000 | 129.5 ms (1.00x) | Skipped | 373.1 ms (2.88x slower) | PSWriteOffice fastest |
+| many-small-sheets | 5000 | 499.4 ms (1.00x) | Skipped | 1.22 s (2.44x slower) | PSWriteOffice fastest |
+| many-small-sheets | 10000 | 989.5 ms (1.00x) | Skipped | 2.94 s (2.97x slower) | PSWriteOffice fastest |
+| multi-sheet-regions | 1000 | 91.8 ms (1.00x) | Skipped | 284.5 ms (3.10x slower) | PSWriteOffice fastest |
+| multi-sheet-regions | 5000 | 405.4 ms (1.00x) | Skipped | 1.04 s (2.57x slower) | PSWriteOffice fastest |
+| multi-sheet-regions | 10000 | 801.6 ms (1.00x) | Skipped | 2.00 s (2.50x slower) | PSWriteOffice fastest |
+| named-range-workbook | 1000 | 85.7 ms (1.00x) | Skipped | 289.6 ms (3.38x slower) | PSWriteOffice fastest |
+| named-range-workbook | 5000 | 328.0 ms (1.00x) | Skipped | 1.06 s (3.25x slower) | PSWriteOffice fastest |
+| named-range-workbook | 10000 | 792.0 ms (1.00x) | Skipped | 2.00 s (2.53x slower) | PSWriteOffice fastest |
+| objects-default | 1000 | 45.4 ms (1.00x) | Skipped | 302.2 ms (6.65x slower) | PSWriteOffice fastest |
+| objects-default | 5000 | 101.0 ms (1.00x) | Skipped | 1.06 s (10.52x slower) | PSWriteOffice fastest |
+| objects-default | 10000 | 226.3 ms (1.00x) | Skipped | 2.11 s (9.33x slower) | PSWriteOffice fastest |
+| objects-no-table | 1000 | 25.6 ms (1.00x) | Skipped | 280.9 ms (10.98x slower) | PSWriteOffice fastest |
+| objects-no-table | 5000 | 62.3 ms (1.00x) | Skipped | 1.05 s (16.88x slower) | PSWriteOffice fastest |
+| objects-no-table | 10000 | 238.4 ms (1.00x) | Skipped | 2.29 s (9.60x slower) | PSWriteOffice fastest |
+| objects-table | 1000 | 29.4 ms (1.00x) | Skipped | 318.9 ms (10.86x slower) | PSWriteOffice fastest |
+| objects-table | 5000 | 63.7 ms (1.00x) | Skipped | 995.8 ms (15.63x slower) | PSWriteOffice fastest |
+| objects-table | 10000 | 175.2 ms (1.00x) | Skipped | 2.05 s (11.68x slower) | PSWriteOffice fastest |
+| objects-table-autofit | 1000 | 47.4 ms (1.00x) | Skipped | 299.2 ms (6.31x slower) | PSWriteOffice fastest |
+| objects-table-autofit | 5000 | 70.7 ms (1.00x) | Skipped | 1.11 s (15.67x slower) | PSWriteOffice fastest |
+| objects-table-autofit | 10000 | 203.8 ms (1.00x) | Skipped | 2.01 s (9.85x slower) | PSWriteOffice fastest |
+| objects-title-freeze | 1000 | 89.5 ms (1.00x) | Skipped | 278.2 ms (3.11x slower) | PSWriteOffice fastest |
+| objects-title-freeze | 5000 | 349.2 ms (1.00x) | Skipped | 970.0 ms (2.78x slower) | PSWriteOffice fastest |
+| objects-title-freeze | 10000 | 892.7 ms (1.00x) | Skipped | 1.78 s (1.99x slower) | PSWriteOffice fastest |
+| pivot-only-workbook | 1000 | 59.7 ms (1.00x) | Skipped | 288.2 ms (4.83x slower) | PSWriteOffice fastest |
+| pivot-only-workbook | 5000 | 182.5 ms (1.00x) | Skipped | 1.04 s (5.71x slower) | PSWriteOffice fastest |
+| pivot-only-workbook | 10000 | 408.0 ms (1.00x) | Skipped | 2.08 s (5.10x slower) | PSWriteOffice fastest |
+| read-named-range-metadata | 1000 | 17.4 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| read-named-range-metadata | 5000 | 19.1 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| read-named-range-metadata | 10000 | 18.1 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| read-no-header-range | 1000 | 18.0 ms (1.00x) | 46.0 ms (2.56x slower) | 126.2 ms (7.02x slower) | PSWriteOffice fastest |
+| read-no-header-range | 5000 | 84.9 ms (1.00x) | 97.6 ms (1.15x slower) | 252.2 ms (2.97x slower) | PSWriteOffice fastest |
+| read-no-header-range | 10000 | 110.7 ms (1.00x) | 220.1 ms (1.99x slower) | 427.8 ms (3.86x slower) | PSWriteOffice fastest |
+| read-table-metadata | 1000 | 15.8 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| read-table-metadata | 5000 | 45.7 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| read-table-metadata | 10000 | 15.3 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| read-used-range-datatable | 1000 | 19.0 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| read-used-range-datatable | 5000 | 42.3 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| read-used-range-datatable | 10000 | 75.3 ms (1.00x) | Skipped | Skipped | PSWriteOffice fastest |
+| report-workbook | 1000 | 100.9 ms (1.00x) | Skipped | 309.1 ms (3.06x slower) | PSWriteOffice fastest |
+| report-workbook | 5000 | 374.6 ms (1.00x) | Skipped | 1.07 s (2.85x slower) | PSWriteOffice fastest |
+| report-workbook | 10000 | 889.0 ms (1.00x) | Skipped | 2.09 s (2.35x slower) | PSWriteOffice fastest |
+| summary-formulas | 1000 | 86.4 ms (1.00x) | Skipped | 272.5 ms (3.15x slower) | PSWriteOffice fastest |
+| summary-formulas | 5000 | 298.0 ms (1.00x) | Skipped | 1.05 s (3.53x slower) | PSWriteOffice fastest |
+| summary-formulas | 10000 | 748.6 ms (1.00x) | Skipped | 1.98 s (2.64x slower) | PSWriteOffice fastest |
+| text-objects-default | 1000 | 73.2 ms (1.00x) | 194.1 ms (2.65x slower) | 424.1 ms (5.79x slower) | PSWriteOffice fastest |
+| text-objects-default | 5000 | 99.5 ms (1.00x) | 427.8 ms (4.30x slower) | 1.71 s (17.14x slower) | PSWriteOffice fastest |
+| text-objects-default | 10000 | 160.8 ms (1.00x) | 790.5 ms (4.92x slower) | 3.17 s (19.71x slower) | PSWriteOffice fastest |
+| update-existing-workbook | 1000 | 170.8 ms (1.00x) | Skipped | 333.1 ms (1.95x slower) | PSWriteOffice fastest |
+| update-existing-workbook | 5000 | 913.2 ms (1.00x) | Skipped | 1.38 s (1.51x slower) | PSWriteOffice fastest |
+| update-existing-workbook | 10000 | 2.39 s (1.00x) | Skipped | 2.65 s (1.11x slower) | PSWriteOffice fastest |
+| wide-objects-default | 1000 | 73.7 ms (1.00x) | Skipped | 227.7 ms (3.09x slower) | PSWriteOffice fastest |
+| wide-objects-default | 5000 | 281.9 ms (1.00x) | Skipped | 827.0 ms (2.93x slower) | PSWriteOffice fastest |
+| wide-objects-default | 10000 | 298.3 ms (1.00x) | Skipped | 1.52 s (5.09x slower) | PSWriteOffice fastest |
+| workbook-package-merge | 1000 | 266.0 ms (1.00x) | Skipped | 653.3 ms (2.46x slower) | PSWriteOffice fastest |
+| workbook-package-merge | 5000 | 857.1 ms (1.00x) | Skipped | 1.56 s (1.82x slower) | PSWriteOffice fastest |
+| workbook-package-merge | 10000 | 1.45 s (1.00x) | Skipped | 2.66 s (1.83x slower) | PSWriteOffice fastest |
 <!-- BENCHMARK:ExcelComparison:END -->
 
 ## CSV
@@ -136,6 +153,12 @@ CSV in the same benchmark matrix. The native baseline uses `GZipStream` with
 `ConvertTo-Csv` / `ConvertFrom-Csv`, while PSWriteOffice uses
 `Export-OfficeCsv -CompressionType GZip` and
 `Import-OfficeCsv -CompressionType GZip`.
+
+CSV runs that include PSWriteOffice use the same direct OfficeIMO source root:
+
+```powershell
+$env:OfficeIMORoot = (Resolve-Path ..\OfficeIMO).Path
+```
 
 ### CSV Capability Coverage
 

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -290,9 +290,10 @@ development binaries when a selected run includes `PSWriteOffice`. Use
 when reusing an existing local build. Quick and focused runs leave this
 README unchanged unless `-UpdateReadme` is specified.
 
-By default the scripts use the OfficeIMO assemblies packaged with
-PSWriteOffice. Pass `-OfficeIMORoot` only when validating unreleased OfficeIMO
-source changes:
+PSWriteOffice benchmark lanes require the current OfficeIMO source tree. Pass
+`-OfficeIMORoot`, or set the `OfficeIMORoot` environment variable, so the build
+uses direct project references. The wrappers stop instead of falling back to a
+published OfficeIMO package when the source path is missing:
 
 ```powershell
 $evotecRoot = if ($env:EVOTEC_GITHUB_ROOT) { $env:EVOTEC_GITHUB_ROOT } else { 'C:\Support\GitHub' }

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -13,6 +13,12 @@ cmdlets against PowerShell-facing Excel alternatives:
 - `ImportExcel`
 - `ExcelFast` for the workbook lanes it supports
 
+Excel smoke, standard, and full suites use five measured iterations; large and
+super-large suites use three. The grouped rotation keeps comparable workbook
+engines adjacent and alternates which engine runs first. PowerForge performs an
+explicit managed-memory cleanup after setup and data creation, outside the timed
+operation, so allocations from one engine do not become another engine's GC bill.
+
 Every read comparison uses the same PSWriteOffice-produced workbook shape for
 the selected row count. The competing readers do not benchmark files created by
 their own writers.
@@ -22,6 +28,12 @@ invalid worksheet position. Its write lane therefore includes ExcelFast's own
 `Get-Workbook` and `Save-Workbook` normalization inside the timed operation.
 This keeps ExcelFast in the comparison without reporting malformed-workbook
 speed as a valid result.
+
+ExcelFast's mixed-object writer currently stores booleans, dates, and numbers
+as culture-formatted text cells. Mixed and wide typed write lanes are therefore
+not equivalent and remain excluded. The ExcelFast write comparison uses the
+text-only default shape, while read lanes use the same PSWriteOffice-produced
+typed workbook fixture as every other reader.
 
 Runs that include PSWriteOffice build directly against a complete OfficeIMO
 source checkout. With sibling PSWriteOffice and OfficeIMO checkouts, set the
@@ -136,6 +148,15 @@ PowerShell CSV import/export:
 - `PSWriteOffice`
 - `NativeCsv`
 
+The CSV release gate uses 25 measured iterations for suites that include the
+short 1,000-row lanes. Large and super-large suites use 11 and 7 iterations,
+respectively. PowerForge keeps each scenario comparison together and alternates
+engine order between iterations, so neither engine keeps the first or second
+position. An explicit managed-memory cleanup runs after setup and data creation,
+outside the timed operation, for every engine. Use `-RepeatCount` for an
+intentional diagnostic override; keep the defaults when recording release or
+README results.
+
 The CSV suite also includes dbatools-shaped read scenarios over the same
 generated CSV shape used by `dataplat/dbatools.library/benchmarks/CsvBenchmarks`.
 `csv-dbatools-quick-single-column` and `csv-dbatools-quick-all-columns` cover the
@@ -191,7 +212,7 @@ pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-CsvPe
 pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-CsvPerformance.ps1 `
     -Suite Standard `
     -RowCount 1000,5000,10000 `
-    -RepeatCount 3 `
+    -RepeatCount 25 `
     -Engine PSWriteOffice,NativeCsv `
     -UpdateReadme
 ```

--- a/Sources/PSWriteOffice/Services/PowerShellObjectNormalizer.cs
+++ b/Sources/PSWriteOffice/Services/PowerShellObjectNormalizer.cs
@@ -267,7 +267,8 @@ internal static class PowerShellObjectNormalizer
             return false;
         }
 
-        if (ps.BaseObject != null &&
+        if (ps.BaseObject is not PSCustomObject &&
+            ps.BaseObject != null &&
             IsScalarClrType(ps.BaseObject.GetType()) &&
             !HasExportableExtendedProperties(ps))
         {

--- a/Tests/BenchmarkOutputValidation.Tests.ps1
+++ b/Tests/BenchmarkOutputValidation.Tests.ps1
@@ -1,0 +1,30 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..\Benchmarks\Excel\excel-performance.validation.ps1')
+}
+
+Describe 'Benchmark output validation' {
+    It 'accepts invariant and current-culture numeric CSV representations' {
+        Test-CsvBenchmarkValueEquivalent -Expected 1.137 -Actual '1.137' | Should -BeTrue
+
+        $current = [Globalization.CultureInfo]::CurrentCulture
+        $localized = ([double]1.137).ToString($null, $current)
+        Test-CsvBenchmarkValueEquivalent -Expected 1.137 -Actual $localized | Should -BeTrue
+    }
+
+    It 'accepts typed booleans and dates without weakening string equality' {
+        Test-CsvBenchmarkValueEquivalent -Expected $true -Actual 'True' | Should -BeTrue
+        Test-CsvBenchmarkValueEquivalent -Expected ([datetime]'2024-01-01T00:01:00') -Actual '01/01/2024 00:01:00' | Should -BeTrue
+        Test-CsvBenchmarkValueEquivalent -Expected "Line 1`r`nLine 2" -Actual "Line 1`r`nLine 2" | Should -BeTrue
+        Test-CsvBenchmarkValueEquivalent -Expected 'Alpha' -Actual 'alpha' | Should -BeFalse
+    }
+
+    It 'rejects a parseable but incorrect numeric value' {
+        Test-CsvBenchmarkValueEquivalent -Expected 1.137 -Actual '2.137' | Should -BeFalse
+    }
+
+    It 'compares scalar values carried through PowerShell object wrappers' {
+        $wrapped = [Management.Automation.PSObject]::AsPSObject([int]1)
+
+        Test-CsvBenchmarkValueEquivalent -Expected $wrapped -Actual '1' | Should -BeTrue
+    }
+}

--- a/Tests/BenchmarkPolicy.Tests.ps1
+++ b/Tests/BenchmarkPolicy.Tests.ps1
@@ -1,0 +1,45 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..\Benchmarks\Excel\excel-performance.core.ps1')
+    $script:csvBenchmarkText = Get-Content -LiteralPath (Join-Path $PSScriptRoot '..\Benchmarks\Csv\csv-performance.benchmark.ps1') -Raw
+    $script:excelBenchmarkText = Get-Content -LiteralPath (Join-Path $PSScriptRoot '..\Benchmarks\Excel\excel-performance.benchmark.ps1') -Raw
+}
+
+Describe 'Benchmark measurement policy' {
+    It 'uses stable repeated measurements for short CSV release-gate lanes' {
+        Get-ExcelBenchmarkWarmupCount -Suite Smoke | Should -Be 3
+        Get-CsvBenchmarkIterationCount -Suite Smoke | Should -Be 25
+        Get-ExcelBenchmarkWarmupCount -Suite Standard | Should -Be 3
+        Get-CsvBenchmarkIterationCount -Suite Standard | Should -Be 25
+        Get-CsvBenchmarkIterationCount -Suite Full | Should -Be 25
+    }
+
+    It 'keeps slower Excel workloads repeated without copying the CSV sample depth' {
+        Get-ExcelBenchmarkIterationCount -Suite Smoke | Should -Be 5
+        Get-ExcelBenchmarkIterationCount -Suite Standard | Should -Be 5
+        Get-ExcelBenchmarkIterationCount -Suite Full | Should -Be 5
+    }
+
+    It 'keeps super-large diagnostics bounded but statistically meaningful' {
+        Get-ExcelBenchmarkWarmupCount -Suite SuperLarge | Should -Be 1
+        Get-CsvBenchmarkIterationCount -Suite SuperLarge | Should -Be 7
+        Get-ExcelBenchmarkIterationCount -Suite SuperLarge | Should -Be 3
+    }
+
+    It 'groups equivalent engines and cleans managed memory outside timed operations' {
+        $script:csvBenchmarkText | Should -Match '-Order GroupedRotated'
+        $script:csvBenchmarkText | Should -Match '-MemoryCleanup BeforeIteration'
+        $script:excelBenchmarkText | Should -Match '-Order GroupedRotated'
+        $script:excelBenchmarkText | Should -Match '-MemoryCleanup BeforeIteration'
+    }
+
+    It 'compares ExcelFast on equivalent default workbook shapes only' {
+        $cases = @(Get-ExcelBenchmarkCase -Suite Smoke)
+        $defaultCase = $cases | Where-Object Name -EQ 'objects-default'
+        $textCase = $cases | Where-Object Name -EQ 'text-objects-default'
+        $tableCase = $cases | Where-Object Name -EQ 'objects-table'
+
+        Test-ExcelBenchmarkEngineCaseSupport -Engine ExcelFast -Case $defaultCase | Should -BeFalse
+        Test-ExcelBenchmarkEngineCaseSupport -Engine ExcelFast -Case $textCase | Should -BeTrue
+        Test-ExcelBenchmarkEngineCaseSupport -Engine ExcelFast -Case $tableCase | Should -BeFalse
+    }
+}

--- a/Tests/BenchmarkResultValidation.Tests.ps1
+++ b/Tests/BenchmarkResultValidation.Tests.ps1
@@ -1,8 +1,6 @@
 BeforeAll {
     $validationHelperPath = Join-Path $PSScriptRoot '..\Benchmarks\Benchmark.ResultValidation.ps1'
-    $benchmarkHelperPath = Join-Path $PSScriptRoot '..\Benchmarks\Excel\excel-performance.helpers.ps1'
 
-    . $benchmarkHelperPath
     . $validationHelperPath
 }
 

--- a/Tests/BenchmarkResultValidation.Tests.ps1
+++ b/Tests/BenchmarkResultValidation.Tests.ps1
@@ -1,0 +1,56 @@
+BeforeAll {
+    $validationHelperPath = Join-Path $PSScriptRoot '..\Benchmarks\Benchmark.ResultValidation.ps1'
+    $benchmarkHelperPath = Join-Path $PSScriptRoot '..\Benchmarks\Excel\excel-performance.helpers.ps1'
+
+    . $benchmarkHelperPath
+    . $validationHelperPath
+}
+
+Describe 'Benchmark result validation' {
+    It 'normalizes every requested row count' {
+        @(Resolve-BenchmarkRequestedRowCount -RowCount @('1000,5000', 10000) -Suite Smoke) |
+            Should -Be @(1000, 5000, 10000)
+    }
+
+    It 'rejects a requested row count that is absent from the summary' {
+        $expected = [pscustomobject]@{
+            Engine = 'PSWriteOffice'
+            Case = [pscustomobject]@{ Name = 'text-objects-default' }
+        }
+        $summary = [pscustomobject]@{
+            Engine = 'PSWriteOffice'
+            Scenario = 'text-objects-default'
+            Variables = @{ RowCount = '1000' }
+            Status = 'Succeeded'
+        }
+
+        {
+            Assert-BenchmarkRequestedLaneCompletion `
+                -Summary @($summary) `
+                -ExpectedRun @($expected) `
+                -RowCount @(1000, 5000)
+        } | Should -Throw '*5000 rows*'
+    }
+
+    It 'accepts only when every requested row count succeeds' {
+        $expected = [pscustomobject]@{
+            Engine = 'PSWriteOffice'
+            Case = [pscustomobject]@{ Name = 'text-objects-default' }
+        }
+        $summary = 1000, 5000 | ForEach-Object {
+            [pscustomobject]@{
+                Engine = 'PSWriteOffice'
+                Scenario = 'text-objects-default'
+                Variables = @{ RowCount = [string]$_ }
+                Status = 'Succeeded'
+            }
+        }
+
+        {
+            Assert-BenchmarkRequestedLaneCompletion `
+                -Summary @($summary) `
+                -ExpectedRun @($expected) `
+                -RowCount @(1000, 5000)
+        } | Should -Not -Throw
+    }
+}


### PR DESCRIPTION
## Summary

- build PSWriteOffice benchmarks directly against the current OfficeIMO source tree and fail instead of silently falling back to published packages
- compare ExcelFast only on equivalent text-only workbook shapes, include repair of its invalid raw Open XML package inside timed work, and exclude typed-loss lanes from equivalent claims
- validate every CSV row and field plus representative Excel values, workbook semantics, and Open XML correctness outside timed operations
- use grouped rotation and explicit pre-iteration memory cleanup through the source-built PowerForge benchmark engine
- require PSWriteOffice to remain fastest or within the five-percent practical tie tolerance in every comparable lane
- avoid redundant scalar classification for ordinary PSCustomObject rows while preserving extended-type-system scalar behavior

No public speed controls, reduced-fidelity formats, or external services are introduced.

## Performance

Two independent 25-sample Windows CSV runs completed 27 competitor lanes with zero comparison failures. Mixed-object writes were 1.07x and 1.14x faster than native PowerShell CSV, with DataTable lanes at least 1.20x faster. Repeated Windows Excel runs measured ExcelFast reads at 1.11x to 1.22x slower and equivalent text writes at 8.76x to 9.00x slower; ImportExcel lanes were 2.88x to 11.15x slower.

On WSL, the 10,000-row CSV run ranged from 1.02x faster on the closest read lanes to 3.55x faster for mixed writes. Equivalent ExcelFast reads were 1.88x to 2.10x slower and writes were 2.39x to 2.87x slower across the 1,000- and 10,000-row profiles.

## Validation

Direct-source Windows and WSL builds, 523 passing Pester tests with one intentional packaged-workflow skip, CSV and Excel semantic validation, standards-valid Open XML, assembly-load isolation, and exact OfficeIMO source-binary provenance pass. Requested competitor lanes fail explicitly when unavailable, and unsupported/non-equivalent ExcelFast lanes remain visible as skips rather than being counted as wins.

## Dependency order

The grouped benchmark ordering, memory cleanup, and fastest-baseline gate are supplied by the source-built PowerForge changes in EvotecIT/PSPublishModule#551. Use direct project/source dependencies during development until the shared changes are merged and eventually released. No package publication is part of this PR.