### PR TITLE
Normalize tabular input across all Office table formats

### DIFF
--- a/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/AddOfficeExcelTableCommand.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 using OfficeIMO.Excel;
+using PSWriteOffice.Services;
 using PSWriteOffice.Services.Excel;
 using PSWriteOffice.Services.Table;
 
@@ -43,6 +44,21 @@ public sealed class AddOfficeExcelTableCommand : PSCmdlet
     /// <summary>Projection to apply before writing the table.</summary>
     [Parameter]
     public OfficeTableView View { get; set; } = OfficeTableView.Normal;
+
+    /// <summary>Text used between items when a cell contains a collection.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string CollectionSeparator { get; set; } = ", ";
+
+    /// <summary>Text used between entries when a cell contains a dictionary.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string DictionaryEntrySeparator { get; set; } = "; ";
+
+    /// <summary>Text used between a dictionary key and value.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string DictionaryKeyValueSeparator { get; set; } = ": ";
 
     /// <summary>Name to assign to the table.</summary>
     [Parameter]
@@ -94,7 +110,14 @@ public sealed class AddOfficeExcelTableCommand : PSCmdlet
 
         var rows = TableInputCollector.RequireRows(_items, nameof(InputObject));
         var projectedRows = TableViewProjection.Project(rows, View);
