### PR TITLE
Make PowerPoint lifecycle commands predictable

### DIFF
--- a/Docs/Generated/PSWriteOffice-help.xml
+++ b/Docs/Generated/PSWriteOffice-help.xml
@@ -115291,19 +115291,43 @@ System.IO.FileInfo</maml:name>
       <command:verb>Save</command:verb>
       <command:noun>OfficePowerPoint</command:noun>
       <maml:description>
-        <maml:para>Saves a presentation to disk.</maml:para>
+        <maml:para>Saves a presentation without disposing it.</maml:para>
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>Invokes the PowerPoint service to persist the document and optionally launch it.</maml:para>
+      <maml:para>Use Close-OfficePowerPoint -Save when the presentation should be saved and closed.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>Save-OfficePowerPoint</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>PassThru</maml:name>
+          <maml:description>
+            <maml:para>Emit the still-open presentation for further processing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
           <maml:name>Password</maml:name>
           <maml:description>
             <maml:para>Password used to save the presentation as an encrypted package.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="FilePath">
+          <maml:name>Path</maml:name>
+          <maml:description>
+            <maml:para>Optional save-as path.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
@@ -115351,10 +115375,34 @@ System.IO.FileInfo</maml:name>
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>PassThru</maml:name>
+        <maml:description>
+          <maml:para>Emit the still-open presentation for further processing.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="false" globbing="true" pipelineInput="False" position="named" aliases="None">
         <maml:name>Password</maml:name>
         <maml:description>
           <maml:para>Password used to save the presentation as an encrypted package.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="FilePath">
+        <maml:name>Path</maml:name>
+        <maml:description>
+          <maml:para>Optional save-as path.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
@@ -115410,7 +115458,7 @@ System.IO.FileInfo</maml:name>
     <command:returnValues>
       <command:returnValue>
         <dev:type>
-          <maml:name>System.Object</maml:name>
+          <maml:name>OfficeIMO.PowerPoint.PowerPointPresentation</maml:name>
         </dev:type>
       </command:returnValue>
     </command:returnValues>

--- a/Docs/Save-OfficePowerPoint.md
+++ b/Docs/Save-OfficePowerPoint.md
@@ -6,16 +6,16 @@ schema: 2.0.0
 ---
 # Save-OfficePowerPoint
 ## SYNOPSIS
