### PR TITLE
Stream IDataReader Excel exports atomically

### DIFF
--- a/Benchmarks/Excel/excel-performance.core.ps1
+++ b/Benchmarks/Excel/excel-performance.core.ps1
@@ -93,7 +93,7 @@ function New-ExcelBenchmarkCase {
 
     $supportedEngines = @('PSWriteOffice')
     if ($OperationKey -notin @('WriteCsv', 'ReadCsvSource', 'ReadUsedRangeDataTable', 'ReadTableMetadata', 'ReadNamedRangeMetadata') -and
-        $Name -ne 'dataset-worksheets') {
+        $Name -notin @('dataset-worksheets', 'datareader-table')) {
         $supportedEngines += 'ImportExcel'
     }
     if ($Name -in @('text-objects-default', 'import-default-full', 'import-default-range', 'read-no-header-range')) {
@@ -133,6 +133,7 @@ function Get-ExcelBenchmarkCase {
         New-ExcelBenchmarkCase -Name objects-title-freeze -Label 'Export objects with title and frozen header' -Suites $workflow -OperationKey WriteWorkbook -Profile MixedObjects
         New-ExcelBenchmarkCase -Name wide-objects-default -Label 'Export wide objects default' -Suites $scale -OperationKey WriteWorkbook -Profile WideObjects
         New-ExcelBenchmarkCase -Name datatable-default -Label 'Export DataTable default' -Suites $scale -OperationKey WriteWorkbook -Profile DataTable
+        New-ExcelBenchmarkCase -Name datareader-table -Label 'Stream IDataReader as table' -Suites $scale -OperationKey WriteWorkbook -Profile DataTable
         New-ExcelBenchmarkCase -Name import-default-full -Label 'Read full sheet from default export' -Suites $basic -OperationKey ReadFullSheet -Profile MixedObjects -ValidateWorkbook:$false
         New-ExcelBenchmarkCase -Name import-default-range -Label 'Read A1 range from default export' -Suites $scale -OperationKey ReadRange -Profile MixedObjects -ValidateWorkbook:$false
         New-ExcelBenchmarkCase -Name read-no-header-range -Label 'Read selected range without headers' -Suites $standard -OperationKey ReadNoHeaderRange -Profile MixedObjects -ValidateWorkbook:$false

--- a/Benchmarks/Excel/excel-performance.operations.ps1
+++ b/Benchmarks/Excel/excel-performance.operations.ps1
@@ -317,6 +317,7 @@ function Invoke-ExcelBenchmarkWriteWorkbook {
         objects-title-freeze { Invoke-ExcelBenchmarkObjectsTitleFreeze -Engine $Engine -Run $Run }
         wide-objects-default { Invoke-ExcelBenchmarkObjectsDefault -Engine $Engine -Run $Run }
         datatable-default { Invoke-ExcelBenchmarkDataTableDefault -Engine $Engine -Run $Run }
+        datareader-table { Invoke-ExcelBenchmarkDataReaderTable -Engine $Engine -Run $Run }
         multi-sheet-regions { Invoke-ExcelBenchmarkMultiSheetRegions -Engine $Engine -Run $Run }
         summary-formulas { Invoke-ExcelBenchmarkSummaryFormulas -Engine $Engine -Run $Run }
         append-existing-table { Invoke-ExcelBenchmarkAppendExistingTable -Engine $Engine -Run $Run }
@@ -392,6 +393,20 @@ function Invoke-ExcelBenchmarkDataTableDefault {
     switch ($Engine) {
         PSWriteOffice { Export-OfficeExcel -Path $Run.Path -InputObject $Run.Payload -WorksheetName $Run.WorksheetName -TableName Data }
         ImportExcel { $Run.Payload | Export-Excel -Path $Run.Path -WorksheetName $Run.WorksheetName }
+    }
+}
+
+function Invoke-ExcelBenchmarkDataReaderTable {
+    param([string] $Engine, [object] $Run)
+    if ($Engine -ne 'PSWriteOffice') {
+        throw "Engine '$Engine' does not expose an equivalent IDataReader workbook export."
+    }
+
+    $reader = $Run.Payload.CreateDataReader()
+    try {
+        Export-OfficeExcel -Path $Run.Path -InputObject $reader -WorksheetName $Run.WorksheetName -TableName Data
+    } finally {
+        $reader.Dispose()
     }
 }
 

--- a/Benchmarks/Excel/excel-performance.validation.ps1
+++ b/Benchmarks/Excel/excel-performance.validation.ps1
@@ -104,7 +104,7 @@ function Test-ExcelBenchmarkOutput {
     }
     Test-ExcelBenchmarkOpenXml -Path $Run.Path
 
-    if ([string]$Case.Scenario -in @('objects-default', 'text-objects-default', 'wide-objects-default')) {
+    if ([string]$Case.Scenario -in @('objects-default', 'text-objects-default', 'wide-objects-default', 'datatable-default', 'datareader-table')) {
         Test-ExcelBenchmarkTabularValues -Case $Case -Run $Run
     }
 }
@@ -113,7 +113,8 @@ function Test-ExcelBenchmarkTabularValues {
     param([object] $Case, [object] $Run)
 
     $actualRows = @(Import-OfficeExcel -Path $Run.Path -WorksheetName $Run.WorksheetName)
-    $expectedRows = @($Run.Payload)
+    $isDataTable = $Run.Payload -is [Data.DataTable]
+    $expectedRows = if ($isDataTable) { @($Run.Payload.Rows) } else { @($Run.Payload) }
     assertValue $actualRows.Count $expectedRows.Count -Message "Expected '$($Case.Scenario)' to preserve every data row."
     if ($expectedRows.Count -eq 0) {
         return
@@ -125,7 +126,14 @@ function Test-ExcelBenchmarkTabularValues {
     foreach ($index in $indexes) {
         $expected = $expectedRows[$index]
         $actual = $actualRows[$index]
-        foreach ($property in $expected.PSObject.Properties) {
+        $expectedValues = if ($isDataTable) {
+            foreach ($column in $Run.Payload.Columns) {
+                [pscustomobject]@{ Name = $column.ColumnName; Value = $expected[$column] }
+            }
+        } else {
+            $expected.PSObject.Properties
+        }
+        foreach ($property in $expectedValues) {
             $expectedValue = ConvertTo-ExcelBenchmarkComparableValue -Value $property.Value
             $actualProperty = $actual.PSObject.Properties[$property.Name]
             if ($null -eq $actualProperty) {
@@ -150,8 +158,8 @@ function ConvertTo-ExcelBenchmarkComparableValue {
     if ($Value -is [bool]) {
         return $Value.ToString().ToLowerInvariant()
     }
-    if ($Value -is [double] -or $Value -is [single]) {
-        return ([Math]::Round([double] $Value, 10)).ToString('G17', [Globalization.CultureInfo]::InvariantCulture)
+    if ($Value -is [decimal] -or $Value -is [double] -or $Value -is [single]) {
+        return ([decimal]::Round([Convert]::ToDecimal($Value, [Globalization.CultureInfo]::InvariantCulture), 10)).ToString('G29', [Globalization.CultureInfo]::InvariantCulture)
     }
     if ($Value -is [IFormattable]) {
         return $Value.ToString($null, [Globalization.CultureInfo]::InvariantCulture)

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -60,6 +60,31 @@ pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-Excel
     -UpdateReadme
 ```
 
+### Streaming `IDataReader` tables
+
+The `datareader-table` scenario measures the SQL-facing path: a forward-only
+`IDataReader` is written as a real XLSX table and then validated for typed values
+and Open XML package correctness. It is a PSWriteOffice capability lane, not a
+cross-library ranking, because the compared PowerShell modules do not expose an
+equivalent `IDataReader` workbook export.
+
+```powershell
+pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\Benchmarks\Compare-ExcelPerformance.ps1 `
+    -Suite Standard `
+    -RowCount 25000 `
+    -RepeatCount 31 `
+    -Scenario datareader-table `
+    -Engine PSWriteOffice
+```
+
+A focused 2026-08-10 before/after run used 25,000 rows, twelve warmups, 31
+measurements, High process priority, and affinities `0x1` and `0x10000` on an
+AMD Ryzen 9 9950X3D2. The package-native path reduced observed mean export time
+from 127.74 to 82.21 ms on `0x1` and from 84.95 to 47.31 ms on `0x10000`.
+Managed allocation fell from about 12.37 MB to 3.00 MB in both processor
+domains. These are workstation observations; the paired processor runs are kept
+visible because the faster CPU domain can change by sub-operation.
+
 <!-- BENCHMARK:ExcelComparison:START -->
 | Scenario | Rows | PSWriteOffice | ExcelFast | ImportExcel | Result |
 | --- | ---: | ---: | ---: | ---: | --- |

--- a/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.DataReaderPackage.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.DataReaderPackage.cs
@@ -1,0 +1,101 @@
+using System.Data;
+using OfficeIMO.Excel;
+using PSWriteOffice.Services;
+using PSWriteOffice.Services.Excel;
+
+namespace PSWriteOffice.Cmdlets.Excel;
+
+public sealed partial class ExportOfficeExcelCommand
+{
+    private bool TryWriteDataReaderPackageDirectly(
+        IDataReader reader,
+        string resolvedPath,
+        bool preserveWorkbook,
+        ExcelTableStyle style,
+        ExcelColumnFormatPlan? columnFormatPlan)
+    {
+        if (!CanWriteDataReaderPackageDirectly(preserveWorkbook, columnFormatPlan))
+        {
+            return false;
+        }
+
+        var options = new ExcelTabularWriteOptions
+        {
+            SheetName = WorksheetName,
+            IncludeHeaders = !NoHeader.IsPresent,
+            CreateTable = !NoTable.IsPresent,
+            TableName = TableName,
+            TableStyle = style,
+            IncludeAutoFilter = !NoAutoFilter.IsPresent,
+            IncludeCellReferences = false,
+            UseSharedStrings = false,
+            DateSystem = string.IsNullOrWhiteSpace(DateSystem)
+                ? ExcelDateSystem.NineteenHundred
+                : ExcelDateSystemService.Resolve(DateSystem!, nameof(DateSystem))
+        };
+        var result = ExcelDocumentService.WriteDataReaderPackage(
+            resolvedPath,
+            new NormalizingDataReader(reader, CreateNormalizerOptions()),
+            options,
+            overwrite: !NoClobber.IsPresent);
+
+        if (!string.IsNullOrWhiteSpace(result.Range))
+        {
+            WriteVerbose($"Exported data reader to {result.SheetName}!{result.Range} through the streaming package writer.");
+        }
+
+        if (Open.IsPresent)
+        {
+            FileOpenService.Open(resolvedPath);
+        }
+
+        WritePassThru(resolvedPath);
+        return true;
+    }
+
+    private bool CanWriteDataReaderPackageDirectly(
+        bool preserveWorkbook,
+        ExcelColumnFormatPlan? columnFormatPlan)
+    {
+        return !preserveWorkbook &&
+            !AppendToTable.IsPresent &&
+            StartRow == 1 &&
+            StartColumn == 1 &&
+            (!NoHeader.IsPresent || NoTable.IsPresent) &&
+            string.IsNullOrWhiteSpace(Title) &&
+            ExcludeProperty is not { Length: > 0 } &&
+            columnFormatPlan == null &&
+            !AutoFit.IsPresent &&
+            !AutoFitFormattedColumn.IsPresent &&
+            !BoldTopRow.IsPresent &&
+            !FreezeTopRow.IsPresent &&
+            !FreezeFirstColumn.IsPresent &&
+            !ShowFirstColumn.IsPresent &&
+            !ShowLastColumn.IsPresent &&
+            !NoRowStripes.IsPresent &&
+            !ShowColumnStripes.IsPresent &&
+            !SafePreflight.IsPresent &&
+            !SafeRepairDefinedNames.IsPresent &&
+            !ValidateOpenXml.IsPresent &&
+            !DisableFastPackageWriter.IsPresent &&
+            !EvaluateFormulas.IsPresent &&
+            !ClearCachedFormulaResults.IsPresent &&
+            !MarkFormulasDirty.IsPresent &&
+            !ForceFullCalculationOnOpen.IsPresent &&
+            !HasWorkbookProperties();
+    }
+
+    private bool HasWorkbookProperties()
+    {
+        return !string.IsNullOrWhiteSpace(DocumentTitle) ||
+            !string.IsNullOrWhiteSpace(Author) ||
+            !string.IsNullOrWhiteSpace(Subject) ||
+            !string.IsNullOrWhiteSpace(Keywords) ||
+            !string.IsNullOrWhiteSpace(Description) ||
+            !string.IsNullOrWhiteSpace(Category) ||
+            !string.IsNullOrWhiteSpace(Company) ||
+            !string.IsNullOrWhiteSpace(Manager) ||
+            !string.IsNullOrWhiteSpace(ApplicationName) ||
+            !string.IsNullOrWhiteSpace(LastModifiedBy);
+    }
+}

--- a/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/ExportOfficeExcelCommand.cs
@@ -27,7 +27,7 @@ namespace PSWriteOffice.Cmdlets.Excel;
 /// </example>
 [Cmdlet(VerbsData.Export, "OfficeExcel", DefaultParameterSetName = ParameterSetCreate, SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.Medium)]
 [Alias("ExcelExport")]
-public sealed class ExportOfficeExcelCommand : PSCmdlet
+public sealed partial class ExportOfficeExcelCommand : PSCmdlet
 {
     private const string ParameterSetCreate = "Create";
     private const string ParameterSetAppend = "Append";
@@ -352,10 +352,31 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
             return;
         }
 
+        var saveOptions = ExcelDocumentService.CreateSaveOptions(
+            SafePreflight.IsPresent,
+            SafeRepairDefinedNames.IsPresent,
+            ValidateOpenXml.IsPresent,
+            DisableFastPackageWriter.IsPresent,
+            EvaluateFormulas.IsPresent,
+            ClearCachedFormulaResults.IsPresent,
+            MarkFormulasDirty.IsPresent,
+            ForceFullCalculationOnOpen.IsPresent);
+
         var directory = System.IO.Path.GetDirectoryName(resolvedPath);
         if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
         {
             Directory.CreateDirectory(directory);
+        }
+
+        var directReader = ExcelTabularInputService.TryGetSingleDataReader(_input);
+        if (directReader != null && TryWriteDataReaderPackageDirectly(
+                directReader,
+                resolvedPath,
+                preserveWorkbook,
+                style,
+                columnFormatPlan))
+        {
+            return;
         }
 
         if (File.Exists(resolvedPath) && !preserveWorkbook)
@@ -366,15 +387,6 @@ public sealed class ExportOfficeExcelCommand : PSCmdlet
         var document = preserveWorkbook
             ? ExcelDocumentService.LoadDocument(resolvedPath, readOnly: false, autoSave: false)
             : ExcelDocumentService.CreateDocument(resolvedPath, autoSave: false);
-        var saveOptions = ExcelDocumentService.CreateSaveOptions(
-            SafePreflight.IsPresent,
-            SafeRepairDefinedNames.IsPresent,
-            ValidateOpenXml.IsPresent,
-            DisableFastPackageWriter.IsPresent,
-            EvaluateFormulas.IsPresent,
-            ClearCachedFormulaResults.IsPresent,
-            MarkFormulasDirty.IsPresent,
-            ForceFullCalculationOnOpen.IsPresent);
 
         try
         {

--- a/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.DataReaderPackage.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.DataReaderPackage.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Data;
+using System.IO;
+using OfficeIMO.Excel;
+
+namespace PSWriteOffice.Services.Excel;
+
+internal static partial class ExcelDocumentService
+{
+    internal static ExcelDataSetImportResult WriteDataReaderPackage(
+        string filePath,
+        IDataReader reader,
+        ExcelTabularWriteOptions options,
+        bool overwrite)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            throw new ArgumentException("File path cannot be empty.", nameof(filePath));
+        }
+
+        if (reader == null)
+        {
+            throw new ArgumentNullException(nameof(reader));
+        }
+
+        if (options == null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        var targetPath = Path.GetFullPath(filePath);
+        if (!overwrite && File.Exists(targetPath))
+        {
+            throw new IOException($"File '{targetPath}' already exists.");
+        }
+
+        var directory = Path.GetDirectoryName(targetPath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var temporaryPath = Path.Combine(
+            directory ?? Directory.GetCurrentDirectory(),
+            "." + Path.GetFileName(targetPath) + "." + Guid.NewGuid().ToString("N") + ".tmp");
+        try
+        {
+            ExcelDataSetImportResult result;
+            using (var stream = new FileStream(
+                temporaryPath,
+                FileMode.CreateNew,
+                FileAccess.ReadWrite,
+                FileShare.None,
+                81920,
+                FileOptions.SequentialScan))
+            {
+                result = ExcelDocument.WriteDataReader(stream, reader, options);
+                stream.Flush();
+            }
+
+            CommitDataReaderPackage(temporaryPath, targetPath, overwrite);
+            temporaryPath = string.Empty;
+            return result;
+        }
+        finally
+        {
+            if (!string.IsNullOrEmpty(temporaryPath) && File.Exists(temporaryPath))
+            {
+                File.Delete(temporaryPath);
+            }
+        }
+    }
+
+    private static void CommitDataReaderPackage(string temporaryPath, string targetPath, bool overwrite)
+    {
+        if (!File.Exists(targetPath))
+        {
+            File.Move(temporaryPath, targetPath);
+            return;
+        }
+
+        if (!overwrite)
+        {
+            throw new IOException($"File '{targetPath}' already exists.");
+        }
+
+#if FRAMEWORK
+        File.Replace(temporaryPath, targetPath, null);
+#else
+        File.Move(temporaryPath, targetPath, overwrite: true);
+#endif
+    }
+}

--- a/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.cs
+++ b/Sources/PSWriteOffice/Services/Excel/ExcelDocumentService.cs
@@ -9,7 +9,7 @@ using PSWriteOffice.Services;
 
 namespace PSWriteOffice.Services.Excel;
 
-internal static class ExcelDocumentService
+internal static partial class ExcelDocumentService
 {
     private static readonly ConcurrentDictionary<ExcelDocument, string> AssociatedPaths = new();
     private static readonly ConcurrentDictionary<ExcelDocument, string> EncryptedSourcePaths = new();

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -9,7 +9,7 @@ BeforeAll {
     . (Join-Path $PSScriptRoot 'TestHelpers.ps1')
 
     if (-not ('PSWriteOfficeTestSupport.LateDestinationDataReader' -as [type])) {
-        Add-Type -TypeDefinition @'
+        $readerTypeDefinition = @'
 using System;
 using System.Data;
 using System.IO;
@@ -71,6 +71,11 @@ namespace PSWriteOfficeTestSupport {
     }
 }
 '@
+        if ($PSVersionTable.PSEdition -eq 'Desktop') {
+            Add-Type -TypeDefinition $readerTypeDefinition -ReferencedAssemblies 'System.Data.dll'
+        } else {
+            Add-Type -TypeDefinition $readerTypeDefinition
+        }
     }
 
     function Get-TestLoadedType {

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -8,6 +8,71 @@ BeforeAll {
 
     . (Join-Path $PSScriptRoot 'TestHelpers.ps1')
 
+    if (-not ('PSWriteOfficeTestSupport.LateDestinationDataReader' -as [type])) {
+        Add-Type -TypeDefinition @'
+using System;
+using System.Data;
+using System.IO;
+
+namespace PSWriteOfficeTestSupport {
+    public sealed class LateDestinationDataReader : IDataReader {
+        private readonly IDataReader _inner;
+        private readonly string _path;
+        private readonly string _content;
+        private bool _created;
+
+        public LateDestinationDataReader(IDataReader inner, string path, string content) {
+            _inner = inner;
+            _path = path;
+            _content = content;
+        }
+
+        public object this[int i] { get { return _inner[i]; } }
+        public object this[string name] { get { return _inner[name]; } }
+        public int Depth { get { return _inner.Depth; } }
+        public bool IsClosed { get { return _inner.IsClosed; } }
+        public int RecordsAffected { get { return _inner.RecordsAffected; } }
+        public int FieldCount { get { return _inner.FieldCount; } }
+        public void Close() { _inner.Close(); }
+        public void Dispose() { _inner.Dispose(); }
+        public bool GetBoolean(int i) { return _inner.GetBoolean(i); }
+        public byte GetByte(int i) { return _inner.GetByte(i); }
+        public long GetBytes(int i, long fieldOffset, byte[] buffer, int bufferOffset, int length) { return _inner.GetBytes(i, fieldOffset, buffer, bufferOffset, length); }
+        public char GetChar(int i) { return _inner.GetChar(i); }
+        public long GetChars(int i, long fieldOffset, char[] buffer, int bufferOffset, int length) { return _inner.GetChars(i, fieldOffset, buffer, bufferOffset, length); }
+        public IDataReader GetData(int i) { return _inner.GetData(i); }
+        public string GetDataTypeName(int i) { return _inner.GetDataTypeName(i); }
+        public DateTime GetDateTime(int i) { return _inner.GetDateTime(i); }
+        public decimal GetDecimal(int i) { return _inner.GetDecimal(i); }
+        public double GetDouble(int i) { return _inner.GetDouble(i); }
+        public Type GetFieldType(int i) { return _inner.GetFieldType(i); }
+        public float GetFloat(int i) { return _inner.GetFloat(i); }
+        public Guid GetGuid(int i) { return _inner.GetGuid(i); }
+        public short GetInt16(int i) { return _inner.GetInt16(i); }
+        public int GetInt32(int i) { return _inner.GetInt32(i); }
+        public long GetInt64(int i) { return _inner.GetInt64(i); }
+        public string GetName(int i) { return _inner.GetName(i); }
+        public int GetOrdinal(string name) { return _inner.GetOrdinal(name); }
+        public DataTable GetSchemaTable() { return _inner.GetSchemaTable(); }
+        public string GetString(int i) { return _inner.GetString(i); }
+        public object GetValue(int i) { return _inner.GetValue(i); }
+        public int GetValues(object[] values) { return _inner.GetValues(values); }
+        public bool IsDBNull(int i) { return _inner.IsDBNull(i); }
+        public bool NextResult() { return _inner.NextResult(); }
+
+        public bool Read() {
+            if (!_created) {
+                File.WriteAllText(_path, _content);
+                _created = true;
+            }
+
+            return _inner.Read();
+        }
+    }
+}
+'@
+    }
+
     function Get-TestLoadedType {
         param(
             [Parameter(Mandatory)]
@@ -1408,6 +1473,110 @@ Describe 'Excel DSL surface' {
         $rows.Count | Should -Be 2
         $rows[0].Name | Should -Be 'A'
         $rows[1].Value | Should -Be 2
+    }
+
+    It 'uses the compact package writer for an unmodified IDataReader export' {
+        $path = Join-Path $TestDrive 'ExportOfficeExcelDataReaderCompact.xlsx'
+        $table = [System.Data.DataTable]::new('SqlRows')
+        [void] $table.Columns.Add('Name', [string])
+        [void] $table.Columns.Add('Value', [int])
+        [void] $table.Rows.Add('A', 1)
+        [void] $table.Rows.Add('B', 2)
+        $reader = $table.CreateDataReader()
+
+        Export-OfficeExcel -Path $path -InputObject $reader -WorksheetName 'Data' -TableName 'SqlRows'
+
+        $reader.IsClosed | Should -BeFalse
+        $archive = [System.IO.Compression.ZipFile]::OpenRead($path)
+        try {
+            $archive.GetEntry('xl/sharedStrings.xml') | Should -BeNullOrEmpty
+
+            $sheetReader = [System.IO.StreamReader]::new($archive.GetEntry('xl/worksheets/sheet1.xml').Open())
+            try {
+                $sheetXml = $sheetReader.ReadToEnd()
+            } finally {
+                $sheetReader.Dispose()
+            }
+
+            $tableReader = [System.IO.StreamReader]::new($archive.GetEntry('xl/tables/table1.xml').Open())
+            try {
+                $tableXml = $tableReader.ReadToEnd()
+            } finally {
+                $tableReader.Dispose()
+            }
+        } finally {
+            $archive.Dispose()
+        }
+
+        $sheetXml | Should -Match '<tableParts count="1">'
+        $sheetXml | Should -Not -Match '<c r="A2"'
+        $tableXml | Should -Match 'name="SqlRows"'
+        $tableXml | Should -Match 'ref="A1:B3"'
+        $tableXml | Should -Match '<autoFilter ref="A1:B3"'
+
+        $rows = @(Import-OfficeExcel -Path $path -WorksheetName 'Data')
+        $rows.Count | Should -Be 2
+        $rows[0].Name | Should -Be 'A'
+        $rows[1].Value | Should -Be 2
+    }
+
+    It 'preserves an existing workbook when the compact IDataReader export fails' {
+        $path = Join-Path $TestDrive 'ExportOfficeExcelDataReaderFailure.xlsx'
+        [PSCustomObject]@{ Name = 'Original'; Value = 42 } |
+            Export-OfficeExcel -Path $path -WorksheetName 'Data' -TableName 'OriginalRows'
+        $beforeHash = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash
+
+        $table = [System.Data.DataTable]::new('SqlRows')
+        [void] $table.Columns.Add('Name', [string])
+        [void] $table.Columns.Add('Value', [int])
+        [void] $table.Rows.Add('Replacement', 7)
+        $reader = $table.CreateDataReader()
+        $reader.Close()
+
+        { Export-OfficeExcel -Path $path -InputObject $reader -WorksheetName 'Data' -TableName 'SqlRows' -ErrorAction Stop } |
+            Should -Throw
+
+        (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash | Should -Be $beforeHash
+        @(Get-ChildItem -LiteralPath $TestDrive -Filter '.ExportOfficeExcelDataReaderFailure.xlsx.*.tmp').Count |
+            Should -Be 0
+        $rows = @(Import-OfficeExcel -Path $path -WorksheetName 'Data')
+        $rows.Count | Should -Be 1
+        $rows[0].Name | Should -Be 'Original'
+        $rows[0].Value | Should -Be 42
+    }
+
+    It 'honors NoClobber when the destination appears during compact IDataReader export' {
+        $path = Join-Path $TestDrive 'ExportOfficeExcelDataReaderNoClobberRace.xlsx'
+        $table = [System.Data.DataTable]::new('SqlRows')
+        [void] $table.Columns.Add('Name', [string])
+        [void] $table.Rows.Add('A')
+        $innerReader = $table.CreateDataReader()
+        $reader = [PSWriteOfficeTestSupport.LateDestinationDataReader]::new(
+            $innerReader,
+            $path,
+            'late destination')
+
+        { Export-OfficeExcel -Path $path -InputObject $reader -WorksheetName 'Data' -NoClobber -ErrorAction Stop } |
+            Should -Throw
+
+        [System.IO.File]::ReadAllText($path) | Should -Be 'late destination'
+        $reader.IsClosed | Should -BeFalse
+        @(Get-ChildItem -LiteralPath $TestDrive -Filter '.ExportOfficeExcelDataReaderNoClobberRace.xlsx.*.tmp').Count |
+            Should -Be 0
+    }
+
+    It 'rejects AppendToTable IDataReader export when the destination is missing' {
+        $path = Join-Path $TestDrive 'ExportOfficeExcelDataReaderAppendMissing.xlsx'
+        $table = [System.Data.DataTable]::new('SqlRows')
+        [void] $table.Columns.Add('Name', [string])
+        [void] $table.Rows.Add('A')
+        $reader = $table.CreateDataReader()
+
+        { Export-OfficeExcel -Path $path -InputObject $reader -WorksheetName 'Data' -Append -AppendToTable -ErrorAction Stop } |
+            Should -Throw
+
+        $path | Should -Not -Exist
+        $reader.IsClosed | Should -BeFalse
     }
 
     It 'exports HTML-parser DataTable output with companion link URL columns' {

--- a/Tests/ExcelDsl.Tests.ps1
+++ b/Tests/ExcelDsl.Tests.ps1
@@ -72,7 +72,10 @@ namespace PSWriteOfficeTestSupport {
 }
 '@
         if ($PSVersionTable.PSEdition -eq 'Desktop') {
-            Add-Type -TypeDefinition $readerTypeDefinition -ReferencedAssemblies 'System.Data.dll'
+            Add-Type -TypeDefinition $readerTypeDefinition -ReferencedAssemblies @(
+                'System.Data.dll'
+                'System.Xml.dll'
+            )
         } else {
             Add-Type -TypeDefinition $readerTypeDefinition
         }


### PR DESCRIPTION
## Summary

- route eligible single-IDataReader Excel exports through OfficeIMO's package-native XLSX writer instead of materializing the full result in the workbook object model
- stage output in a same-directory temporary file and atomically commit it only after a successful write
- preserve the existing file on write failures and recheck NoClobber at final commit so concurrent creation cannot be overwritten
- preserve caller ownership of the IDataReader and leave it open
- keep AppendToTable on the established workbook path so missing-target and append semantics remain unchanged
- add capability-only benchmark coverage with structural workbook and row/value validation

## User-facing behavior

The public Export-OfficeExcel API is unchanged. Simple one-reader XLSX exports gain the streaming path automatically when their requested options are supported. More complex workbook operations continue through the existing general path.

Worksheet and table naming follow the shared OfficeIMO normalization contract, including ReaderData as the default table name. Empty readers still produce a valid header-only table when headers are requested.

## Dependency

This PR depends on EvotecIT/OfficeIMO#2272 and should be merged/released only after the required OfficeIMO.Excel API is available to this repository's normal package build. The implementation was validated against the exact OfficeIMO source head from that PR; no package-version probe or temporary compatibility bridge is included.

## Validation

- Release builds passed for .NET Framework 4.7.2 and .NET 8 against the current OfficeIMO project references
- compiled focused tests passed 11/11
- the full ExcelDsl Pester suite passed 129/129
- focused coverage exercises success, reader ownership, failure atomicity, NoClobber races, name normalization, AppendToTable routing, and benchmark validation
- independent local review findings were repaired and confirmed with no unresolved P0-P2 issue