-        var table = ExcelTabularInputService.ToDataTable(projectedRows, TableName);
+        var normalizerOptions = PowerShellObjectNormalizerOptions.ForTable(
+            CollectionSeparator,
+            DictionaryEntrySeparator,
+            DictionaryKeyValueSeparator);
+        var table = ExcelTabularInputService.ToDataTable(
+            projectedRows,
+            TableName,
+            normalizerOptions: normalizerOptions);
         if (table.Columns.Count == 0)
         {
             throw new InvalidOperationException("Unable to infer columns from the supplied data.");

--- a/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
@@ -135,6 +135,21 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
     [Parameter]
     public string[]? ExcludeProperty { get; set; }
 
+    /// <summary>Text used between items when a cell contains a collection.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string CollectionSeparator { get; set; } = ", ";
+
+    /// <summary>Text used between entries when a cell contains a dictionary.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string DictionaryEntrySeparator { get; set; } = "; ";
+
+    /// <summary>Text used between a dictionary key and value.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string DictionaryKeyValueSeparator { get; set; } = ": ";
+
     /// <summary>Header-to-format map. Values may be preset names such as Text, Currency, Percent, Date, or custom Excel number formats.</summary>
     [Parameter]
     public Hashtable? ColumnFormat { get; set; }
@@ -396,7 +411,11 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
             if (reader != null && CanExportReaderDirectly(isAppendingToExistingSheet))
             {
                 var readerSheet = PrepareSheet(document);
-                var readerRange = ExportDataReader(readerSheet, reader, style, columnFormatPlan);
+                var readerRange = ExportDataReader(
+                    readerSheet,
+                    new NormalizingDataReader(reader, CreateNormalizerOptions()),
+                    style,
+                    columnFormatPlan);
                 if (!string.IsNullOrWhiteSpace(readerRange))
                 {
                     WriteVerbose($"Exported data reader to {readerSheet.Name}!{readerRange}.");
@@ -520,7 +539,10 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
             return false;
         }
 
-        sheet.InsertObjects<object?>(items, includeHeaders, dataStartRow);
+        var normalizedItems = PowerShellObjectNormalizer
+            .NormalizeItems(items, CreateNormalizerOptions())
+            .ToList();
+        sheet.InsertObjects<object?>(normalizedItems, includeHeaders, dataStartRow);
         range = sheet.UsedRangeA1;
         if (string.IsNullOrWhiteSpace(range))
         {
@@ -852,6 +874,9 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
     {
         return new PowerShellObjectNormalizerOptions
         {
+            CollectionSeparator = CollectionSeparator,
+            DictionaryEntrySeparator = DictionaryEntrySeparator,
+            DictionaryKeyValueSeparator = DictionaryKeyValueSeparator,
             IncludeUnexportableProperties = IncludeUnexportableProperties.IsPresent,
             PropertyErrorAction = PropertyConversionErrorAction,
             PropertyErrorCallback = PropertyConversionErrorAction == ActionPreference.Continue

--- a/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
@@ -1178,7 +1178,9 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
             return;
         }
 
-        if (value is IEnumerable enumerable && value is not string && value is not IDictionary)
+        if (value is IEnumerable enumerable &&
+            value is not string &&
+            !PowerShellDictionaryAdapter.IsDictionaryLike(value))
         {
             foreach (var item in enumerable)
             {

--- a/Sources/PSWriteOffice/Cmdlets/Excel/OfficeExcelReportBlockCommands.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/OfficeExcelReportBlockCommands.cs
@@ -5,7 +5,9 @@ using System.Globalization;
 using System.Linq;
 using System.Management.Automation;
 using OfficeIMO.Excel;
+using PSWriteOffice.Services;
 using PSWriteOffice.Services.Excel;
+using PSWriteOffice.Services.Table;
 
 namespace PSWriteOffice.Cmdlets.Excel;
 
@@ -272,10 +274,12 @@ public sealed class AddOfficeExcelReportLegendCommand : PSCmdlet
 [Alias("ExcelReportTable")]
 public sealed class AddOfficeExcelReportTableCommand : PSCmdlet
 {
+    private readonly List<object?> _items = new();
+
     /// <summary>Objects to flatten and render as a table.</summary>
-    [Parameter(Mandatory = true, Position = 0)]
+    [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
     [Alias("Data")]
-    public object[] InputObject { get; set; } = Array.Empty<object>();
+    public object? InputObject { get; set; }
 
     /// <summary>Optional section title displayed above the table.</summary>
     [Parameter(Position = 1)]
@@ -284,6 +288,29 @@ public sealed class AddOfficeExcelReportTableCommand : PSCmdlet
     /// <summary>Built-in table style to apply.</summary>
     [Parameter]
     public string TableStyle { get; set; } = "TableStyleMedium9";
+
+    /// <summary>Properties to include, in the requested column order.</summary>
+    [Parameter]
+    public string[]? Property { get; set; }
+
+    /// <summary>Properties to exclude from the rendered table.</summary>
+    [Parameter]
+    public string[]? ExcludeProperty { get; set; }
+
+    /// <summary>Text used between items when a cell contains a collection.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string CollectionSeparator { get; set; } = ", ";
+
+    /// <summary>Text used between entries when a cell contains a dictionary.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string DictionaryEntrySeparator { get; set; } = "; ";
+
+    /// <summary>Text used between a dictionary key and value.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string DictionaryKeyValueSeparator { get; set; } = ": ";
 
     /// <summary>Emphasize the first table column when the selected style supports it.</summary>
     [Parameter]
@@ -320,10 +347,22 @@ public sealed class AddOfficeExcelReportTableCommand : PSCmdlet
     /// <inheritdoc />
     protected override void ProcessRecord()
     {
-        if (InputObject.Length == 0)
-        {
-            throw new PSArgumentException("Provide at least one data row.", nameof(InputObject));
-        }
+        TableInputCollector.AddInput(_items, InputObject, preserveTabularInput: true);
+    }
+
+    /// <inheritdoc />
+    protected override void EndProcessing()
+    {
+        var inputRows = TableInputCollector.RequireRows(_items, nameof(InputObject));
+        var normalizerOptions = PowerShellObjectNormalizerOptions.ForTable(
+            CollectionSeparator,
+            DictionaryEntrySeparator,
+            DictionaryKeyValueSeparator);
+        var table = ExcelTabularInputService.ToDataTable(
+            inputRows,
+            copyExistingTables: true,
+            normalizerOptions: normalizerOptions);
+        var reportRows = ExcelTabularInputService.ToDictionaryRows(table);
 
         if (!Enum.TryParse(TableStyle, ignoreCase: true, out ExcelTableStyle style))
         {
@@ -332,8 +371,13 @@ public sealed class AddOfficeExcelReportTableCommand : PSCmdlet
 
         var composer = ExcelDslContext.Require(this).RequireComposer();
         var range = composer.TableFrom(
-            InputObject,
+            reportRows,
             Title,
+            configure: options =>
+            {
+                options.Columns = NormalizePropertyList(Property);
+                options.ExcludeProperties = NormalizePropertyList(ExcludeProperty) ?? Array.Empty<string>();
+            },
             style: style,
             autoFilter: !NoAutoFilter.IsPresent,
             freezeHeaderRow: !NoFreezeHeaderRow.IsPresent,
@@ -350,6 +394,22 @@ public sealed class AddOfficeExcelReportTableCommand : PSCmdlet
         {
             WriteObject(range);
         }
+    }
+
+    private static string[]? NormalizePropertyList(string[]? properties)
+    {
+        if (properties == null || properties.Length == 0)
+        {
+            return null;
+        }
+
+        var normalized = properties
+            .Where(static property => !string.IsNullOrWhiteSpace(property))
+            .Select(static property => property.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return normalized.Length == 0 ? null : normalized;
     }
 }
 

--- a/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Markdown/AddOfficeMarkdownTableCommand.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 using OfficeIMO.Markdown;
+using PSWriteOffice.Services;
 using PSWriteOffice.Services.Markdown;
 using PSWriteOffice.Services.Table;
 
@@ -48,6 +49,21 @@ public sealed class AddOfficeMarkdownTableCommand : PSCmdlet
     /// <summary>Projection to apply before writing the table.</summary>
     [Parameter]
     public OfficeTableView View { get; set; } = OfficeTableView.Normal;
+
+    /// <summary>Text used between items when a cell contains a collection.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string CollectionSeparator { get; set; } = ", ";
+
+    /// <summary>Text used between entries when a cell contains a dictionary.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string DictionaryEntrySeparator { get; set; } = "; ";
+
+    /// <summary>Text used between a dictionary key and value.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string DictionaryKeyValueSeparator { get; set; } = ": ";
 
     /// <summary>Disable automatic alignment heuristics for tables.</summary>
     [Parameter]
@@ -102,7 +118,11 @@ public sealed class AddOfficeMarkdownTableCommand : PSCmdlet
     private void RenderTable(MarkdownDoc doc, object[] rows)
     {
         var projectedRows = TableViewProjection.Project(rows, View);
-        var normalizedRows = projectedRows.Select(NormalizeItem).ToArray();
+        var options = PowerShellObjectNormalizerOptions.ForTable(
+            CollectionSeparator,
+            DictionaryEntrySeparator,
+            DictionaryKeyValueSeparator);
+        var normalizedRows = PowerShellObjectNormalizer.NormalizeItems(projectedRows, options);
         if (DisableAutoAlign.IsPresent)
         {
             doc.TableFrom(normalizedRows);
@@ -123,54 +143,6 @@ public sealed class AddOfficeMarkdownTableCommand : PSCmdlet
         var items = new List<object?>();
         TableInputCollector.AddInput(items, value);
         return TableInputCollector.RequireRows(items, nameof(InputObject));
-    }
-
-    private static object? NormalizeItem(object? item)
-    {
-        if (item == null)
-        {
-            return null;
-        }
-
-        if (IsScalar(item))
-        {
-            return item;
-        }
-
-        var ps = PSObject.AsPSObject(item);
-        if (ps.BaseObject is IDictionary dict)
-        {
-            return dict;
-        }
-
-        var properties = ps.Properties
-            .Where(p => p.MemberType == PSMemberTypes.NoteProperty || p.MemberType == PSMemberTypes.Property)
-            .Select(p => p.Name)
-            .Where(n => !string.IsNullOrWhiteSpace(n))
-            .ToList();
-
-        if (properties.Count > 0)
-        {
-            var result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-            foreach (var name in properties)
-            {
-                result[name] = ps.Properties[name]?.Value;
-            }
-            return result;
-        }
-
-        return item;
-    }
-
-    private static bool IsScalar(object item)
-    {
-        var type = item.GetType();
-        return type.IsPrimitive
-            || item is string
-            || item is decimal
-            || item is DateTime
-            || item is DateTimeOffset
-            || item is Guid;
     }
 
     private MarkdownDoc ResolveDocument()

--- a/Sources/PSWriteOffice/Cmdlets/Markdown/ConvertToOfficeMarkdownCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Markdown/ConvertToOfficeMarkdownCommand.cs
@@ -1,9 +1,8 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Management.Automation;
 using OfficeIMO.Markdown;
+using PSWriteOffice.Services;
 
 namespace PSWriteOffice.Cmdlets.Markdown;
 
@@ -38,6 +37,21 @@ public sealed class ConvertToOfficeMarkdownCommand : PSCmdlet
     [Parameter(ValueFromPipeline = true)]
     public object? InputObject { get; set; }
 
+    /// <summary>Text used between items when a cell contains a collection.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string CollectionSeparator { get; set; } = ", ";
+
+    /// <summary>Text used between entries when a cell contains a dictionary.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string DictionaryEntrySeparator { get; set; } = "; ";
+
+    /// <summary>Text used between a dictionary key and value.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string DictionaryKeyValueSeparator { get; set; } = ": ";
+
     /// <summary>Disable automatic alignment heuristics for tables.</summary>
     [Parameter]
     public SwitchParameter DisableAutoAlign { get; set; }
@@ -49,7 +63,7 @@ public sealed class ConvertToOfficeMarkdownCommand : PSCmdlet
     /// <inheritdoc />
     protected override void ProcessRecord()
     {
-        _items.Add(NormalizeItem(InputObject));
+        _items.Add(InputObject);
     }
 
     /// <inheritdoc />
@@ -60,14 +74,19 @@ public sealed class ConvertToOfficeMarkdownCommand : PSCmdlet
             return;
         }
 
+        var options = PowerShellObjectNormalizerOptions.ForTable(
+            CollectionSeparator,
+            DictionaryEntrySeparator,
+            DictionaryKeyValueSeparator);
+        var normalizedItems = PowerShellObjectNormalizer.NormalizeItems(_items, options);
         var doc = MarkdownDoc.Create();
         if (DisableAutoAlign.IsPresent)
         {
-            doc.TableFrom(_items);
+            doc.TableFrom(normalizedItems);
         }
         else
         {
-            doc.TableFromAuto(_items);
+            doc.TableFromAuto(normalizedItems);
         }
 
         if (PassThru.IsPresent)
@@ -80,50 +99,4 @@ public sealed class ConvertToOfficeMarkdownCommand : PSCmdlet
         }
     }
 
-    private static object? NormalizeItem(object? item)
-    {
-        if (item == null)
-        {
-            return null;
-        }
-
-        if (IsScalar(item))
-        {
-            return item;
-        }
-
-        var ps = PSObject.AsPSObject(item);
-        if (ps.BaseObject is IDictionary dict)
-        {
-            return dict;
-        }
-
-        var properties = ps.Properties
-            .Where(p => p.MemberType == PSMemberTypes.NoteProperty || p.MemberType == PSMemberTypes.Property)
-            .Select(p => p.Name)
-            .Where(n => !string.IsNullOrWhiteSpace(n))
-            .ToList();
-        if (properties.Count > 0)
-        {
-            var result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-            foreach (var name in properties)
-            {
-                result[name] = ps.Properties[name]?.Value;
-            }
-            return result;
-        }
-
-        return item;
-    }
-
-    private static bool IsScalar(object item)
-    {
-        var type = item.GetType();
-        return type.IsPrimitive
-            || item is string
-            || item is decimal
-            || item is DateTime
-            || item is DateTimeOffset
-            || item is Guid;
-    }
 }

--- a/Sources/PSWriteOffice/Cmdlets/Pdf/AddOfficePdfTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Pdf/AddOfficePdfTableCommand.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 using OfficeIMO.Pdf;
+using PSWriteOffice.Services;
 using PSWriteOffice.Services.Pdf;
 using PSWriteOffice.Services.Table;
 using PSWriteOffice.Services.Text;
@@ -61,6 +62,16 @@ public sealed class AddOfficePdfTableCommand : PSCmdlet
     [Parameter]
     [AllowEmptyString]
     public string CollectionSeparator { get; set; } = ", ";
+
+    /// <summary>Text used between entries when a cell contains a dictionary.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string DictionaryEntrySeparator { get; set; } = "; ";
+
+    /// <summary>Text used between a dictionary key and value.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string DictionaryKeyValueSeparator { get; set; } = ": ";
 
     /// <summary>Table alignment.</summary>
     [Parameter]
@@ -238,7 +249,10 @@ public sealed class AddOfficePdfTableCommand : PSCmdlet
     private void RenderTable(PdfDocument document, object[] inputRows)
     {
         var projectedRows = TableViewProjection.Project(inputRows, View);
-        var normalizationOptions = PdfCommandUtilities.CreateTableNormalizationOptions(CollectionSeparator);
+        var normalizationOptions = PdfCommandUtilities.CreateTableNormalizationOptions(
+            CollectionSeparator,
+            DictionaryEntrySeparator,
+            DictionaryKeyValueSeparator);
         if (OfficeTableSpecParser.TryCreate(projectedRows, Property, Header, out var tableSpec, normalizationOptions))
         {
             var style = ApplyPdfCellStyles(CreateStyle(), tableSpec.Placements);
@@ -246,15 +260,19 @@ public sealed class AddOfficePdfTableCommand : PSCmdlet
             return;
         }
 
-        var rowArrayInput = projectedRows.All(item => item is IEnumerable && item is not string && item is not IDictionary);
+        var rowArrayInput = projectedRows.All(IsRowEnumerable);
         string[][] rows = rowArrayInput
-            ? PdfCommandUtilities.ConvertDataRows(projectedRows, Header, CollectionSeparator)
-            : projectedRows.Length == 1 && projectedRows[0] is IEnumerable enumerable && projectedRows[0] is not string && projectedRows[0] is not IDictionary
-            ? PdfCommandUtilities.ConvertDataRows(enumerable, Header, CollectionSeparator)
-            : PdfCommandUtilities.ConvertToTableRows(projectedRows, Property, Header, CollectionSeparator);
+            ? PdfCommandUtilities.ConvertDataRows(projectedRows, Header, normalizationOptions)
+            : projectedRows.Length == 1 && IsRowEnumerable(projectedRows[0]) && projectedRows[0] is IEnumerable enumerable
+            ? PdfCommandUtilities.ConvertDataRows(enumerable, Header, normalizationOptions)
+            : PdfCommandUtilities.ConvertToTableRows(projectedRows, Property, Header, normalizationOptions);
 
         document.Table(rows, Align, CreateStyle());
     }
+
+    private static bool IsRowEnumerable(object item)
+        => item is IEnumerable and not string and not IDictionary &&
+           !PowerShellDictionaryAdapter.IsDictionaryLike(item);
 
     private static PdfTableCell[][] ToPdfRows(OfficeTableSpec table)
     {

--- a/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/PowerPoint/AddOfficePowerPointTableCommand.cs
@@ -49,6 +49,21 @@ public sealed class AddOfficePowerPointTableCommand : PSCmdlet
     [Parameter(ParameterSetName = ParameterSetInputObject)]
     public OfficeTableView View { get; set; } = OfficeTableView.Normal;
 
+    /// <summary>Text used between items when a cell contains a collection.</summary>
+    [Parameter(ParameterSetName = ParameterSetInputObject)]
+    [AllowEmptyString]
+    public string CollectionSeparator { get; set; } = ", ";
+
+    /// <summary>Text used between entries when a cell contains a dictionary.</summary>
+    [Parameter(ParameterSetName = ParameterSetInputObject)]
+    [AllowEmptyString]
+    public string DictionaryEntrySeparator { get; set; } = "; ";
+
+    /// <summary>Text used between a dictionary key and value.</summary>
+    [Parameter(ParameterSetName = ParameterSetInputObject)]
+    [AllowEmptyString]
+    public string DictionaryKeyValueSeparator { get; set; } = ": ";
+
     /// <summary>Row count for an empty table.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ParameterSetSize)]
     public int Rows { get; set; }
@@ -124,17 +139,22 @@ public sealed class AddOfficePowerPointTableCommand : PSCmdlet
         TableInputCollector.AddInput(items, InputObject);
         var inputRows = TableInputCollector.RequireRows(items, nameof(InputObject));
         var projectedRows = TableViewProjection.Project(inputRows, View);
+        var normalizerOptions = PowerShellObjectNormalizerOptions.ForTable(
+            CollectionSeparator,
+            DictionaryEntrySeparator,
+            DictionaryKeyValueSeparator);
         var explicitHeaders = ResolveExplicitHeaders();
         if (OfficeTableSpecParser.TryCreate(
                 projectedRows,
                 propertyNames: explicitHeaders,
                 header: NoHeader.IsPresent ? Array.Empty<string>() : explicitHeaders,
-                out var tableSpec))
+                out var tableSpec,
+                normalizerOptions))
         {
             return CreateStructuredTable(slide, tableSpec);
         }
 
-        var normalized = PowerShellObjectNormalizer.NormalizeItems(projectedRows);
+        var normalized = PowerShellObjectNormalizer.NormalizeItems(projectedRows, normalizerOptions);
         var rows = NormalizeRows(normalized);
         var headers = ResolveHeaders(rows);
 

--- a/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Word/AddOfficeWordTableCommand.cs
@@ -50,6 +50,21 @@ public sealed class AddOfficeWordTableCommand : PSCmdlet
     [Parameter]
     public OfficeTableView View { get; set; } = OfficeTableView.Normal;
 
+    /// <summary>Text used between items when a cell contains a collection.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string CollectionSeparator { get; set; } = ", ";
+
+    /// <summary>Text used between entries when a cell contains a dictionary.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string DictionaryEntrySeparator { get; set; } = "; ";
+
+    /// <summary>Text used between a dictionary key and value.</summary>
+    [Parameter]
+    [AllowEmptyString]
+    public string DictionaryKeyValueSeparator { get; set; } = ": ";
+
     /// <summary>Legacy switch that maps to <see cref="OfficeTableView.Transpose"/>.</summary>
     [Parameter]
     public SwitchParameter Transpose { get; set; }
@@ -85,6 +100,10 @@ public sealed class AddOfficeWordTableCommand : PSCmdlet
         var context = WordDslContext.Require(this);
         var effectiveView = Transpose.IsPresent ? OfficeTableView.Transpose : View;
         var tableRows = TableViewProjection.Project(rows, effectiveView);
+        var normalizerOptions = PowerShellObjectNormalizerOptions.ForTable(
+            CollectionSeparator,
+            DictionaryEntrySeparator,
+            DictionaryKeyValueSeparator);
         var legacyLayout = ResolveLegacyLayout(Layout);
         int? conditionHeaderRowIndex = NoHeader.IsPresent ? null : 0;
         WordTable table;
@@ -92,7 +111,8 @@ public sealed class AddOfficeWordTableCommand : PSCmdlet
                 tableRows,
                 propertyNames: null,
                 header: NoHeader.IsPresent ? Array.Empty<string>() : null,
-                out var tableSpec))
+                out var tableSpec,
+                normalizerOptions))
         {
             table = CreateTable(context, tableSpec, Style, legacyLayout);
             conditionHeaderRowIndex = tableSpec.HeaderRowIndex;
@@ -101,7 +121,7 @@ public sealed class AddOfficeWordTableCommand : PSCmdlet
         {
             table = CreateTable(
                 context,
-                PowerShellObjectNormalizer.NormalizeItems(tableRows),
+                PowerShellObjectNormalizer.NormalizeItems(tableRows, normalizerOptions),
                 Style,
                 includeHeader: !NoHeader.IsPresent,
                 layout: legacyLayout);

--- a/Sources/PSWriteOffice/PSWriteOffice.csproj
+++ b/Sources/PSWriteOffice/PSWriteOffice.csproj
@@ -11,7 +11,7 @@
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <OfficeIMOVersion>3.1.1</OfficeIMOVersion>
+        <OfficeIMOVersion>3.2.0</OfficeIMOVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Sources/PSWriteOffice/Services/Excel/ExcelTabularInputService.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelTabularInputService.cs
@@ -20,6 +20,8 @@ internal static class ExcelTabularInputService
             throw new ArgumentNullException(nameof(input));
         }
 
+        normalizerOptions ??= PowerShellObjectNormalizerOptions.Default;
+
         var items = new List<object?>();
         foreach (var item in input)
         {
@@ -41,12 +43,12 @@ internal static class ExcelTabularInputService
             var single = Unwrap(items[0]);
             if (single is DataTable dataTable)
             {
-                return copyExistingTables ? dataTable.Copy() : dataTable;
+                return NormalizeTabularValues(dataTable, copyExistingTables, normalizerOptions);
             }
 
             if (single is DataView dataView)
             {
-                return dataView.ToTable();
+                return NormalizeTabularValues(dataView.ToTable(), copyExistingTable: false, normalizerOptions);
             }
 
             if (single is IDataReader reader)
@@ -55,7 +57,7 @@ internal static class ExcelTabularInputService
                     ? new DataTable()
                     : new DataTable(tableName);
                 dataTableFromReader.Load(reader);
-                return dataTableFromReader;
+                return NormalizeTabularValues(dataTableFromReader, copyExistingTable: false, normalizerOptions);
             }
         }
 
@@ -76,7 +78,7 @@ internal static class ExcelTabularInputService
 
             if (rows.Count > 0)
             {
-                return FromDataRows(rows);
+                return NormalizeTabularValues(FromDataRows(rows), copyExistingTable: false, normalizerOptions);
             }
         }
 
@@ -96,7 +98,7 @@ internal static class ExcelTabularInputService
 
             if (rows.Count > 0)
             {
-                return FromDataRows(rows);
+                return NormalizeTabularValues(FromDataRows(rows), copyExistingTable: false, normalizerOptions);
             }
         }
 