-Saves a presentation to disk.
+Saves a presentation without disposing it.
 
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Save-OfficePowerPoint -Presentation <PowerPointPresentation> [-Show] [-Password <string>] [-PdfPath <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+Save-OfficePowerPoint -Presentation <PowerPointPresentation> [-Path <string>] [-Show] [-Password <string>] [-PdfPath <string>] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Invokes the PowerPoint service to persist the document and optionally launch it.
+Use Close-OfficePowerPoint -Save when the presentation should be saved and closed.
 
 ## EXAMPLES
 
@@ -31,20 +31,52 @@ Saves the current presentation and exports a PDF sidecar.
 
 ## PARAMETERS
 
+### -PassThru
+Emit the still-open presentation for further processing.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases:
+Possible values:
+
+Required: False
+Position: named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Password
 Password used to save the presentation as an encrypted package.
 
 ```yaml
 Type: String
 Parameter Sets: __AllParameterSets
-Aliases: None
+Aliases:
 Possible values:
 
 Required: False
 Position: named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: True
+Accept wildcard characters: False
+```
+
+### -Path
+Optional save-as path.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: FilePath
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
 ```
 
 ### -PdfPath
@@ -53,14 +85,14 @@ Optional PDF path to create from the same presentation.
 ```yaml
 Type: String
 Parameter Sets: __AllParameterSets
-Aliases: None
+Aliases:
 Possible values:
 
 Required: False
 Position: named
 Default value: None
 Accept pipeline input: False
-Accept wildcard characters: True
+Accept wildcard characters: False
 ```
 
 ### -Presentation
@@ -69,14 +101,14 @@ Presentation instance to save.
 ```yaml
 Type: PowerPointPresentation
 Parameter Sets: __AllParameterSets
-Aliases: None
+Aliases:
 Possible values:
 
 Required: True
 Position: named
 Default value: None
 Accept pipeline input: True (ByValue)
-Accept wildcard characters: True
+Accept wildcard characters: False
 ```
 
 ### -Show
@@ -85,14 +117,14 @@ Launch the saved file in the default viewer.
 ```yaml
 Type: SwitchParameter
 Parameter Sets: __AllParameterSets
-Aliases: None
+Aliases:
 Possible values:
 
 Required: False
 Position: named
-Default value: None
+Default value: False
 Accept pipeline input: False
-Accept wildcard characters: True
+Accept wildcard characters: False
 ```
 
 ### CommonParameters
@@ -104,7 +136,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-- `System.Object`
+- `OfficeIMO.PowerPoint.PowerPointPresentation`
 
 ## RELATED LINKS
 

--- a/Sources/PSWriteOffice/Cmdlets/OpenDocument/ConvertToOfficeOpenDocumentCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/OpenDocument/ConvertToOfficeOpenDocumentCommand.cs
@@ -99,7 +99,7 @@ public sealed class ConvertToOfficeOpenDocumentCommand : PSCmdlet
                     var presentation = PowerPointPresentation;
                     if (sourcePath != null)
                     {
-                        presentation = PowerPointDocumentService.LoadPresentation(sourcePath);
+                        presentation = PowerPointDocumentService.LoadPresentation(sourcePath, readOnly: true);
                         ownedPresentation = presentation;
                     }
                     var presentationResult = presentation.ToOpenDocumentResult(PowerPointOptions);

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/ConvertToOfficePowerPointHtmlCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/ConvertToOfficePowerPointHtmlCommand.cs
@@ -124,7 +124,7 @@ public sealed class ConvertToOfficePowerPointHtmlCommand : PSCmdlet
         }
 
         dispose = true;
-        return PowerPointDocumentService.LoadPresentation(PdfCommandUtilities.ResolvePath(this, Path), Password);
+        return PowerPointDocumentService.LoadPresentation(PdfCommandUtilities.ResolvePath(this, Path), Password, readOnly: true);
     }
 
     private PowerPointHtmlSaveOptions CreateOptions()

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/ExportOfficePowerPointImageCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/ExportOfficePowerPointImageCommand.cs
@@ -51,7 +51,7 @@ public sealed class ExportOfficePowerPointImageCommand : PSCmdlet
             if (ParameterSetName == "Path")
             {
                 var input = SessionState.Path.GetUnresolvedProviderPathFromPSPath(Path);
-                owned = PowerPointDocumentService.LoadPresentation(input);
+                owned = PowerPointDocumentService.LoadPresentation(input, readOnly: true);
                 presentation = owned;
             }
             IReadOnlyList<OfficeImageExportResult> results = presentation.SaveAsImages(output, Format, Options);

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointInspectionCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/GetOfficePowerPointInspectionCommand.cs
@@ -37,7 +37,8 @@ public sealed class GetOfficePowerPointInspectionCommand : PSCmdlet
             if (ParameterSetName == "Path")
             {
                 owned = PowerPointDocumentService.LoadPresentation(
-                    SessionState.Path.GetUnresolvedProviderPathFromPSPath(Path));
+                    SessionState.Path.GetUnresolvedProviderPathFromPSPath(Path),
+                    readOnly: true);
                 presentation = owned;
             }
             WriteObject(presentation.Inspect(Options));

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/NewOfficePowerPointCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/NewOfficePowerPointCommand.cs
@@ -111,6 +111,8 @@ public class NewOfficePowerPointCommand : PSCmdlet
 
             SavePdfIfRequested(presentation);
             PowerPointDocumentService.SavePresentation(presentation, Open.IsPresent, Password);
+            PowerPointDocumentService.ClosePresentation(presentation, save: false, show: false);
+            presentation = null;
 
             if (PassThru.IsPresent)
             {
@@ -119,7 +121,10 @@ public class NewOfficePowerPointCommand : PSCmdlet
         }
         catch (Exception ex)
         {
-            presentation?.Dispose();
+            if (presentation != null)
+            {
+                PowerPointDocumentService.ClosePresentation(presentation, save: false, show: false);
+            }
             WriteError(new ErrorRecord(ex, "PowerPointCreateFailed", ErrorCategory.InvalidOperation, FilePath));
         }
     }

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/NewOfficePowerPointCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/NewOfficePowerPointCommand.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Management.Automation;
 using OfficeIMO.PowerPoint;
 using OfficeIMO.PowerPoint.Pdf;
+using PSWriteOffice.Services;
 using PSWriteOffice.Services.Pdf;
 using PSWriteOffice.Services.PowerPoint;
 
@@ -110,9 +111,18 @@ public class NewOfficePowerPointCommand : PSCmdlet
             }
 
             SavePdfIfRequested(presentation);
-            PowerPointDocumentService.SavePresentation(presentation, Open.IsPresent, Password);
+            var savedPath = PowerPointDocumentService.SavePresentation(
+                presentation,
+                show: false,
+                Password,
+                filePath: null);
             PowerPointDocumentService.ClosePresentation(presentation, save: false, show: false);
             presentation = null;
+
+            if (Open.IsPresent)
+            {
+                FileOpenService.Open(savedPath);
+            }
 
             if (PassThru.IsPresent)
             {

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/SaveOfficePowerPointCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/SaveOfficePowerPointCommand.cs
@@ -7,8 +7,8 @@ using PSWriteOffice.Services.PowerPoint;
 
 namespace PSWriteOffice.Cmdlets.PowerPoint;
 
-/// <summary>Saves a presentation to disk.</summary>
-/// <para>Invokes the PowerPoint service to persist the document and optionally launch it.</para>
+/// <summary>Saves a presentation without disposing it.</summary>
+/// <para>Use <c>Close-OfficePowerPoint -Save</c> when the presentation should be saved and closed.</para>
 /// <example>
 ///   <summary>Save and open the deck.</summary>
 ///   <prefix>PS&gt; </prefix>
@@ -19,12 +19,18 @@ namespace PSWriteOffice.Cmdlets.PowerPoint;
 ///   <para>Saves the current presentation and exports a PDF sidecar.</para>
 /// </example>
 [Cmdlet(VerbsData.Save, "OfficePowerPoint", SupportsShouldProcess = true)]
+[OutputType(typeof(PowerPointPresentation))]
 public class SaveOfficePowerPointCommand : PSCmdlet
 {
     /// <summary>Presentation instance to save.</summary>
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
     [ValidateNotNull]
     public PowerPointPresentation Presentation { get; set; } = null!;
+
+    /// <summary>Optional save-as path.</summary>
+    [Parameter]
+    [Alias("FilePath")]
+    public string? Path { get; set; }
 
     /// <summary>Launch the saved file in the default viewer.</summary>
     [Parameter]
@@ -38,6 +44,10 @@ public class SaveOfficePowerPointCommand : PSCmdlet
     [Parameter]
     public string? PdfPath { get; set; }
 
+    /// <summary>Emit the still-open presentation for further processing.</summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
     /// <inheritdoc />
     protected override void ProcessRecord()
     {
@@ -49,10 +59,23 @@ public class SaveOfficePowerPointCommand : PSCmdlet
 
         try
         {
-            if (ShouldProcess("PowerPoint presentation", "Save"))
+            var associatedPath = PowerPointDocumentService.GetAssociatedPath(Presentation);
+            if (string.IsNullOrWhiteSpace(Path) && string.IsNullOrWhiteSpace(associatedPath))
             {
+                throw new PSInvalidOperationException("No file path provided. Use -Path or open the presentation from disk.");
+            }
+
+            var targetPath = string.IsNullOrWhiteSpace(Path)
+                ? associatedPath!
+                : SessionState.Path.GetUnresolvedProviderPathFromPSPath(Path);
+            if (ShouldProcess(targetPath, "Save PowerPoint presentation"))
+            {
+                PowerPointDocumentService.SavePresentation(Presentation, Show.IsPresent, Password, targetPath);
                 SavePdfIfRequested();
-                PowerPointDocumentService.SavePresentation(Presentation, Show.IsPresent, Password);
+                if (PassThru.IsPresent)
+                {
+                    WriteObject(Presentation);
+                }
             }
         }
         catch (Exception ex)

--- a/Sources/PSWriteOffice/Services/OfficeEncryptedPackageService.cs
+++ b/Sources/PSWriteOffice/Services/OfficeEncryptedPackageService.cs
@@ -9,6 +9,26 @@ namespace PSWriteOffice.Services;
 
 internal static class OfficeEncryptedPackageService
 {
+    internal static bool HasCompoundFileSignature(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        byte[] signature = new byte[8];
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        if (stream.Read(signature, 0, signature.Length) != signature.Length)
+        {
+            return false;
+        }
+
+        return signature[0] == 0xD0 && signature[1] == 0xCF &&
+            signature[2] == 0x11 && signature[3] == 0xE0 &&
+            signature[4] == 0xA1 && signature[5] == 0xB1 &&
+            signature[6] == 0x1A && signature[7] == 0xE1;
+    }
+
     public static ExcelDocument LoadExcel(string path, string password, bool readOnly, bool autoSave)
     {
         if (autoSave)

--- a/Sources/PSWriteOffice/Services/OfficeEncryptedPackageService.cs
+++ b/Sources/PSWriteOffice/Services/OfficeEncryptedPackageService.cs
@@ -55,17 +55,17 @@ internal static class OfficeEncryptedPackageService
         }
     }
 
-    public static PowerPointPresentation OpenPowerPoint(string path, string password)
+    public static PowerPointPresentation OpenPowerPoint(string path, string password, bool readOnly = false)
     {
         return PowerPointPresentation.LoadEncrypted(path, password, new PowerPointLoadOptions
         {
-            AccessMode = DocumentAccessMode.ReadWrite,
+            AccessMode = readOnly ? DocumentAccessMode.ReadOnly : DocumentAccessMode.ReadWrite,
             PersistenceMode = DocumentPersistenceMode.Explicit
         });
     }
 
-    public static void SavePowerPoint(PowerPointPresentation presentation, Stream stream, string password)
+    public static void SavePowerPoint(PowerPointPresentation presentation, string path, string password)
     {
-        presentation.SaveEncrypted(stream, password);
+        presentation.SaveEncrypted(path, password);
     }
 }

--- a/Sources/PSWriteOffice/Services/PowerPoint/PowerPointDocumentService.cs
+++ b/Sources/PSWriteOffice/Services/PowerPoint/PowerPointDocumentService.cs
@@ -34,7 +34,10 @@ public static class PowerPointDocumentService
         }
 
         var resolvedPath = Path.GetFullPath(filePath);
-        var presentation = PowerPointPresentation.Create(resolvedPath);
+        var presentation = PowerPointPresentation.Create(resolvedPath, new PowerPointCreateOptions
+        {
+            PersistenceMode = DocumentPersistenceMode.Explicit
+        });
         Track(presentation, resolvedPath, encrypted: false);
         return presentation;
     }
@@ -91,6 +94,11 @@ public static class PowerPointDocumentService
         }
 
         var resolvedPath = Path.GetFullPath(string.IsNullOrWhiteSpace(filePath) ? associatedPath! : filePath!);
+        string? targetDirectory = Path.GetDirectoryName(resolvedPath);
+        if (!string.IsNullOrWhiteSpace(targetDirectory))
+        {
+            Directory.CreateDirectory(targetDirectory);
+        }
         if (!string.IsNullOrEmpty(password))
         {
             OfficeEncryptedPackageService.SavePowerPoint(presentation, resolvedPath, password!);

--- a/Sources/PSWriteOffice/Services/PowerPoint/PowerPointDocumentService.cs
+++ b/Sources/PSWriteOffice/Services/PowerPoint/PowerPointDocumentService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using OfficeIMO.Drawing;
 using OfficeIMO.PowerPoint;
 using PSWriteOffice.Services;
@@ -87,6 +88,7 @@ public static class PowerPointDocumentService
     public static string SavePresentation(PowerPointPresentation presentation, bool show, string? password = null, string? filePath = null)
     {
         if (presentation == null) throw new ArgumentNullException(nameof(presentation));
+        EnsureExternalPresentationUsesExplicitPersistence(presentation);
         var associatedPath = GetAssociatedPath(presentation);
         if (string.IsNullOrWhiteSpace(filePath) && string.IsNullOrWhiteSpace(associatedPath))
         {
@@ -107,7 +109,7 @@ public static class PowerPointDocumentService
         {
             bool trackedEncryptedSource = Presentations.TryGetValue(presentation, out var association) &&
                 association.Encrypted &&
-                string.Equals(resolvedPath, Path.GetFullPath(associatedPath!), StringComparison.OrdinalIgnoreCase);
+                PathsIdentifySameFile(resolvedPath, Path.GetFullPath(associatedPath!));
             if (trackedEncryptedSource || IsEncryptedTarget(resolvedPath))
             {
                 throw new InvalidOperationException("Provide -Password when saving a presentation loaded from an encrypted package.");
@@ -129,6 +131,8 @@ public static class PowerPointDocumentService
     /// <summary>Closes a presentation, optionally saving and opening it first.</summary>
     public static void ClosePresentation(PowerPointPresentation presentation, bool save, bool show, string? password = null)
     {
+        if (presentation == null) throw new ArgumentNullException(nameof(presentation));
+        EnsureExternalPresentationUsesExplicitPersistence(presentation);
         string? savedPath = null;
         if (save || show)
         {
@@ -165,6 +169,27 @@ public static class PowerPointDocumentService
         }
 
         return OfficeEncryptedPackageService.HasCompoundFileSignature(path);
+    }
+
+    private static void EnsureExternalPresentationUsesExplicitPersistence(
+        PowerPointPresentation presentation)
+    {
+        if (!Presentations.TryGetValue(presentation, out _) &&
+            presentation.PersistenceMode == DocumentPersistenceMode.SaveOnDispose)
+        {
+            throw new InvalidOperationException(
+                "External presentations using SaveOnDispose cannot be managed safely. " +
+                "Create or load the presentation with DocumentPersistenceMode.Explicit before using PSWriteOffice save or close commands.");
+        }
+    }
+
+    private static bool PathsIdentifySameFile(string left, string right)
+    {
+        StringComparison comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
+                                      RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return string.Equals(Path.GetFullPath(left), Path.GetFullPath(right), comparison);
     }
 
     private static void Track(PowerPointPresentation presentation, string path, bool encrypted)

--- a/Sources/PSWriteOffice/Services/PowerPoint/PowerPointDocumentService.cs
+++ b/Sources/PSWriteOffice/Services/PowerPoint/PowerPointDocumentService.cs
@@ -97,8 +97,10 @@ public static class PowerPointDocumentService
         }
         else
         {
-            if (Presentations.TryGetValue(presentation, out var association) && association.Encrypted &&
-                string.Equals(resolvedPath, Path.GetFullPath(associatedPath!), StringComparison.OrdinalIgnoreCase))
+            bool trackedEncryptedSource = Presentations.TryGetValue(presentation, out var association) &&
+                association.Encrypted &&
+                string.Equals(resolvedPath, Path.GetFullPath(associatedPath!), StringComparison.OrdinalIgnoreCase);
+            if (trackedEncryptedSource || IsExternalEncryptedTarget(presentation, resolvedPath))
             {
                 throw new InvalidOperationException("Provide -Password when saving a presentation loaded from an encrypted package.");
             }
@@ -119,9 +121,10 @@ public static class PowerPointDocumentService
     /// <summary>Closes a presentation, optionally saving and opening it first.</summary>
     public static void ClosePresentation(PowerPointPresentation presentation, bool save, bool show, string? password = null)
     {
+        string? savedPath = null;
         if (save || show)
         {
-            SavePresentation(presentation, show, password);
+            savedPath = SavePresentation(presentation, show: false, password, filePath: null);
         }
 
         try
@@ -132,6 +135,33 @@ public static class PowerPointDocumentService
         {
             Presentations.Remove(presentation);
         }
+
+        if (show && savedPath != null)
+        {
+            FileOpenService.Open(savedPath);
+        }
+    }
+
+    private static bool IsExternalEncryptedTarget(PowerPointPresentation presentation, string path)
+    {
+        if (Presentations.TryGetValue(presentation, out _))
+        {
+            return false;
+        }
+
+        string extension = Path.GetExtension(path);
+        if (!extension.Equals(".pptx", StringComparison.OrdinalIgnoreCase) &&
+            !extension.Equals(".pptm", StringComparison.OrdinalIgnoreCase) &&
+            !extension.Equals(".potx", StringComparison.OrdinalIgnoreCase) &&
+            !extension.Equals(".potm", StringComparison.OrdinalIgnoreCase) &&
+            !extension.Equals(".ppsx", StringComparison.OrdinalIgnoreCase) &&
+            !extension.Equals(".ppsm", StringComparison.OrdinalIgnoreCase) &&
+            !extension.Equals(".ppam", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return OfficeEncryptedPackageService.HasCompoundFileSignature(path);
     }
 
     private static void Track(PowerPointPresentation presentation, string path, bool encrypted)

--- a/Sources/PSWriteOffice/Services/PowerPoint/PowerPointDocumentService.cs
+++ b/Sources/PSWriteOffice/Services/PowerPoint/PowerPointDocumentService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Concurrent;
 using System.IO;
+using System.Runtime.CompilerServices;
+using OfficeIMO.Drawing;
 using OfficeIMO.PowerPoint;
 using PSWriteOffice.Services;
 
@@ -9,7 +11,19 @@ namespace PSWriteOffice.Services.PowerPoint;
 /// <summary>Helper methods bridging DSL cmdlets with OfficeIMO PowerPoint presentations.</summary>
 public static class PowerPointDocumentService
 {
-    private static readonly ConcurrentDictionary<PowerPointPresentation, string> Presentations = new();
+    private sealed class PresentationAssociation
+    {
+        internal PresentationAssociation(string path, bool encrypted)
+        {
+            Path = path;
+            Encrypted = encrypted;
+        }
+
+        internal string Path { get; }
+        internal bool Encrypted { get; }
+    }
+
+    private static readonly ConditionalWeakTable<PowerPointPresentation, PresentationAssociation> Presentations = new();
 
     /// <summary>Creates a new presentation at the specified path.</summary>
     public static PowerPointPresentation CreatePresentation(string filePath)
@@ -21,12 +35,20 @@ public static class PowerPointDocumentService
 
         var resolvedPath = Path.GetFullPath(filePath);
         var presentation = PowerPointPresentation.Create(resolvedPath);
-        Presentations[presentation] = resolvedPath;
+        Track(presentation, resolvedPath, encrypted: false);
         return presentation;
     }
 
     /// <summary>Loads an existing presentation.</summary>
-    public static PowerPointPresentation LoadPresentation(string filePath, string? password = null)
+    public static PowerPointPresentation LoadPresentation(string filePath, string? password = null) =>
+        LoadPresentation(filePath, password, readOnly: false);
+
+    /// <summary>Loads an existing presentation with an explicit access mode.</summary>
+    public static PowerPointPresentation LoadPresentation(string filePath, bool readOnly) =>
+        LoadPresentation(filePath, password: null, readOnly);
+
+    /// <summary>Loads an existing presentation with password and access-mode options.</summary>
+    public static PowerPointPresentation LoadPresentation(string filePath, string? password, bool readOnly)
     {
         var resolvedPath = Path.GetFullPath(filePath);
         if (!File.Exists(resolvedPath))
@@ -35,39 +57,63 @@ public static class PowerPointDocumentService
         }
 
         var presentation = !string.IsNullOrEmpty(password)
-            ? OfficeEncryptedPackageService.OpenPowerPoint(resolvedPath, password!)
-            : PowerPointPresentation.Load(resolvedPath);
-        Presentations[presentation] = resolvedPath;
+            ? OfficeEncryptedPackageService.OpenPowerPoint(resolvedPath, password!, readOnly)
+            : PowerPointPresentation.Load(resolvedPath, new PowerPointLoadOptions
+            {
+                AccessMode = readOnly ? DocumentAccessMode.ReadOnly : DocumentAccessMode.ReadWrite,
+                PersistenceMode = DocumentPersistenceMode.Explicit
+            });
+        Track(presentation, resolvedPath, encrypted: !string.IsNullOrEmpty(password));
         return presentation;
     }
 
-    /// <summary>Saves and optionally opens the presentation.</summary>
-    public static void SavePresentation(PowerPointPresentation presentation, bool show, string? password = null)
+    /// <summary>Returns the associated path for a presentation, including externally created OfficeIMO instances.</summary>
+    public static string? GetAssociatedPath(PowerPointPresentation presentation)
     {
-        if (!Presentations.TryGetValue(presentation, out var filePath))
+        if (presentation == null) throw new ArgumentNullException(nameof(presentation));
+        return Presentations.TryGetValue(presentation, out var association)
+            ? association.Path
+            : presentation.FilePath;
+    }
+
+    /// <summary>Saves without closing and optionally opens the persisted presentation.</summary>
+    public static void SavePresentation(PowerPointPresentation presentation, bool show, string? password = null) =>
+        SavePresentation(presentation, show, password, filePath: null);
+
+    /// <summary>Saves without closing, optionally to a new path, and returns the associated destination.</summary>
+    public static string SavePresentation(PowerPointPresentation presentation, bool show, string? password = null, string? filePath = null)
+    {
+        if (presentation == null) throw new ArgumentNullException(nameof(presentation));
+        var associatedPath = GetAssociatedPath(presentation);
+        if (string.IsNullOrWhiteSpace(filePath) && string.IsNullOrWhiteSpace(associatedPath))
         {
-            throw new ArgumentException("Presentation was not created or loaded via this service.", nameof(presentation));
+            throw new InvalidOperationException("No file path provided. Use -Path or open the presentation from disk.");
         }
 
-        var resolvedPath = Path.GetFullPath(filePath);
+        var resolvedPath = Path.GetFullPath(string.IsNullOrWhiteSpace(filePath) ? associatedPath! : filePath!);
         if (!string.IsNullOrEmpty(password))
         {
-            using var encrypted = new MemoryStream();
-            OfficeEncryptedPackageService.SavePowerPoint(presentation, encrypted, password!);
-            presentation.Dispose();
-            File.WriteAllBytes(resolvedPath, encrypted.ToArray());
+            OfficeEncryptedPackageService.SavePowerPoint(presentation, resolvedPath, password!);
         }
         else
         {
-            presentation.Save();
-            presentation.Dispose();
+            if (Presentations.TryGetValue(presentation, out var association) && association.Encrypted &&
+                string.Equals(resolvedPath, Path.GetFullPath(associatedPath!), StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Provide -Password when saving a presentation loaded from an encrypted package.");
+            }
+
+            presentation.Save(resolvedPath);
         }
-        Presentations.TryRemove(presentation, out _);
+
+        Track(presentation, resolvedPath, encrypted: !string.IsNullOrEmpty(password));
 
         if (show)
         {
             FileOpenService.Open(resolvedPath);
         }
+
+        return resolvedPath;
     }
 
     /// <summary>Closes a presentation, optionally saving and opening it first.</summary>
@@ -76,10 +122,21 @@ public static class PowerPointDocumentService
         if (save || show)
         {
             SavePresentation(presentation, show, password);
-            return;
         }
 
-        presentation.Dispose();
-        Presentations.TryRemove(presentation, out _);
+        try
+        {
+            presentation.Dispose();
+        }
+        finally
+        {
+            Presentations.Remove(presentation);
+        }
+    }
+
+    private static void Track(PowerPointPresentation presentation, string path, bool encrypted)
+    {
+        Presentations.Remove(presentation);
+        Presentations.Add(presentation, new PresentationAssociation(path, encrypted));
     }
 }

--- a/Sources/PSWriteOffice/Services/PowerPoint/PowerPointDocumentService.cs
+++ b/Sources/PSWriteOffice/Services/PowerPoint/PowerPointDocumentService.cs
@@ -108,7 +108,7 @@ public static class PowerPointDocumentService
             bool trackedEncryptedSource = Presentations.TryGetValue(presentation, out var association) &&
                 association.Encrypted &&
                 string.Equals(resolvedPath, Path.GetFullPath(associatedPath!), StringComparison.OrdinalIgnoreCase);
-            if (trackedEncryptedSource || IsExternalEncryptedTarget(presentation, resolvedPath))
+            if (trackedEncryptedSource || IsEncryptedTarget(resolvedPath))
             {
                 throw new InvalidOperationException("Provide -Password when saving a presentation loaded from an encrypted package.");
             }
@@ -150,13 +150,8 @@ public static class PowerPointDocumentService
         }
     }
 
-    private static bool IsExternalEncryptedTarget(PowerPointPresentation presentation, string path)
+    private static bool IsEncryptedTarget(string path)
     {
-        if (Presentations.TryGetValue(presentation, out _))
-        {
-            return false;
-        }
-
         string extension = Path.GetExtension(path);
         if (!extension.Equals(".pptx", StringComparison.OrdinalIgnoreCase) &&
             !extension.Equals(".pptm", StringComparison.OrdinalIgnoreCase) &&

--- a/Tests/OfficeIMONextSupport.Tests.ps1
+++ b/Tests/OfficeIMONextSupport.Tests.ps1
@@ -248,30 +248,23 @@ Describe 'Expanded OfficeIMO support' {
     It 'releases path-loaded PowerPoint presentations after image export' {
         $powerPointPath = Join-Path $TestDrive 'transient.pptx'
         New-OfficePowerPoint -Path $powerPointPath { PptSlide { PptTitle -Title 'Transient' } } | Out-Null
-        $serviceType = Get-TestPSWriteOfficeType -AssemblyName 'PSWriteOffice' -TypeName 'PSWriteOffice.Services.PowerPoint.PowerPointDocumentService' -CommandName 'Export-OfficePowerPointImage'
-        $presentationsField = $serviceType.GetField('Presentations', [System.Reflection.BindingFlags]'NonPublic, Static')
-        $presentations = $presentationsField.GetValue($null)
-        $before = $presentations.Count
 
         Export-OfficePowerPointImage -Path $powerPointPath -OutputPath (Join-Path $TestDrive 'transient-images') -Format Svg | Out-Null
-        $presentations.Count | Should -Be $before
-
         Get-OfficePowerPointInspection -Path $powerPointPath | Out-Null
 
-        $presentations.Count | Should -Be $before
+        $renamedPath = Join-Path $TestDrive 'transient-renamed.pptx'
+        Move-Item -LiteralPath $powerPointPath -Destination $renamedPath
+        Test-Path -LiteralPath $renamedPath | Should -BeTrue
     }
 
     It 'releases path-loaded Office documents after OpenDocument conversion' {
         $flags = [System.Reflection.BindingFlags]'NonPublic, Static'
         $wordServiceType = Get-TestPSWriteOfficeType -AssemblyName 'PSWriteOffice' -TypeName 'PSWriteOffice.Services.Word.WordDocumentService' -CommandName 'ConvertTo-OfficeOpenDocument'
         $excelServiceType = Get-TestPSWriteOfficeType -AssemblyName 'PSWriteOffice' -TypeName 'PSWriteOffice.Services.Excel.ExcelDocumentService' -CommandName 'ConvertTo-OfficeOpenDocument'
-        $powerPointServiceType = Get-TestPSWriteOfficeType -AssemblyName 'PSWriteOffice' -TypeName 'PSWriteOffice.Services.PowerPoint.PowerPointDocumentService' -CommandName 'ConvertTo-OfficeOpenDocument'
         $wordDocuments = $wordServiceType.GetField('AssociatedPaths', $flags).GetValue($null)
         $excelDocuments = $excelServiceType.GetField('AssociatedPaths', $flags).GetValue($null)
-        $presentations = $powerPointServiceType.GetField('Presentations', $flags).GetValue($null)
         $beforeWord = $wordDocuments.Count
         $beforeExcel = $excelDocuments.Count
-        $beforePowerPoint = $presentations.Count
 
         $wordPath = Join-Path $TestDrive 'convert.docx'
         $excelPath = Join-Path $TestDrive 'convert.xlsx'
@@ -286,7 +279,9 @@ Describe 'Expanded OfficeIMO support' {
 
         $wordDocuments.Count | Should -Be $beforeWord
         $excelDocuments.Count | Should -Be $beforeExcel
-        $presentations.Count | Should -Be $beforePowerPoint
+        $movedPowerPointPath = Join-Path $TestDrive 'convert-moved.pptx'
+        Move-Item -LiteralPath $powerPointPath -Destination $movedPowerPointPath
+        Test-Path -LiteralPath $movedPowerPointPath | Should -BeTrue
     }
 
     It 'returns Word review/comparison and PowerPoint inspection reports' {

--- a/Tests/PowerPoint.Tests.ps1
+++ b/Tests/PowerPoint.Tests.ps1
@@ -181,6 +181,34 @@ Describe 'PowerPoint cmdlets' {
         }
     }
 
+    It 'does not overwrite a different encrypted target from a tracked presentation without a password' {
+        if (-not (Test-OfficeLoadedMethod -TypeName 'OfficeIMO.PowerPoint.PowerPointPresentation' -MethodName 'OpenEncrypted')) {
+            return
+        }
+
+        $sourcePath = Join-Path $TestDrive 'TrackedNormalPowerPoint.pptx'
+        $encryptedTarget = Join-Path $TestDrive 'ProtectedPowerPointTarget.pptx'
+        New-OfficePowerPoint -Path $encryptedTarget -Password 'secret' {
+            PptSlide { PptTitle -Title 'Protected target' }
+        }
+
+        $presentation = New-OfficePowerPoint -Path $sourcePath -NoSave
+        try {
+            Add-OfficePowerPointSlide -Presentation $presentation | Out-Null
+            { Save-OfficePowerPoint -Presentation $presentation -Path $encryptedTarget -ErrorAction Stop } |
+                Should -Throw '*Provide -Password*'
+        } finally {
+            Close-OfficePowerPoint -Presentation $presentation -ErrorAction SilentlyContinue
+        }
+
+        $reloaded = Get-OfficePowerPoint -FilePath $encryptedTarget -Password 'secret'
+        try {
+            $reloaded.Slides.Count | Should -Be 1
+        } finally {
+            Close-OfficePowerPoint -Presentation $reloaded
+        }
+    }
+
     It 'loads owned inspection sources as explicit read-only presentations' {
         $path = Join-Path $TestDrive 'PowerPointReadOnly.pptx'
         New-OfficePowerPoint -Path $path { PptSlide { PptTitle -Title 'Read only' } } | Out-Null

--- a/Tests/PowerPoint.Tests.ps1
+++ b/Tests/PowerPoint.Tests.ps1
@@ -68,6 +68,97 @@ Describe 'PowerPoint cmdlets' {
         }
     }
 
+    It 'saves an external OfficeIMO presentation without closing it and supports save as' {
+        $savedAsPath = Join-Path $TestDrive 'PowerPointExternal.Copy.pptx'
+        $seedPath = Join-Path $TestDrive 'PowerPointTypeSeed.pptx'
+        $seed = New-OfficePowerPoint -FilePath $seedPath -NoSave
+        $presentationType = $seed.GetType()
+        Close-OfficePowerPoint -Presentation $seed
+        $create = $presentationType.GetMethods() |
+            Where-Object { $_.Name -eq 'Create' -and $_.GetParameters().Count -eq 0 } |
+            Select-Object -First 1
+        $presentation = $create.Invoke($null, @())
+        try {
+            Add-OfficePowerPointSlide -Presentation $presentation | Out-Null
+
+            $returned = Save-OfficePowerPoint -Presentation $presentation -Path $savedAsPath -PassThru
+            [object]::ReferenceEquals($presentation, $returned) | Should -BeTrue
+            Test-Path -LiteralPath $savedAsPath | Should -BeTrue
+
+            Add-OfficePowerPointSlide -Presentation $presentation | Out-Null
+            Save-OfficePowerPoint -Presentation $presentation
+            $presentation.Slides.Count | Should -Be 2
+        } finally {
+            if ($presentation) {
+                Close-OfficePowerPoint -Presentation $presentation -ErrorAction SilentlyContinue
+            }
+        }
+
+        $reloaded = Get-OfficePowerPoint -FilePath $savedAsPath
+        try {
+            $reloaded.Slides.Count | Should -Be 2
+        } finally {
+            Close-OfficePowerPoint -Presentation $reloaded
+        }
+    }
+
+    It 'saves an encrypted presentation through the canonical path writer' {
+        if (-not (Test-OfficeLoadedMethod -TypeName 'OfficeIMO.PowerPoint.PowerPointPresentation' -MethodName 'OpenEncrypted')) {
+            return
+        }
+
+        $sourcePath = Join-Path $TestDrive 'EncryptedPowerPointSource.pptx'
+        $savedAsPath = Join-Path (Join-Path $TestDrive 'encrypted-output') 'EncryptedPowerPoint.Copy.pptx'
+        $presentation = New-OfficePowerPoint -Path $sourcePath -NoSave
+        try {
+            Add-OfficePowerPointSlide -Presentation $presentation | Out-Null
+            Save-OfficePowerPoint -Presentation $presentation -Path $savedAsPath -Password 'secret'
+            Test-Path -LiteralPath $savedAsPath | Should -BeTrue
+        } finally {
+            Close-OfficePowerPoint -Presentation $presentation
+        }
+
+        $reloaded = Get-OfficePowerPoint -FilePath $savedAsPath -Password 'secret'
+        try {
+            $reloaded.Slides.Count | Should -Be 1
+        } finally {
+            Close-OfficePowerPoint -Presentation $reloaded
+        }
+    }
+
+    It 'loads owned inspection sources as explicit read-only presentations' {
+        $path = Join-Path $TestDrive 'PowerPointReadOnly.pptx'
+        New-OfficePowerPoint -Path $path { PptSlide { PptTitle -Title 'Read only' } } | Out-Null
+
+        $presentation = [PSWriteOffice.Services.PowerPoint.PowerPointDocumentService]::LoadPresentation($path, $null, $true)
+        try {
+            $presentation.AccessMode.ToString() | Should -Be 'ReadOnly'
+            $presentation.PersistenceMode.ToString() | Should -Be 'Explicit'
+        } finally {
+            [PSWriteOffice.Services.PowerPoint.PowerPointDocumentService]::ClosePresentation($presentation, $false, $false)
+        }
+    }
+
+    It 'preserves the existing PowerPoint service method signatures' {
+        $serviceType = [PSWriteOffice.Services.PowerPoint.PowerPointDocumentService]
+        $load = $serviceType.GetMethods() | Where-Object {
+            $_.Name -eq 'LoadPresentation' -and
+            $_.GetParameters().Count -eq 2 -and
+            $_.GetParameters()[0].ParameterType -eq [string] -and
+            $_.GetParameters()[1].ParameterType -eq [string]
+        }
+        $save = $serviceType.GetMethods() | Where-Object {
+            $_.Name -eq 'SavePresentation' -and
+            $_.GetParameters().Count -eq 3 -and
+            $_.GetParameters()[1].ParameterType -eq [bool] -and
+            $_.GetParameters()[2].ParameterType -eq [string]
+        }
+
+        $load | Should -HaveCount 1
+        $save | Should -HaveCount 1
+        $save.ReturnType | Should -Be ([void])
+    }
+
     It 'round-trips encrypted presentations through lifecycle cmdlets' {
         if (-not (Test-OfficeLoadedMethod -TypeName 'OfficeIMO.PowerPoint.PowerPointPresentation' -MethodName 'OpenEncrypted')) {
             (Get-Command New-OfficePowerPoint).Parameters.Keys | Should -Contain 'Password'

--- a/Tests/PowerPoint.Tests.ps1
+++ b/Tests/PowerPoint.Tests.ps1
@@ -69,7 +69,7 @@ Describe 'PowerPoint cmdlets' {
     }
 
     It 'saves an external OfficeIMO presentation without closing it and supports save as' {
-        $savedAsPath = Join-Path $TestDrive 'PowerPointExternal.Copy.pptx'
+        $savedAsPath = Join-Path (Join-Path $TestDrive 'save-as-output') 'PowerPointExternal.Copy.pptx'
         $seedPath = Join-Path $TestDrive 'PowerPointTypeSeed.pptx'
         $seed = New-OfficePowerPoint -FilePath $seedPath -NoSave
         $presentationType = $seed.GetType()
@@ -97,6 +97,22 @@ Describe 'PowerPoint cmdlets' {
         $reloaded = Get-OfficePowerPoint -FilePath $savedAsPath
         try {
             $reloaded.Slides.Count | Should -Be 2
+        } finally {
+            Close-OfficePowerPoint -Presentation $reloaded
+        }
+    }
+
+    It 'does not persist edits made after save when closed without save' {
+        $path = Join-Path $TestDrive 'PowerPointExplicitClose.pptx'
+        $presentation = New-OfficePowerPoint -FilePath $path -NoSave
+        Add-OfficePowerPointSlide -Presentation $presentation | Out-Null
+        Save-OfficePowerPoint -Presentation $presentation
+        Add-OfficePowerPointSlide -Presentation $presentation | Out-Null
+        Close-OfficePowerPoint -Presentation $presentation
+
+        $reloaded = Get-OfficePowerPoint -FilePath $path
+        try {
+            $reloaded.Slides.Count | Should -Be 1
         } finally {
             Close-OfficePowerPoint -Presentation $reloaded
         }

--- a/Tests/PowerPoint.Tests.ps1
+++ b/Tests/PowerPoint.Tests.ps1
@@ -126,6 +126,45 @@ Describe 'PowerPoint cmdlets' {
         }
     }
 
+    It 'does not overwrite an externally loaded encrypted presentation without a password' {
+        if (-not (Test-OfficeLoadedMethod -TypeName 'OfficeIMO.PowerPoint.PowerPointPresentation' -MethodName 'LoadEncrypted')) {
+            return
+        }
+
+        $sourcePath = Join-Path $TestDrive 'EncryptedExternalPowerPoint.pptx'
+        New-OfficePowerPoint -Path $sourcePath -Password 'secret' {
+            PptSlide { PptTitle -Title 'Encrypted external deck' }
+        }
+
+        $presentationType = [AppDomain]::CurrentDomain.GetAssemblies() |
+            ForEach-Object { $_.GetType('OfficeIMO.PowerPoint.PowerPointPresentation', $false) } |
+            Where-Object { $null -ne $_ } |
+            Select-Object -First 1
+        $loadEncrypted = $presentationType.GetMethods() | Where-Object {
+            $_.Name -eq 'LoadEncrypted' -and
+            $_.GetParameters().Count -eq 3 -and
+            $_.GetParameters()[0].ParameterType -eq [string] -and
+            $_.GetParameters()[1].ParameterType -eq [string]
+        } | Select-Object -First 1
+        $presentation = $loadEncrypted.Invoke(
+            $null,
+            [object[]]@([string] $sourcePath, [string] 'secret', $null))
+        try {
+            { Save-OfficePowerPoint -Presentation $presentation -Path $sourcePath -ErrorAction Stop } |
+                Should -Throw '*Provide -Password*'
+            Save-OfficePowerPoint -Presentation $presentation -Path $sourcePath -Password 'secret'
+        } finally {
+            Close-OfficePowerPoint -Presentation $presentation -ErrorAction SilentlyContinue
+        }
+
+        $reloaded = Get-OfficePowerPoint -FilePath $sourcePath -Password 'secret'
+        try {
+            $reloaded.Slides.Count | Should -Be 1
+        } finally {
+            Close-OfficePowerPoint -Presentation $reloaded
+        }
+    }
+
     It 'loads owned inspection sources as explicit read-only presentations' {
         $path = Join-Path $TestDrive 'PowerPointReadOnly.pptx'
         New-OfficePowerPoint -Path $path { PptSlide { PptTitle -Title 'Read only' } } | Out-Null

--- a/Tests/PowerPoint.Tests.ps1
+++ b/Tests/PowerPoint.Tests.ps1
@@ -118,6 +118,80 @@ Describe 'PowerPoint cmdlets' {
         }
     }
 
+    It 'rejects external SaveOnDispose presentations before tracking them' {
+        $path = Join-Path $TestDrive 'PowerPointExternalAutoSave.pptx'
+        $presentationType = [AppDomain]::CurrentDomain.GetAssemblies() |
+            ForEach-Object { $_.GetType('OfficeIMO.PowerPoint.PowerPointPresentation', $false) } |
+            Where-Object { $null -ne $_ } |
+            Select-Object -First 1
+        $optionsType = [AppDomain]::CurrentDomain.GetAssemblies() |
+            ForEach-Object { $_.GetType('OfficeIMO.PowerPoint.PowerPointCreateOptions', $false) } |
+            Where-Object { $null -ne $_ } |
+            Select-Object -First 1
+        $modeType = [AppDomain]::CurrentDomain.GetAssemblies() |
+            ForEach-Object { $_.GetType('OfficeIMO.Drawing.DocumentPersistenceMode', $false) } |
+            Where-Object { $null -ne $_ } |
+            Select-Object -First 1
+        $options = [Activator]::CreateInstance($optionsType)
+        $options.PersistenceMode = [Enum]::Parse($modeType, 'SaveOnDispose')
+        $create = $presentationType.GetMethods() | Where-Object {
+            $_.Name -eq 'Create' -and
+            $_.GetParameters().Count -eq 2 -and
+            $_.GetParameters()[0].ParameterType -eq [string]
+        } | Select-Object -First 1
+        $presentation = $create.Invoke($null, [object[]]@([string] $path, $options))
+        try {
+            Add-OfficePowerPointSlide -Presentation $presentation | Out-Null
+
+            { Save-OfficePowerPoint -Presentation $presentation -Path $path -ErrorAction Stop } |
+                Should -Throw '*DocumentPersistenceMode.Explicit*'
+            { Close-OfficePowerPoint -Presentation $presentation -ErrorAction Stop } |
+                Should -Throw '*DocumentPersistenceMode.Explicit*'
+        } finally {
+            $presentation.Dispose()
+        }
+
+        Test-Path -LiteralPath $path | Should -BeTrue
+    }
+
+    It 'treats case-distinct encrypted source paths separately on case-sensitive systems' {
+        if (-not [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+                [System.Runtime.InteropServices.OSPlatform]::Linux)) {
+            return
+        }
+        if (-not (Test-OfficeLoadedMethod -TypeName 'OfficeIMO.PowerPoint.PowerPointPresentation' -MethodName 'OpenEncrypted')) {
+            return
+        }
+
+        $sourcePath = Join-Path $TestDrive 'Deck.pptx'
+        $savedAsPath = Join-Path $TestDrive 'deck.pptx'
+        New-OfficePowerPoint -Path $sourcePath -Password 'secret' {
+            PptSlide { PptTitle -Title 'Encrypted source' }
+        }
+
+        $presentation = Get-OfficePowerPoint -FilePath $sourcePath -Password 'secret'
+        try {
+            Save-OfficePowerPoint -Presentation $presentation -Path $savedAsPath
+        } finally {
+            Close-OfficePowerPoint -Presentation $presentation -ErrorAction SilentlyContinue
+        }
+
+        Test-Path -LiteralPath $sourcePath | Should -BeTrue
+        Test-Path -LiteralPath $savedAsPath | Should -BeTrue
+        $encryptedReload = Get-OfficePowerPoint -FilePath $sourcePath -Password 'secret'
+        try {
+            $encryptedReload.Slides.Count | Should -Be 1
+        } finally {
+            Close-OfficePowerPoint -Presentation $encryptedReload
+        }
+        $reloaded = Get-OfficePowerPoint -FilePath $savedAsPath
+        try {
+            $reloaded.Slides.Count | Should -Be 1
+        } finally {
+            Close-OfficePowerPoint -Presentation $reloaded
+        }
+    }
+
     It 'saves an encrypted presentation through the canonical path writer' {
         if (-not (Test-OfficeLoadedMethod -TypeName 'OfficeIMO.PowerPoint.PowerPointPresentation' -MethodName 'OpenEncrypted')) {
             return


### PR DESCRIPTION
## Summary

- make `Save-OfficePowerPoint` a true save operation that leaves the presentation open
- add consistent `-Path` / `-FilePath`, `-PassThru`, and external pathless presentation support
- require externally supplied presentations to use explicit persistence before PSWriteOffice manages their save/close lifecycle, preventing close-without-save from auto-saving edits
- route encrypted saves through OfficeIMO's canonical writer, compare source paths using platform filesystem casing rules, and prevent unpassworded overwrite of an existing encrypted target
- use read-only loads for transient image, HTML, inspection, and OpenDocument operations
- replace strong presentation registries with weak lifecycle associations
- save, dispose, and unregister before `New` or `Close` opens the final file

## Behavior and migration

Use `Save-OfficePowerPoint` when the presentation should remain open. Use `Close-OfficePowerPoint -Save` when save-and-close is intended. Existing service signatures remain available.

External OfficeIMO presentations must be created or loaded with `DocumentPersistenceMode.Explicit` before they are passed to PSWriteOffice save or close commands. This avoids a hidden save from an external `SaveOnDispose` instance.

Slide import remains read/write only until the owner fix in OfficeIMO #2210 is released; no downstream compatibility branch or duplicate package-copy implementation is included here.

## Validation

Release builds pass for net8.0 and net472. The PowerPoint Pester contract has 39 passing tests, including external persistence and encrypted case-distinct path coverage, and generated help describes save-as, pass-through, and still-open behavior.