### PR TITLE
Remove redundant XmlDoc2CmdletDoc dependency

### DIFF
--- a/Sources/PSWriteOffice/PSWriteOffice.csproj
+++ b/Sources/PSWriteOffice/PSWriteOffice.csproj
@@ -37,32 +37,14 @@
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
 
-    <ItemGroup>
-        <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation. DLL itself
-        will be removed/hidden -->
-        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.7.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
     <PropertyGroup>
-        <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation. -->
+        <!-- PowerForge enriches module help from the compiler XML documentation file. -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
         <DefineConstants>$(DefineConstants);FRAMEWORK</DefineConstants>
     </PropertyGroup>
-
-    <Target Name="CopyDocumentationToPublishFolder" AfterTargets="GenerateDocumentationFile;Publish">
-        <!-- This is needed for XmlDoc2CmdletDoc to copy a PowerShell documentation file to Publish
-        folder -->
-        <ItemGroup>
-            <DocFiles Include="$(OutputPath)$(AssemblyName).dll-Help.xml" />
-        </ItemGroup>
-        <Copy SourceFiles="@(DocFiles)" DestinationFolder="$(PublishDir)" />
-    </Target>
 
     <ItemGroup Condition="'$(UseOfficeIMOProjectReferences)' == 'true'">
         <ProjectReference Include="$(OfficeIMORoot)\OfficeIMO.Drawing\OfficeIMO.Drawing.csproj" />


### PR DESCRIPTION
PowerForge already generates binary cmdlet Markdown and external MAML through this repository's existing documentation configuration and NETBinaryModuleDocumentation setting.

This removes the redundant MatejKafka.XmlDoc2CmdletDoc package and its package-specific dll-Help.xml copy target. Compiler XML generation remains enabled for PowerForge enrichment; no public API or cmdlet behavior changes.