@@ -107,6 +109,31 @@ internal static class ExcelTabularInputService
 
         var normalized = PowerShellObjectNormalizer.NormalizeItems(items, normalizerOptions);
         return ExcelObjectDataTableBuilder.FromObjects(normalized, tableName ?? string.Empty);
+    }
+
+    /// <summary>Projects a normalized DataTable into dictionary rows accepted by generic report composers.</summary>
+    public static object[] ToDictionaryRows(DataTable table)
+    {
+        if (table == null)
+        {
+            throw new ArgumentNullException(nameof(table));
+        }
+
+        var rows = new object[table.Rows.Count];
+        for (var rowIndex = 0; rowIndex < table.Rows.Count; rowIndex++)
+        {
+            var sourceRow = table.Rows[rowIndex];
+            var row = new Dictionary<string, object?>(table.Columns.Count, StringComparer.OrdinalIgnoreCase);
+            foreach (DataColumn column in table.Columns)
+            {
+                var value = sourceRow[column];
+                row[column.ColumnName] = value == DBNull.Value ? null : value;
+            }
+
+            rows[rowIndex] = row;
+        }
+
+        return rows;
     }
 
     private static bool TryProjectToDataTable(
@@ -241,6 +268,89 @@ internal static class ExcelTabularInputService
         }
 
         return result;
+    }
+
+    private static DataTable NormalizeTabularValues(
+        DataTable source,
+        bool copyExistingTable,
+        PowerShellObjectNormalizerOptions options)
+    {
+        object?[][]? normalizedRows = null;
+        for (var rowIndex = 0; rowIndex < source.Rows.Count; rowIndex++)
+        {
+            var sourceRow = source.Rows[rowIndex];
+            object?[]? normalizedRow = null;
+            for (var columnIndex = 0; columnIndex < source.Columns.Count; columnIndex++)
+            {
+                var value = sourceRow[columnIndex];
+                var normalized = PowerShellObjectNormalizer.NormalizeCellValueForTable(value, options);
+                if (normalizedRow == null && !CellValuesEqual(value, normalized))
+                {
+                    if (normalizedRows == null)
+                    {
+                        normalizedRows = new object?[source.Rows.Count][];
+                        for (var previousRowIndex = 0; previousRowIndex < rowIndex; previousRowIndex++)
+                        {
+                            normalizedRows[previousRowIndex] = source.Rows[previousRowIndex].ItemArray.Cast<object?>().ToArray();
+                        }
+                    }
+                    normalizedRow = new object?[source.Columns.Count];
+                    for (var copyIndex = 0; copyIndex < columnIndex; copyIndex++)
+                    {
+                        normalizedRow[copyIndex] = sourceRow[copyIndex];
+                    }
+                }
+
+                if (normalizedRow != null)
+                {
+                    normalizedRow[columnIndex] = normalized;
+                }
+            }
+
+            if (normalizedRows != null)
+            {
+                normalizedRows[rowIndex] = normalizedRow ?? sourceRow.ItemArray.Cast<object?>().ToArray();
+            }
+        }
+
+        if (normalizedRows == null)
+        {
+            return copyExistingTable ? source.Copy() : source;
+        }
+
+        var result = new DataTable(source.TableName)
+        {
+            CaseSensitive = source.CaseSensitive,
+            Locale = source.Locale,
+            Namespace = source.Namespace,
+            Prefix = source.Prefix
+        };
+        foreach (DataColumn column in source.Columns)
+        {
+            result.Columns.Add(column.ColumnName, typeof(object));
+        }
+
+        foreach (var row in normalizedRows)
+        {
+            var values = row ?? Array.Empty<object?>();
+            for (var index = 0; index < values.Length; index++)
+            {
+                values[index] ??= DBNull.Value;
+            }
+            result.Rows.Add(values);
+        }
+
+        return result;
+    }
+
+    private static bool CellValuesEqual(object? left, object? right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        return left?.GetType() == right?.GetType() && Equals(left, right);
     }
 
     private static object? Unwrap(object? item)

--- a/Sources/PSWriteOffice/Services/Excel/NormalizingDataReader.cs
+++ b/Sources/PSWriteOffice/Services/Excel/NormalizingDataReader.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Data;
+using PSWriteOffice.Services;
+
+namespace PSWriteOffice.Services.Excel;
+
+/// <summary>Preserves streaming IDataReader behavior while normalizing complex Office table cell values.</summary>
+internal sealed class NormalizingDataReader : IDataReader
+{
+    private readonly IDataReader _reader;
+    private readonly PowerShellObjectNormalizerOptions _options;
+
+    internal NormalizingDataReader(IDataReader reader, PowerShellObjectNormalizerOptions options)
+    {
+        _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    public object this[int i] => GetValue(i);
+    public object this[string name] => GetValue(GetOrdinal(name));
+    public int Depth => _reader.Depth;
+    public bool IsClosed => _reader.IsClosed;
+    public int RecordsAffected => _reader.RecordsAffected;
+    public int FieldCount => _reader.FieldCount;
+
+    public void Close() => _reader.Close();
+    public void Dispose() => _reader.Dispose();
+    public bool GetBoolean(int i) => _reader.GetBoolean(i);
+    public byte GetByte(int i) => _reader.GetByte(i);
+    public long GetBytes(int i, long fieldOffset, byte[]? buffer, int bufferoffset, int length) => _reader.GetBytes(i, fieldOffset, buffer, bufferoffset, length);
+    public char GetChar(int i) => _reader.GetChar(i);
+    public long GetChars(int i, long fieldoffset, char[]? buffer, int bufferoffset, int length) => _reader.GetChars(i, fieldoffset, buffer, bufferoffset, length);
+    public IDataReader GetData(int i) => _reader.GetData(i);
+    public string GetDataTypeName(int i) => _reader.GetDataTypeName(i);
+    public DateTime GetDateTime(int i) => _reader.GetDateTime(i);
+    public decimal GetDecimal(int i) => _reader.GetDecimal(i);
+    public double GetDouble(int i) => _reader.GetDouble(i);
+    public Type GetFieldType(int i) => _reader.GetFieldType(i);
+    public float GetFloat(int i) => _reader.GetFloat(i);
+    public Guid GetGuid(int i) => _reader.GetGuid(i);
+    public short GetInt16(int i) => _reader.GetInt16(i);
+    public int GetInt32(int i) => _reader.GetInt32(i);
+    public long GetInt64(int i) => _reader.GetInt64(i);
+    public string GetName(int i) => _reader.GetName(i);
+    public int GetOrdinal(string name) => _reader.GetOrdinal(name);
+    public DataTable? GetSchemaTable() => _reader.GetSchemaTable();
+    public string GetString(int i) => _reader.GetString(i);
+
+    public object GetValue(int i)
+    {
+        var value = _reader.GetValue(i);
+        if (value == DBNull.Value)
+        {
+            return value;
+        }
+
+        return PowerShellObjectNormalizer.NormalizeCellValueForTable(value, _options) ?? DBNull.Value;
+    }
+
+    public int GetValues(object[] values)
+    {
+        if (values == null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        var count = Math.Min(values.Length, FieldCount);
+        for (var index = 0; index < count; index++)
+        {
+            values[index] = GetValue(index);
+        }
+
+        return count;
+    }
+
+    public bool IsDBNull(int i) => _reader.IsDBNull(i);
+    public bool NextResult() => _reader.NextResult();
+    public bool Read() => _reader.Read();
+}

--- a/Sources/PSWriteOffice/Services/Pdf/PdfCommandUtilities.cs
+++ b/Sources/PSWriteOffice/Services/Pdf/PdfCommandUtilities.cs
@@ -264,6 +264,17 @@ internal static class PdfCommandUtilities
         string[]? property,
         string[]? header,
         string collectionSeparator = ", ")
+        => ConvertToTableRows(
+            inputObject,
+            property,
+            header,
+            CreateTableNormalizationOptions(collectionSeparator));
+
+    internal static string[][] ConvertToTableRows(
+        object[] inputObject,
+        string[]? property,
+        string[]? header,
+        PowerShellObjectNormalizerOptions normalizationOptions)
     {
         if (inputObject.Length == 0)
         {
@@ -272,7 +283,7 @@ internal static class PdfCommandUtilities
 
         var propertyNames = property != null && property.Length > 0
             ? property
-            : GetPropertyNames(inputObject[0]);
+            : GetPropertyNames(inputObject[0], normalizationOptions);
 
         var rows = new List<string[]>();
         if (header != null && header.Length > 0)
@@ -284,7 +295,6 @@ internal static class PdfCommandUtilities
             rows.Add(propertyNames);
         }
 
-        var normalizationOptions = CreateTableNormalizationOptions(collectionSeparator);
         foreach (var item in inputObject)
         {
             if (PowerShellObjectNormalizer.TryProjectItem(
@@ -310,9 +320,14 @@ internal static class PdfCommandUtilities
         IEnumerable rows,
         string[]? header = null,
         string collectionSeparator = ", ")
+        => ConvertDataRows(rows, header, CreateTableNormalizationOptions(collectionSeparator));
+
+    internal static string[][] ConvertDataRows(
+        IEnumerable rows,
+        string[]? header,
+        PowerShellObjectNormalizerOptions normalizationOptions)
     {
         var result = new List<string[]>();
-        var normalizationOptions = CreateTableNormalizationOptions(collectionSeparator);
         if (header != null && header.Length > 0)
         {
             result.Add(header);
@@ -346,20 +361,23 @@ internal static class PdfCommandUtilities
         return result.ToArray();
     }
 
-    internal static PowerShellObjectNormalizerOptions CreateTableNormalizationOptions(string collectionSeparator)
+    internal static PowerShellObjectNormalizerOptions CreateTableNormalizationOptions(
+        string collectionSeparator,
+        string dictionaryEntrySeparator = "; ",
+        string dictionaryKeyValueSeparator = ": ")
     {
         if (collectionSeparator == null)
         {
             throw new PSArgumentNullException(nameof(collectionSeparator));
         }
 
-        return new PowerShellObjectNormalizerOptions
-        {
-            NormalizeCollectionValues = true,
-            CollectionSeparator = collectionSeparator,
-            Culture = CultureInfo.InvariantCulture,
-            FormatScalarValuesAsText = true
-        };
+        var options = PowerShellObjectNormalizerOptions.ForTable(
+            collectionSeparator,
+            dictionaryEntrySeparator,
+            dictionaryKeyValueSeparator);
+        options.Culture = CultureInfo.InvariantCulture;
+        options.FormatScalarValuesAsText = true;
+        return options;
     }
 
     internal static IReadOnlyDictionary<string, string> ConvertFieldValues(IDictionary fieldValues)
@@ -395,11 +413,18 @@ internal static class PdfCommandUtilities
         }
     }
 
-    private static string[] GetPropertyNames(object item)
+    private static string[] GetPropertyNames(
+        object item,
+        PowerShellObjectNormalizerOptions normalizationOptions)
     {
-        if (item is IDictionary dictionary)
+        if (PowerShellObjectNormalizer.TryProjectItem(
+                item,
+                columns: null,
+                out var columns,
+                out _,
+                normalizationOptions))
         {
-            return dictionary.Keys.Cast<object>().Select(key => Convert.ToString(key, CultureInfo.InvariantCulture) ?? string.Empty).ToArray();
+            return columns;
         }
 
         return PSObject.AsPSObject(item).Properties

--- a/Sources/PSWriteOffice/Services/PowerShellCellValueFormatter.cs
+++ b/Sources/PSWriteOffice/Services/PowerShellCellValueFormatter.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Management.Automation;
+
+namespace PSWriteOffice.Services;
+
+/// <summary>Formats nested collection and dictionary values consistently for Office table cells.</summary>
+internal static class PowerShellCellValueFormatter
+{
+    public static bool TryFormatComplexValue(object? value, PowerShellObjectNormalizerOptions options, out string text)
+    {
+        if (!options.NormalizeCollectionValues)
+        {
+            text = string.Empty;
+            return false;
+        }
+
+        value = Unwrap(value);
+        if (value is string || value == null)
+        {
+            text = string.Empty;
+            return false;
+        }
+
+        if (!PowerShellDictionaryAdapter.TryGetEntries(value, options.MaxCollectionItems, out _) && value is not IEnumerable)
+        {
+            text = string.Empty;
+            return false;
+        }
+
+        text = FormatValue(value, options, 0, new HashSet<object>(ReferenceComparer.Instance));
+        return true;
+    }
+
+    private static string FormatValue(
+        object? value,
+        PowerShellObjectNormalizerOptions options,
+        int depth,
+        HashSet<object> activeObjects)
+    {
+        value = Unwrap(value);
+        if (value == null)
+        {
+            return string.Empty;
+        }
+
+        if (value is string text)
+        {
+            return text;
+        }
+
+        if (depth >= options.MaxNestingDepth)
+        {
+            throw new InvalidDataException($"The cell value exceeds the {options.MaxNestingDepth}-level normalization limit.");
+        }
+
+        if (PowerShellDictionaryAdapter.TryGetEntries(value, options.MaxCollectionItems, out var entries))
+        {
+            return TrackReference(value, activeObjects, () =>
+            {
+                var values = new List<string>(entries.Count);
+                foreach (var entry in entries)
+                {
+                    values.Add(
+                        FormatScalar(entry.Key, options) +
+                        options.DictionaryKeyValueSeparator +
+                        FormatValue(entry.Value, options, depth + 1, activeObjects));
+                }
+
+                return string.Join(options.DictionaryEntrySeparator, values);
+            });
+        }
+
+        if (value is IEnumerable enumerable)
+        {
+            return TrackReference(value, activeObjects, () =>
+            {
+                var values = new List<string>();
+                var enumerator = enumerable.GetEnumerator();
+                try
+                {
+                    while (enumerator.MoveNext())
+                    {
+                        if (values.Count >= options.MaxCollectionItems)
+                        {
+                            throw new InvalidDataException($"The collection exceeds the {options.MaxCollectionItems}-item normalization limit.");
+                        }
+
+                        values.Add(FormatValue(enumerator.Current, options, depth + 1, activeObjects));
+                    }
+                }
+                finally
+                {
+                    (enumerator as IDisposable)?.Dispose();
+                }
+
+                return string.Join(options.CollectionSeparator, values);
+            });
+        }
+
+        return FormatScalar(value, options);
+    }
+
+    private static string TrackReference(object value, ISet<object> activeObjects, Func<string> formatter)
+    {
+        if (value.GetType().IsValueType)
+        {
+            return formatter();
+        }
+
+        if (!activeObjects.Add(value))
+        {
+            throw new InvalidDataException("The cell value contains a reference cycle.");
+        }
+
+        try
+        {
+            return formatter();
+        }
+        finally
+        {
+            activeObjects.Remove(value);
+        }
+    }
+
+    private static object? Unwrap(object? value) => value is PSObject psObject ? psObject.BaseObject : value;
+
+    private static string FormatScalar(object? value, PowerShellObjectNormalizerOptions options)
+    {
+        value = Unwrap(value);
+        if (value == null)
+        {
+            return string.Empty;
+        }
+
+        if (value is bool boolValue)
+        {
+            return boolValue ? "True" : "False";
+        }
+
+        if (value is IFormattable formattable)
+        {
+            return formattable.ToString(null, options.Culture) ?? string.Empty;
+        }
+
+        return LanguagePrimitives.ConvertTo(value, typeof(string), options.Culture) as string ?? value.ToString() ?? string.Empty;
+    }
+
+    private sealed class ReferenceComparer : IEqualityComparer<object>
+    {
+        public static ReferenceComparer Instance { get; } = new();
+
+        public new bool Equals(object? left, object? right) => ReferenceEquals(left, right);
+        public int GetHashCode(object value) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(value);
+    }
+}

--- a/Sources/PSWriteOffice/Services/PowerShellDictionaryAdapter.cs
+++ b/Sources/PSWriteOffice/Services/PowerShellDictionaryAdapter.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using System.Reflection;
+
+namespace PSWriteOffice.Services;
+
+/// <summary>Adapts PowerShell, non-generic, and generic dictionary implementations.</summary>
+internal static class PowerShellDictionaryAdapter
+{
+    private static readonly ConcurrentDictionary<Type, bool> DictionaryTypeCache = new();
+    private static readonly ConcurrentDictionary<Type, DictionaryEntryAccessor> EntryAccessorCache = new();
+
+    public static bool IsDictionaryLike(object? value)
+    {
+        if (value is PSObject psObject)
+        {
+            value = psObject.BaseObject;
+        }
+
+        return value is IDictionary ||
+            value != null && DictionaryTypeCache.GetOrAdd(value.GetType(), IsGenericDictionaryType);
+    }
+
+    public static bool TryGetEntries(object? value, int maximumItems, out IReadOnlyList<PowerShellDictionaryEntry> entries)
+    {
+        var result = new List<PowerShellDictionaryEntry>();
+        entries = result;
+        if (value == null)
+        {
+            return false;
+        }
+
+        if (maximumItems <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumItems));
+        }
+
+        if (value is PSObject psObject)
+        {
+            value = psObject.BaseObject;
+        }
+
+        if (value is IDictionary dictionary)
+        {
+            foreach (DictionaryEntry entry in dictionary)
+            {
+                AddBounded(result, new PowerShellDictionaryEntry(entry.Key, entry.Value), maximumItems);
+            }
+
+            return true;
+        }
+
+        var type = value.GetType();
+        if (!DictionaryTypeCache.GetOrAdd(type, IsGenericDictionaryType) || value is not IEnumerable enumerable)
+        {
+            return false;
+        }
+
+        foreach (var item in enumerable)
+        {
+            if (item == null)
+            {
+                continue;
+            }
+
+            var accessor = EntryAccessorCache.GetOrAdd(item.GetType(), CreateEntryAccessor);
+            if (!accessor.IsValid)
+            {
+                result.Clear();
+                return false;
+            }
+
+            AddBounded(
+                result,
+                new PowerShellDictionaryEntry(accessor.Key!.GetValue(item), accessor.Value!.GetValue(item)),
+                maximumItems);
+        }
+
+        return true;
+    }
+
+    public static object? GetValue(
+        IReadOnlyList<PowerShellDictionaryEntry> entries,
+        string column,
+        StringComparison comparison = StringComparison.OrdinalIgnoreCase)
+    {
+        foreach (var entry in entries)
+        {
+            if (string.Equals(entry.Key?.ToString(), column, comparison))
+            {
+                return entry.Value;
+            }
+        }
+
+        return null;
+    }
+
+    private static void AddBounded(
+        ICollection<PowerShellDictionaryEntry> entries,
+        PowerShellDictionaryEntry entry,
+        int maximumItems)
+    {
+        if (entries.Count >= maximumItems)
+        {
+            throw new InvalidDataException($"The dictionary exceeds the {maximumItems}-item normalization limit.");
+        }
+
+        entries.Add(entry);
+    }
+
+    private static bool IsGenericDictionaryType(Type type)
+    {
+        return type.GetInterfaces().Any(interfaceType =>
+        {
+            if (!interfaceType.IsGenericType)
+            {
+                return false;
+            }
+
+            var definition = interfaceType.GetGenericTypeDefinition();
+            return definition == typeof(IDictionary<,>) || definition == typeof(IReadOnlyDictionary<,>);
+        });
+    }
+
+    private static DictionaryEntryAccessor CreateEntryAccessor(Type type)
+    {
+        return new DictionaryEntryAccessor(
+            type.GetProperty("Key", BindingFlags.Instance | BindingFlags.Public),
+            type.GetProperty("Value", BindingFlags.Instance | BindingFlags.Public));
+    }
+
+    private sealed class DictionaryEntryAccessor
+    {
+        public DictionaryEntryAccessor(PropertyInfo? key, PropertyInfo? value)
+        {
+            Key = key;
+            Value = value;
+        }
+
+        public PropertyInfo? Key { get; }
+        public PropertyInfo? Value { get; }
+        public bool IsValid => Key?.CanRead == true && Value?.CanRead == true;
+    }
+}
+
+internal readonly struct PowerShellDictionaryEntry
+{
+    public PowerShellDictionaryEntry(object? key, object? value)
+    {
+        Key = key;
+        Value = value;
+    }
+
+    public object? Key { get; }
+    public object? Value { get; }
+}

--- a/Sources/PSWriteOffice/Services/PowerShellObjectNormalizer.DataRow.cs
+++ b/Sources/PSWriteOffice/Services/PowerShellObjectNormalizer.DataRow.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Management.Automation;
+
+namespace PSWriteOffice.Services;
+
+/// <summary>Contains ADO.NET row projection for the shared PowerShell object normalizer.</summary>
+internal static partial class PowerShellObjectNormalizer
+{
+    private static Dictionary<string, object?> ProjectDataRowDictionary(
+        DataRow row,
+        PowerShellObjectNormalizerOptions options)
+    {
+        var columns = row.Table.Columns;
+        var result = new Dictionary<string, object?>(columns.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (DataColumn column in columns)
+        {
+            result[column.ColumnName] = NormalizeCellValue(row[column], options);
+        }
+
+        return result;
+    }
+
+    private static bool TryGetDataRow(object item, out DataRow row)
+    {
+        if (item is PSObject psObject)
+        {
+            item = psObject.BaseObject;
+        }
+
+        if (item is DataRow dataRow)
+        {
+            row = dataRow;
+            return true;
+        }
+
+        if (item is DataRowView dataRowView)
+        {
+            row = dataRowView.Row;
+            return true;
+        }
+
+        row = null!;
+        return false;
+    }
+
+    private static void ProjectDataRow(
+        DataRow row,
+        string[]? columns,
+        out string[] projectedColumns,
+        out object?[] values,
+        PowerShellObjectNormalizerOptions options)
+    {
+        if (columns == null)
+        {
+            var tableColumns = row.Table.Columns;
+            projectedColumns = new string[tableColumns.Count];
+            values = new object?[tableColumns.Count];
+            for (var i = 0; i < tableColumns.Count; i++)
+            {
+                var column = tableColumns[i];
+                projectedColumns[i] = column.ColumnName;
+                values[i] = NormalizeCellValue(row[column], options);
+            }
+
+            return;
+        }
+
+        projectedColumns = columns;
+        values = new object?[columns.Length];
+        ProjectDataRowInto(row, columns, values, options);
+    }
+
+    private static void ProjectDataRowInto(
+        DataRow row,
+        string[] columns,
+        object?[] values,
+        PowerShellObjectNormalizerOptions options)
+    {
+        for (var i = 0; i < columns.Length; i++)
+        {
+            var column = GetDataColumn(row.Table.Columns, columns[i]);
+            values[i] = column == null ? null : NormalizeCellValue(row[column], options);
+        }
+    }
+
+    private static DataColumn? GetDataColumn(DataColumnCollection columns, string columnName)
+    {
+        if (columns.Contains(columnName))
+        {
+            return columns[columnName];
+        }
+
+        foreach (DataColumn column in columns)
+        {
+            if (string.Equals(column.ColumnName, columnName, StringComparison.OrdinalIgnoreCase))
+            {
+                return column;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Sources/PSWriteOffice/Services/PowerShellObjectNormalizer.cs
+++ b/Sources/PSWriteOffice/Services/PowerShellObjectNormalizer.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 
 namespace PSWriteOffice.Services;
 
-internal static class PowerShellObjectNormalizer
+internal static partial class PowerShellObjectNormalizer
 {
     private static readonly ConcurrentDictionary<Type, bool> ClrProjectionCandidateCache = new();
     private static readonly ConcurrentDictionary<Type, ClrProjectionPlan> ClrProjectionPlanCache = new();
@@ -50,9 +50,9 @@ internal static class PowerShellObjectNormalizer
             return NormalizePSObject(psObject, options);
         }
 
-        if (item is IDictionary dict)
+        if (PowerShellDictionaryAdapter.TryGetEntries(item, options.MaxCollectionItems, out var dictionaryEntries))
         {
-            return dict;
+            return ProjectDictionaryMap(dictionaryEntries, options);
         }
 
         if (IsScalarClrType(item.GetType()))
@@ -60,9 +60,9 @@ internal static class PowerShellObjectNormalizer
             return NormalizeCellValue(item, options);
         }
 
-        if (TryGetClrProjectionPlan(item.GetType(), out _))
+        if (TryGetClrProjectionPlan(item.GetType(), out var plan))
         {
-            return item;
+            return ProjectClrObjectMap(item, plan, options);
         }
 
         return NormalizePSObject(PSObject.AsPSObject(item), options);
@@ -78,6 +78,13 @@ internal static class PowerShellObjectNormalizer
         }
 
         return NormalizeCellValueToText(value, options) ?? string.Empty;
+    }
+
+    /// <summary>Normalizes one value while preserving scalar types used by Office file formats.</summary>
+    public static object? NormalizeCellValueForTable(object? value, PowerShellObjectNormalizerOptions? options = null)
+    {
+        options ??= PowerShellObjectNormalizerOptions.Default;
+        return NormalizeCellValue(value, options);
     }
 
     public static bool TryProjectItem(object? item, string[]? columns, out string[] projectedColumns, out object?[] values, PowerShellObjectNormalizerOptions? options = null)
@@ -107,9 +114,9 @@ internal static class PowerShellObjectNormalizer
             return TryProjectPSObject(psObject, columns, out projectedColumns, out values, options);
         }
 
-        if (item is IDictionary dictionary)
+        if (PowerShellDictionaryAdapter.TryGetEntries(item, options.MaxCollectionItems, out var dictionaryEntries))
         {
-            ProjectDictionary(dictionary, columns, out projectedColumns, out values);
+            ProjectDictionary(dictionaryEntries, columns, out projectedColumns, out values, options);
             return true;
         }
 
@@ -155,9 +162,9 @@ internal static class PowerShellObjectNormalizer
             return true;
         }
 
-        if (item is IDictionary dictionary)
+        if (PowerShellDictionaryAdapter.TryGetEntries(item, options.MaxCollectionItems, out var dictionaryEntries))
         {
-            ProjectDictionaryInto(dictionary, columns, values);
+            ProjectDictionaryInto(dictionaryEntries, columns, values, options);
             return true;
         }
 
@@ -188,7 +195,7 @@ internal static class PowerShellObjectNormalizer
 
         options ??= PowerShellObjectNormalizerOptions.Default;
 
-        if (item == null || item is IDictionary)
+        if (item == null || PowerShellDictionaryAdapter.IsDictionaryLike(item))
         {
             return false;
         }
@@ -199,7 +206,7 @@ internal static class PowerShellObjectNormalizer
         }
 
         var ps = item as PSObject ?? PSObject.AsPSObject(item);
-        if (ps.BaseObject is IDictionary)
+        if (PowerShellDictionaryAdapter.IsDictionaryLike(ps.BaseObject))
         {
             return false;
         }
@@ -263,7 +270,7 @@ internal static class PowerShellObjectNormalizer
 
         options ??= PowerShellObjectNormalizerOptions.Default;
 
-        if (item == null || item is IDictionary)
+        if (item == null || PowerShellDictionaryAdapter.IsDictionaryLike(item))
         {
             return false;
         }
@@ -274,7 +281,7 @@ internal static class PowerShellObjectNormalizer
         }
 
         var ps = item as PSObject ?? PSObject.AsPSObject(item);
-        if (ps.BaseObject is IDictionary)
+        if (PowerShellDictionaryAdapter.IsDictionaryLike(ps.BaseObject))
         {
             return false;
         }
@@ -470,9 +477,9 @@ internal static class PowerShellObjectNormalizer
 
     private static object? NormalizePSObject(PSObject ps, PowerShellObjectNormalizerOptions options)
     {
-        if (ps.BaseObject is IDictionary dict)
+        if (PowerShellDictionaryAdapter.TryGetEntries(ps.BaseObject, options.MaxCollectionItems, out var dictionaryEntries))
         {
-            return dict;
+            return ProjectDictionaryMap(dictionaryEntries, options);
         }
 
         Dictionary<string, object?>? result = null;
@@ -519,9 +526,9 @@ internal static class PowerShellObjectNormalizer
 
     private static bool TryProjectPSObject(PSObject ps, string[]? columns, out string[] projectedColumns, out object?[] values, PowerShellObjectNormalizerOptions options)
     {
-        if (ps.BaseObject is IDictionary dictionary)
+        if (PowerShellDictionaryAdapter.TryGetEntries(ps.BaseObject, options.MaxCollectionItems, out var dictionaryEntries))
         {
-            ProjectDictionary(dictionary, columns, out projectedColumns, out values);
+            ProjectDictionary(dictionaryEntries, columns, out projectedColumns, out values, options);
             return true;
         }
 
@@ -598,9 +605,9 @@ internal static class PowerShellObjectNormalizer
 
     private static void ProjectPSObjectInto(PSObject ps, string[] columns, object?[] values, PowerShellObjectNormalizerOptions options)
     {
-        if (ps.BaseObject is IDictionary dictionary)
+        if (PowerShellDictionaryAdapter.TryGetEntries(ps.BaseObject, options.MaxCollectionItems, out var dictionaryEntries))
         {
-            ProjectDictionaryInto(dictionary, columns, values);
+            ProjectDictionaryInto(dictionaryEntries, columns, values, options);
             return;
         }
 
@@ -637,22 +644,28 @@ internal static class PowerShellObjectNormalizer
         }
     }
 
-    private static void ProjectDictionary(IDictionary dictionary, string[]? columns, out string[] projectedColumns, out object?[] values)
+    private static void ProjectDictionary(
+        IReadOnlyList<PowerShellDictionaryEntry> entries,
+        string[]? columns,
+        out string[] projectedColumns,
+        out object?[] values,
+        PowerShellObjectNormalizerOptions options)
     {
         if (columns == null)
         {
             var names = new List<string>();
             var rowValues = new List<object?>();
-            foreach (DictionaryEntry entry in dictionary)
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var entry in entries)
             {
                 var key = entry.Key?.ToString();
-                if (string.IsNullOrWhiteSpace(key))
+                if (string.IsNullOrWhiteSpace(key) || !seen.Add(key!))
                 {
                     continue;
                 }
 
                 names.Add(key!);
-                rowValues.Add(entry.Value);
+                rowValues.Add(NormalizeCellValue(entry.Value, options));
             }
 
             projectedColumns = names.ToArray();
@@ -664,82 +677,39 @@ internal static class PowerShellObjectNormalizer
         values = new object?[columns.Length];
         for (var i = 0; i < columns.Length; i++)
         {
-            values[i] = GetDictionaryValue(dictionary, columns[i]);
+            values[i] = NormalizeCellValue(PowerShellDictionaryAdapter.GetValue(entries, columns[i]), options);
         }
     }
 
-    private static void ProjectDictionaryInto(IDictionary dictionary, string[] columns, object?[] values)
+    private static void ProjectDictionaryInto(
+        IReadOnlyList<PowerShellDictionaryEntry> entries,
+        string[] columns,
+        object?[] values,
+        PowerShellObjectNormalizerOptions options)
     {
         for (var i = 0; i < columns.Length; i++)
         {
-            values[i] = GetDictionaryValue(dictionary, columns[i]);
+            values[i] = NormalizeCellValue(PowerShellDictionaryAdapter.GetValue(entries, columns[i]), options);
         }
     }
 
-    private static Dictionary<string, object?> ProjectDataRowDictionary(DataRow row, PowerShellObjectNormalizerOptions options)
+    private static Dictionary<string, object?> ProjectDictionaryMap(
+        IReadOnlyList<PowerShellDictionaryEntry> entries,
+        PowerShellObjectNormalizerOptions options)
     {
-        var columns = row.Table.Columns;
-        var result = new Dictionary<string, object?>(columns.Count, StringComparer.OrdinalIgnoreCase);
-        foreach (DataColumn column in columns)
+        var result = new Dictionary<string, object?>(entries.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in entries)
         {
-            result[column.ColumnName] = NormalizeCellValue(row[column], options);
+            var key = entry.Key?.ToString();
+            if (string.IsNullOrWhiteSpace(key) || result.ContainsKey(key!))
+            {
+                continue;
+            }
+
+            result[key!] = NormalizeCellValue(entry.Value, options);
         }
 
         return result;
-    }
-
-    private static bool TryGetDataRow(object item, out DataRow row)
-    {
-        if (item is PSObject psObject)
-        {
-            item = psObject.BaseObject;
-        }
-
-        if (item is DataRow dataRow)
-        {
-            row = dataRow;
-            return true;
-        }
-
-        if (item is DataRowView dataRowView)
-        {
-            row = dataRowView.Row;
-            return true;
-        }
-
-        row = null!;
-        return false;
-    }
-
-    private static void ProjectDataRow(DataRow row, string[]? columns, out string[] projectedColumns, out object?[] values, PowerShellObjectNormalizerOptions options)
-    {
-        if (columns == null)
-        {
-            var tableColumns = row.Table.Columns;
-            projectedColumns = new string[tableColumns.Count];
-            values = new object?[tableColumns.Count];
-            for (var i = 0; i < tableColumns.Count; i++)
-            {
-                var column = tableColumns[i];
-                projectedColumns[i] = column.ColumnName;
-                values[i] = NormalizeCellValue(row[column], options);
-            }
-
-            return;
-        }
-
-        projectedColumns = columns;
-        values = new object?[columns.Length];
-        ProjectDataRowInto(row, columns, values, options);
-    }
-
-    private static void ProjectDataRowInto(DataRow row, string[] columns, object?[] values, PowerShellObjectNormalizerOptions options)
-    {
-        for (var i = 0; i < columns.Length; i++)
-        {
-            var column = GetDataColumn(row.Table.Columns, columns[i]);
-            values[i] = column == null ? null : NormalizeCellValue(row[column], options);
-        }
     }
 
     private static void ProjectClrObject(object item, ClrProjectionPlan plan, string[]? columns, out string[] projectedColumns, out object?[] values, PowerShellObjectNormalizerOptions options)
@@ -777,6 +747,23 @@ internal static class PowerShellObjectNormalizer
 
             values[i] = value;
         }
+    }
+
+    private static Dictionary<string, object?> ProjectClrObjectMap(
+        object item,
+        ClrProjectionPlan plan,
+        PowerShellObjectNormalizerOptions options)
+    {
+        var result = new Dictionary<string, object?>(plan.Properties.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var property in plan.Properties)
+        {
+            if (TryReadClrProperty(item, property, property.Name, options, out var value))
+            {
+                result[property.Name] = value;
+            }
+        }
+
+        return result;
     }
 
     private static void ProjectClrObjectInto(object item, ClrProjectionPlan plan, string[] columns, object?[] values, PowerShellObjectNormalizerOptions options)
@@ -826,42 +813,6 @@ internal static class PowerShellObjectNormalizer
     private static Exception UnwrapClrPropertyException(Exception exception) =>
         exception is TargetInvocationException { InnerException: not null } ? exception.InnerException : exception;
 
-    private static object? GetDictionaryValue(IDictionary dictionary, string column)
-    {
-        if (dictionary.Contains(column))
-        {
-            return dictionary[column];
-        }
-
-        foreach (DictionaryEntry entry in dictionary)
-        {
-            if (string.Equals(entry.Key?.ToString(), column, StringComparison.OrdinalIgnoreCase))
-            {
-                return entry.Value;
-            }
-        }
-
-        return null;
-    }
-
-    private static DataColumn? GetDataColumn(DataColumnCollection columns, string columnName)
-    {
-        if (columns.Contains(columnName))
-        {
-            return columns[columnName];
-        }
-
-        foreach (DataColumn column in columns)
-        {
-            if (string.Equals(column.ColumnName, columnName, StringComparison.OrdinalIgnoreCase))
-            {
-                return column;
-            }
-        }
-
-        return null;
-    }
-
     private static bool ShouldExportProperty(PSPropertyInfo property)
     {
         if (!property.IsGettable)
@@ -883,20 +834,9 @@ internal static class PowerShellObjectNormalizer
             return normalized;
         }
 
-        if (value is IDictionary)
+        if (PowerShellCellValueFormatter.TryFormatComplexValue(value, options, out var complexText))
         {
-            return value;
-        }
-
-        if (value is IEnumerable enumerable)
-        {
-            var values = new List<string>();
-            foreach (var item in enumerable)
-            {
-                values.Add(ConvertValueToString(item));
-            }
-
-            return string.Join(options.CollectionSeparator, values);
+            return complexText;
         }
 
         return value;
@@ -931,20 +871,9 @@ internal static class PowerShellObjectNormalizer
             return charValue.ToString();
         }
 
-        if (value is IDictionary)
+        if (PowerShellCellValueFormatter.TryFormatComplexValue(value, options, out var complexText))
         {
-            return value.ToString();
-        }
-
-        if (options.NormalizeCollectionValues && value is IEnumerable enumerable)
-        {
-            var values = new List<string>();
-            foreach (var item in enumerable)
-            {
-                values.Add(ConvertValueToString(item));
-            }
-
-            return string.Join(options.CollectionSeparator, values);
+            return complexText;
         }
 
         return value is IFormattable fallbackFormattable
@@ -985,16 +914,6 @@ internal static class PowerShellObjectNormalizer
         }
 
         return false;
-    }
-
-    private static string ConvertValueToString(object? value)
-    {
-        if (value == null)
-        {
-            return string.Empty;
-        }
-
-        return LanguagePrimitives.ConvertTo(value, typeof(string), CultureInfo.InvariantCulture) as string ?? string.Empty;
     }
 
     private static bool TryGetClrProjectionPlan(Type type, out ClrProjectionPlan plan)
@@ -1071,25 +990,4 @@ internal static class PowerShellObjectNormalizer
         public IReadOnlyDictionary<string, PropertyInfo> PropertiesByName { get; }
     }
 
-}
-
-internal sealed class PowerShellObjectNormalizerOptions
-{
-    internal static readonly PowerShellObjectNormalizerOptions Default = new();
-
-    public bool IncludeUnexportableProperties { get; set; }
-
-    public ActionPreference PropertyErrorAction { get; set; } = ActionPreference.SilentlyContinue;
-
-    public Action<string, Exception>? PropertyErrorCallback { get; set; }
-
-    public Func<string, Exception, object?>? UnexportablePropertyValueFactory { get; set; }
-
-    public bool NormalizeCollectionValues { get; set; } = true;
-
-    public string CollectionSeparator { get; set; } = ", ";
-
-    public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
-
-    public bool FormatScalarValuesAsText { get; set; }
 }

--- a/Sources/PSWriteOffice/Services/PowerShellObjectNormalizerOptions.cs
+++ b/Sources/PSWriteOffice/Services/PowerShellObjectNormalizerOptions.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Globalization;
+using System.Management.Automation;
+
+namespace PSWriteOffice.Services;
+
+/// <summary>Controls how PowerShell and CLR values are projected into Office table cells.</summary>
+internal sealed class PowerShellObjectNormalizerOptions
+{
+    internal static readonly PowerShellObjectNormalizerOptions Default = new();
+
+    public bool IncludeUnexportableProperties { get; set; }
+
+    public ActionPreference PropertyErrorAction { get; set; } = ActionPreference.SilentlyContinue;
+
+    public Action<string, Exception>? PropertyErrorCallback { get; set; }
+
+    public Func<string, Exception, object?>? UnexportablePropertyValueFactory { get; set; }
+
+    public bool NormalizeCollectionValues { get; set; } = true;
+
+    public string CollectionSeparator { get; set; } = ", ";
+
+    public string DictionaryEntrySeparator { get; set; } = "; ";
+
+    public string DictionaryKeyValueSeparator { get; set; } = ": ";
+
+    public int MaxCollectionItems { get; set; } = 1_048_575;
+
+    public int MaxNestingDepth { get; set; } = 64;
+
+    public CultureInfo Culture { get; set; } = CultureInfo.InvariantCulture;
+
+    public bool FormatScalarValuesAsText { get; set; }
+
+    public static PowerShellObjectNormalizerOptions ForTable(
+        string collectionSeparator,
+        string dictionaryEntrySeparator,
+        string dictionaryKeyValueSeparator)
+    {
+        return new PowerShellObjectNormalizerOptions
+        {
+            CollectionSeparator = collectionSeparator,
+            DictionaryEntrySeparator = dictionaryEntrySeparator,
+            DictionaryKeyValueSeparator = dictionaryKeyValueSeparator
+        };
+    }
+}

--- a/Sources/PSWriteOffice/Services/Table/OfficeTableSpecParser.cs
+++ b/Sources/PSWriteOffice/Services/Table/OfficeTableSpecParser.cs
@@ -315,7 +315,7 @@ internal static class OfficeTableSpecParser
     {
         row = UnwrapPSObject(row)!;
         return row is IEnumerable and not string and not IDictionary and not DataTable and not DataView and not IDataReader and not DataSet &&
-               !IsGenericDictionary(row);
+               !PowerShellDictionaryAdapter.IsDictionaryLike(row);
     }
 
     private static IEnumerable<object?> Enumerate(object row)
@@ -422,23 +422,4 @@ internal static class OfficeTableSpecParser
     private static object? UnwrapPSObject(object? value)
         => value is PSObject psObject ? psObject.BaseObject : value;
 
-    private static bool IsGenericDictionary(object value)
-    {
-        foreach (var interfaceType in value.GetType().GetInterfaces())
-        {
-            if (!interfaceType.IsGenericType)
-            {
-                continue;
-            }
-
-            var genericDefinition = interfaceType.GetGenericTypeDefinition();
-            if (genericDefinition == typeof(IDictionary<,>) ||
-                genericDefinition == typeof(IReadOnlyDictionary<,>))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
 }

--- a/Sources/PSWriteOffice/Services/Table/TableInputCollector.cs
+++ b/Sources/PSWriteOffice/Services/Table/TableInputCollector.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
+using PSWriteOffice.Services;
 
 namespace PSWriteOffice.Services.Table;
 
@@ -62,27 +63,7 @@ internal static class TableInputCollector
             and not IDictionary
             and not IDataReader
             and not DataSet
-            && !IsGenericDictionary(value)
+            && !PowerShellDictionaryAdapter.IsDictionaryLike(value)
             && (!preserveTabularInput || value is not DataTable && value is not DataView);
-    }
-
-    private static bool IsGenericDictionary(object value)
-    {
-        foreach (var interfaceType in value.GetType().GetInterfaces())
-        {
-            if (!interfaceType.IsGenericType)
-            {
-                continue;
-            }
-
-            var genericDefinition = interfaceType.GetGenericTypeDefinition();
-            if (genericDefinition == typeof(IDictionary<,>) ||
-                genericDefinition == typeof(IReadOnlyDictionary<,>))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/Sources/PSWriteOffice/Services/Table/TableViewProjection.cs
+++ b/Sources/PSWriteOffice/Services/Table/TableViewProjection.cs
@@ -15,26 +15,36 @@ internal static class TableViewProjection
     {
         return view switch
         {
-            OfficeTableView.Normal => rows.ToArray(),
-            OfficeTableView.Transpose => TransposeRows(ExpandSingleTabularInput(rows)),
+            OfficeTableView.Normal => ExpandTabularInputs(rows).ToArray(),
+            OfficeTableView.Transpose => TransposeRows(ExpandTabularInputs(rows)),
             _ => throw new PSArgumentException($"Unsupported table view '{view}'.", nameof(view))
         };
     }
 
-    private static IReadOnlyList<object> ExpandSingleTabularInput(IReadOnlyList<object> rows)
+    private static IReadOnlyList<object> ExpandTabularInputs(IReadOnlyList<object> rows)
     {
-        if (rows.Count != 1)
+        var expanded = new List<object>(rows.Count);
+        foreach (var row in rows)
         {
-            return rows;
+            var source = row is PSObject psObject ? psObject.BaseObject : row;
+            switch (source)
+            {
+                case DataTable table:
+                    expanded.AddRange(table.Rows.Cast<DataRow>().Cast<object>());
+                    break;
+                case DataView view:
+                    expanded.AddRange(view.Cast<DataRowView>().Cast<object>());
+                    break;
+                case IDataReader reader:
+                    expanded.AddRange(ReadDataReaderRows(reader));
+                    break;
+                default:
+                    expanded.Add(row);
+                    break;
+            }
         }
 
-        return rows[0] switch
-        {
-            DataTable table => table.Rows.Cast<DataRow>().Cast<object>().ToArray(),
-            DataView view => view.Cast<DataRowView>().Cast<object>().ToArray(),
-            IDataReader reader => ReadDataReaderRows(reader),
-            _ => rows
-        };
+        return expanded;
     }
 
     private static IReadOnlyList<object> ReadDataReaderRows(IDataReader reader)

--- a/Tests/TabularInputContracts.Tests.ps1
+++ b/Tests/TabularInputContracts.Tests.ps1
@@ -1,0 +1,426 @@
+BeforeAll {
+    if (-not $env:PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES) {
+        $env:PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES = 'true'
+    }
+    if (-not $env:PSWRITEOFFICE_DEVELOPMENT_CONFIGURATION) {
+        $env:PSWRITEOFFICE_DEVELOPMENT_CONFIGURATION = 'Debug'
+    }
+
+    $ModuleManifest = if ($env:PSWRITEOFFICE_MODULE_MANIFEST) {
+        $env:PSWRITEOFFICE_MODULE_MANIFEST
+    } else {
+        Join-Path $PSScriptRoot '..\PSWriteOffice.psd1'
+    }
+    Import-Module $ModuleManifest -Global -Force -ErrorAction Stop
+
+    if (-not ('PSWriteOffice.Tests.TabularContractRow' -as [type])) {
+        Add-Type -TypeDefinition @'
+using System.Collections.Generic;
+
+namespace PSWriteOffice.Tests {
+    public sealed class TabularContractRow {
+        public string Name { get; set; }
+        public string[] Tags { get; set; }
+        public Dictionary<string, object> Metadata { get; set; }
+    }
+
+    public sealed class ReadOnlyTabularContractRow : IReadOnlyDictionary<string, object> {
+        private readonly KeyValuePair<string, object>[] _entries;
+        private readonly Dictionary<string, object> _lookup;
+
+        public ReadOnlyTabularContractRow(IDictionary<string, object> values) {
+            _lookup = new Dictionary<string, object>(values, System.StringComparer.OrdinalIgnoreCase);
+            _entries = new List<KeyValuePair<string, object>>(values).ToArray();
+        }
+
+        public object this[string key] { get { return _lookup[key]; } }
+        public IEnumerable<string> Keys { get { foreach (var entry in _entries) yield return entry.Key; } }
+        public IEnumerable<object> Values { get { foreach (var entry in _entries) yield return entry.Value; } }
+        public int Count { get { return _entries.Length; } }
+        public bool ContainsKey(string key) { return _lookup.ContainsKey(key); }
+        public bool TryGetValue(string key, out object value) { return _lookup.TryGetValue(key, out value); }
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator() {
+            return ((IEnumerable<KeyValuePair<string, object>>)_entries).GetEnumerator();
+        }
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return _entries.GetEnumerator(); }
+    }
+}
+'@
+    }
+
+    function New-TestTabularContractReader {
+        $table = [System.Data.DataTable]::new('Rows')
+        [void] $table.Columns.Add('Name', [string])
+        [void] $table.Columns.Add('Tags', [object])
+        [void] $table.Columns.Add('Metadata', [object])
+        [void] $table.Rows.Add(
+            'Alpha',
+            [object] @('One', 'Two'),
+            [object] ([ordered]@{ Region = 'EU'; Tier = 1 }))
+        return ,$table.CreateDataReader()
+    }
+}
+
+Describe 'Shared tabular input contracts' {
+    It 'exposes nested value formatting consistently across table outputs' {
+        $commands = @(
+            'Add-OfficeExcelTable'
+            'Export-OfficeExcel'
+            'Add-OfficeExcelReportTable'
+            'Add-OfficeWordTable'
+            'Add-OfficePowerPointTable'
+            'Add-OfficePdfTable'
+            'Add-OfficeMarkdownTable'
+            'ConvertTo-OfficeMarkdown'
+        )
+
+        foreach ($commandName in $commands) {
+            $parameters = (Get-Command $commandName -ErrorAction Stop).Parameters.Keys
+            $parameters | Should -Contain 'CollectionSeparator'
+            $parameters | Should -Contain 'DictionaryEntrySeparator'
+            $parameters | Should -Contain 'DictionaryKeyValueSeparator'
+        }
+    }
+
+    It 'renders object and dictionary row families through Excel report tables' {
+        $genericDictionary = [System.Collections.Generic.Dictionary[string, object]]::new()
+        $genericDictionary.Add('Name', 'GenericDictionary')
+        $genericDictionary.Add('Value', 3)
+
+        $cases = @(
+            [pscustomobject]@{
+                Name  = 'PSCustomObject'
+                Input = [pscustomobject]@{ Name = 'PSCustomObject'; Value = 1 }
+            }
+            [pscustomobject]@{
+                Name  = 'OrderedDictionary'
+                Input = [ordered]@{ Name = 'OrderedDictionary'; Value = 2 }
+            }
+            [pscustomobject]@{
+                Name  = 'GenericDictionary'
+                Input = $genericDictionary
+            }
+            [pscustomobject]@{
+                Name  = 'ClrObject'
+                Input = [System.Collections.DictionaryEntry]::new('ClrObject', 4)
+            }
+        )
+
+        foreach ($case in $cases) {
+            $path = Join-Path $TestDrive ("Report-{0}.xlsx" -f $case.Name)
+            $inputRow = $case.Input
+
+            New-OfficeExcel -Path $path {
+                Add-OfficeExcelReportSheet -Name 'Report' {
+                    Add-OfficeExcelReportTable -InputObject $inputRow
+                }
+            }
+
+            $rows = @(Import-OfficeExcel -Path $path -WorksheetName 'Report')
+            $rows.Count | Should -Be 1
+
+            if ($case.Name -eq 'ClrObject') {
+                $rows[0].Key | Should -Be 'ClrObject'
+                $rows[0].Value | Should -Be 4
+            } else {
+                $rows[0].Name | Should -Be $case.Name
+                $rows[0].Value | Should -BeGreaterThan 0
+            }
+        }
+    }
+
+    It 'renders ADO.NET tabular input families without DataRow metadata' {
+        $createTable = {
+            $table = [System.Data.DataTable]::new('Rows')
+            [void] $table.Columns.Add('Name', [string])
+            [void] $table.Columns.Add('Value', [int])
+            [void] $table.Rows.Add('Alpha', 7)
+            return ,$table
+        }
+
+        $inputFactories = [ordered]@{
+            DataTable   = { & $createTable }
+            DataView    = { (& $createTable).DefaultView }
+            DataRow     = { (& $createTable).Rows[0] }
+            IDataReader = { return ,((& $createTable).CreateDataReader()) }
+        }
+
+        foreach ($entry in $inputFactories.GetEnumerator()) {
+            $path = Join-Path $TestDrive ("Report-{0}.xlsx" -f $entry.Key)
+            $inputRows = & $entry.Value
+            try {
+                New-OfficeExcel -Path $path {
+                    Add-OfficeExcelReportSheet -Name 'Report' {
+                        Add-OfficeExcelReportTable -InputObject $inputRows
+                    }
+                }
+            } finally {
+                if ($inputRows -is [System.Data.IDataReader]) {
+                    $inputRows.Dispose()
+                }
+            }
+
+            $rows = @(Import-OfficeExcel -Path $path -WorksheetName 'Report')
+            $rows.Count | Should -Be 1 -Because $entry.Key
+            $rows[0].Name | Should -Be 'Alpha' -Because $entry.Key
+            $rows[0].Value | Should -Be 7 -Because $entry.Key
+            $rows[0].PSObject.Properties.Name | Should -Not -Contain 'RowError'
+            $rows[0].PSObject.Properties.Name | Should -Not -Contain 'Table'
+        }
+    }
+
+    It 'renders scalar input as a single Value column' {
+        $path = Join-Path $TestDrive 'Report-Scalar.xlsx'
+
+        New-OfficeExcel -Path $path {
+            Add-OfficeExcelReportSheet -Name 'Report' {
+                Add-OfficeExcelReportTable -InputObject 'Scalar value'
+            }
+        }
+
+        $rows = @(Import-OfficeExcel -Path $path -WorksheetName 'Report')
+        $rows.Count | Should -Be 1
+        $rows[0].Value | Should -Be 'Scalar value'
+    }
+
+    It 'formats nested collections and dictionaries identically in Excel and Markdown tables' {
+        $inputRow = [pscustomobject]@{
+            Name     = 'Alpha'
+            Tags     = @('One', 'Two')
+            Metadata = [ordered]@{ Region = 'EU'; Tier = 1 }
+        }
+        $excelPath = Join-Path $TestDrive 'Report-NestedValues.xlsx'
+
+        New-OfficeExcel -Path $excelPath {
+            Add-OfficeExcelReportSheet -Name 'Report' {
+                Add-OfficeExcelReportTable -InputObject $inputRow `
+                    -CollectionSeparator ' | ' `
+                    -DictionaryEntrySeparator '; ' `
+                    -DictionaryKeyValueSeparator ': '
+            }
+        }
+
+        $excelRows = @(Import-OfficeExcel -Path $excelPath -WorksheetName 'Report')
+        $excelRows[0].Tags | Should -Be 'One | Two'
+        $excelRows[0].Metadata | Should -Be 'Region: EU; Tier: 1'
+
+        $markdownPath = Join-Path $TestDrive 'Report-NestedValues.md'
+        New-OfficeMarkdown -Path $markdownPath {
+            Add-OfficeMarkdownTable -InputObject $inputRow `
+                -CollectionSeparator ' | ' `
+                -DictionaryEntrySeparator '; ' `
+                -DictionaryKeyValueSeparator ': '
+        }
+
+        $markdown = Get-Content -LiteralPath $markdownPath -Raw
+        $markdown | Should -Match ([regex]::Escape('One \| Two'))
+        $markdown | Should -Match 'Region: EU; Tier: 1'
+
+        $convertedMarkdown = $inputRow | ConvertTo-OfficeMarkdown `
+            -CollectionSeparator ' | ' `
+            -DictionaryEntrySeparator '; ' `
+            -DictionaryKeyValueSeparator ': '
+        $convertedMarkdown | Should -Match ([regex]::Escape('One \| Two'))
+        $convertedMarkdown | Should -Match 'Region: EU; Tier: 1'
+    }
+
+    It 'supports column inclusion and exclusion on Excel report tables' {
+        $path = Join-Path $TestDrive 'Report-Projection.xlsx'
+        $inputRow = [pscustomobject]@{ Name = 'Alpha'; Value = 1; Internal = 'Hidden' }
+
+        New-OfficeExcel -Path $path {
+            Add-OfficeExcelReportSheet -Name 'Report' {
+                Add-OfficeExcelReportTable -InputObject $inputRow -Property Value, Name -ExcludeProperty Internal
+            }
+        }
+
+        $rows = @(Import-OfficeExcel -Path $path -WorksheetName 'Report')
+        $rows[0].PSObject.Properties.Name | Should -Be @('Value', 'Name')
+        $rows[0].Value | Should -Be 1
+        $rows[0].Name | Should -Be 'Alpha'
+    }
+
+    It 'streams IDataReader rows with shared nested formatting into direct Excel exports' {
+        $path = Join-Path $TestDrive 'DirectReader.xlsx'
+        $reader = New-TestTabularContractReader
+        try {
+            Export-OfficeExcel -Path $path -InputObject $reader `
+                -CollectionSeparator ' | ' `
+                -DictionaryEntrySeparator '; ' `
+                -DictionaryKeyValueSeparator ': '
+        } finally {
+            $reader.Dispose()
+        }
+
+        $rows = @(Import-OfficeExcel -Path $path -WorksheetName 'Sheet1')
+        $rows.Count | Should -Be 1
+        $rows[0].Name | Should -Be 'Alpha'
+        $rows[0].Tags | Should -Be 'One | Two'
+        $rows[0].Metadata | Should -Be 'Region: EU; Tier: 1'
+    }
+
+    It 'normalizes dictionary fast-path exports before OfficeIMO writes the workbook' {
+        $path = Join-Path $TestDrive 'DirectDictionary.xlsx'
+        $row = [ordered]@{
+            Name = 'Alpha'
+            Tags = @('One', 'Two')
+            Metadata = [ordered]@{ Region = 'EU'; Tier = 1 }
+        }
+
+        Export-OfficeExcel -Path $path -InputObject $row `
+            -CollectionSeparator ' | ' `
+            -DictionaryEntrySeparator '; ' `
+            -DictionaryKeyValueSeparator ': '
+
+        $rows = @(Import-OfficeExcel -Path $path -WorksheetName 'Sheet1')
+        $rows[0].Tags | Should -Be 'One | Two'
+        $rows[0].Metadata | Should -Be 'Region: EU; Tier: 1'
+    }
+
+    It 'materializes IDataReader rows consistently across Word PowerPoint PDF and Markdown tables' {
+        $wordPath = Join-Path $TestDrive 'Reader.docx'
+        $reader = New-TestTabularContractReader
+        try {
+            New-OfficeWord -Path $wordPath {
+                Add-OfficeWordTable -InputObject $reader -Style TableGrid `
+                    -CollectionSeparator ' | ' `
+                    -DictionaryEntrySeparator '; ' `
+                    -DictionaryKeyValueSeparator ': '
+            } | Out-Null
+        } finally {
+            $reader.Dispose()
+        }
+
+        $word = Get-OfficeWord -Path $wordPath -ReadOnly
+        try {
+            $word.Tables[0].Rows[1].Cells[0].Paragraphs[0].Text | Should -Be 'Alpha'
+            $word.Tables[0].Rows[1].Cells[1].Paragraphs[0].Text | Should -Be 'One | Two'
+            $word.Tables[0].Rows[1].Cells[2].Paragraphs[0].Text | Should -Be 'Region: EU; Tier: 1'
+        } finally {
+            $word.Dispose()
+        }
+
+        $powerPointPath = Join-Path $TestDrive 'Reader.pptx'
+        $presentation = New-OfficePowerPoint -FilePath $powerPointPath -NoSave
+        try {
+            $slide = Add-OfficePowerPointSlide -Presentation $presentation
+            $reader = New-TestTabularContractReader
+            try {
+                $table = Add-OfficePowerPointTable -Slide $slide -InputObject $reader `
+                    -CollectionSeparator ' | ' `
+                    -DictionaryEntrySeparator '; ' `
+                    -DictionaryKeyValueSeparator ': '
+            } finally {
+                $reader.Dispose()
+            }
+
+            $table.GetCell(1, 0).Text | Should -Be 'Alpha'
+            $table.GetCell(1, 1).Text | Should -Be 'One | Two'
+            $table.GetCell(1, 2).Text | Should -Be 'Region: EU; Tier: 1'
+        } finally {
+            Close-OfficePowerPoint -Presentation $presentation
+        }
+
+        $pdfPath = Join-Path $TestDrive 'Reader.pdf'
+        $reader = New-TestTabularContractReader
+        try {
+            New-OfficePdf -Path $pdfPath {
+                Add-OfficePdfTable -InputObject $reader `
+                    -CollectionSeparator ' | ' `
+                    -DictionaryEntrySeparator '; ' `
+                    -DictionaryKeyValueSeparator ': '
+            } | Out-Null
+        } finally {
+            $reader.Dispose()
+        }
+
+        $pdfText = Get-OfficePdfText -Path $pdfPath
+        $pdfText | Should -Match 'Alpha'
+        $pdfText | Should -Match 'One \| Two'
+        $pdfText | Should -Match 'Region: EU; Tier: 1'
+
+        $markdownPath = Join-Path $TestDrive 'Reader.md'
+        $reader = New-TestTabularContractReader
+        try {
+            New-OfficeMarkdown -Path $markdownPath {
+                Add-OfficeMarkdownTable -InputObject $reader `
+                    -CollectionSeparator ' | ' `
+                    -DictionaryEntrySeparator '; ' `
+                    -DictionaryKeyValueSeparator ': '
+            }
+        } finally {
+            $reader.Dispose()
+        }
+
+        $markdown = Get-Content -LiteralPath $markdownPath -Raw
+        $markdown | Should -Match 'Alpha'
+        $markdown | Should -Match ([regex]::Escape('One \| Two'))
+        $markdown | Should -Match 'Region: EU; Tier: 1'
+    }
+
+    It 'projects CLR rows before nested values reach format-specific writers' {
+        $metadata = [System.Collections.Generic.Dictionary[string, object]]::new()
+        $metadata.Add('Region', 'EU')
+        $metadata.Add('Tier', 1)
+        $row = [PSWriteOffice.Tests.TabularContractRow]::new()
+        $row.Name = 'Alpha'
+        $row.Tags = @('One', 'Two')
+        $row.Metadata = $metadata
+
+        $markdown = $row | ConvertTo-OfficeMarkdown `
+            -CollectionSeparator ' | ' `
+            -DictionaryEntrySeparator '; ' `
+            -DictionaryKeyValueSeparator ': '
+
+        $markdown | Should -Match 'Alpha'
+        $markdown | Should -Match ([regex]::Escape('One \| Two'))
+        $markdown | Should -Match 'Region: EU; Tier: 1'
+    }
+
+    It 'keeps IReadOnlyDictionary-only rows as named columns across table formats' {
+        $values = [System.Collections.Generic.Dictionary[string, object]]::new()
+        $values.Add('Name', 'Alpha')
+        $values.Add('Tags', @('One', 'Two'))
+        $values.Add('Metadata', [ordered]@{ Region = 'EU'; Tier = 1 })
+        $row = [PSWriteOffice.Tests.ReadOnlyTabularContractRow]::new($values)
+
+        $markdown = $row | ConvertTo-OfficeMarkdown -CollectionSeparator ' | '
+        $markdown | Should -Match 'Name'
+        $markdown | Should -Match 'Alpha'
+        $markdown | Should -Match ([regex]::Escape('One \| Two'))
+
+        $wordPath = Join-Path $TestDrive 'ReadOnlyDictionary.docx'
+        New-OfficeWord -Path $wordPath {
+            Add-OfficeWordTable -InputObject $row -Style TableGrid -CollectionSeparator ' | '
+        } | Out-Null
+        $word = Get-OfficeWord -Path $wordPath -ReadOnly
+        try {
+            $word.Tables[0].Rows[0].Cells[0].Paragraphs[0].Text | Should -Be 'Name'
+            $word.Tables[0].Rows[1].Cells[0].Paragraphs[0].Text | Should -Be 'Alpha'
+            $word.Tables[0].Rows[1].Cells[1].Paragraphs[0].Text | Should -Be 'One | Two'
+        } finally {
+            $word.Dispose()
+        }
+
+        $powerPointPath = Join-Path $TestDrive 'ReadOnlyDictionary.pptx'
+        $presentation = New-OfficePowerPoint -FilePath $powerPointPath -NoSave
+        try {
+            $slide = Add-OfficePowerPointSlide -Presentation $presentation
+            $table = Add-OfficePowerPointTable -Slide $slide -InputObject $row -CollectionSeparator ' | '
+            $table.GetCell(0, 0).Text | Should -Be 'Name'
+            $table.GetCell(1, 0).Text | Should -Be 'Alpha'
+            $table.GetCell(1, 1).Text | Should -Be 'One | Two'
+        } finally {
+            Close-OfficePowerPoint -Presentation $presentation
+        }
+
+        $pdfPath = Join-Path $TestDrive 'ReadOnlyDictionary.pdf'
+        New-OfficePdf -Path $pdfPath {
+            Add-OfficePdfTable -InputObject $row -CollectionSeparator ' | '
+        } | Out-Null
+        $pdfText = Get-OfficePdfText -Path $pdfPath
+        $pdfText | Should -Match 'Name'
+        $pdfText | Should -Match 'Alpha'
+        $pdfText | Should -Match 'One \| Two'
+    }
+}

--- a/Tests/TabularInputContracts.Tests.ps1
+++ b/Tests/TabularInputContracts.Tests.ps1
@@ -384,6 +384,32 @@ Describe 'Shared tabular input contracts' {
         $values.Add('Metadata', [ordered]@{ Region = 'EU'; Tier = 1 })
         $row = [PSWriteOffice.Tests.ReadOnlyTabularContractRow]::new($values)
 
+        $exportPath = Join-Path $TestDrive 'ReadOnlyDictionaryExport.xlsx'
+        Export-OfficeExcel -Path $exportPath -InputObject $row -CollectionSeparator ' | '
+        $exportRows = @(Import-OfficeExcel -Path $exportPath -WorksheetName 'Sheet1')
+        $exportRows[0].Name | Should -Be 'Alpha'
+        $exportRows[0].Tags | Should -Be 'One | Two'
+
+        $tablePath = Join-Path $TestDrive 'ReadOnlyDictionaryTable.xlsx'
+        New-OfficeExcel -Path $tablePath {
+            Add-OfficeExcelSheet -Name 'Data' -Content {
+                Add-OfficeExcelTable -InputObject $row -TableName 'ReadOnlyRows' -CollectionSeparator ' | '
+            }
+        }
+        $tableRows = @(Import-OfficeExcel -Path $tablePath -WorksheetName 'Data')
+        $tableRows[0].Name | Should -Be 'Alpha'
+        $tableRows[0].Tags | Should -Be 'One | Two'
+
+        $reportPath = Join-Path $TestDrive 'ReadOnlyDictionaryReport.xlsx'
+        New-OfficeExcel -Path $reportPath {
+            Add-OfficeExcelReportSheet -Name 'Report' {
+                Add-OfficeExcelReportTable -InputObject $row -CollectionSeparator ' | '
+            }
+        }
+        $reportRows = @(Import-OfficeExcel -Path $reportPath -WorksheetName 'Report')
+        $reportRows[0].Name | Should -Be 'Alpha'
+        $reportRows[0].Tags | Should -Be 'One | Two'
+
         $markdown = $row | ConvertTo-OfficeMarkdown -CollectionSeparator ' | '
         $markdown | Should -Match 'Name'
         $markdown | Should -Match 'Alpha'


### PR DESCRIPTION
## Summary

PSWriteOffice now applies one tabular-input contract across every table-producing format.

- normalize PowerShell objects, CLR objects, non-generic and generic dictionaries, read-only dictionaries, ADO.NET tables/readers/rows, and scalar values
- format nested collections and dictionaries consistently with caller-configurable separators
- apply the shared behavior to Excel tables, direct Excel exports, Excel report tables, Word, PowerPoint, PDF, and Markdown
- preserve streaming `IDataReader` exports while normalizing complex cell values
- cover the behavior on PowerShell 7 and Windows PowerShell 5.1 with generated document assertions

## Dependency

Consumes the released OfficeIMO 3.2.0 packages for the shared runtime dictionary-row projection used by Excel and PowerPoint table composition.