### PR TITLE
Configure grouped low-noise Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+- package-ecosystem: nuget
+  directory: /Sources
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 7
+    include:
+    - '*'
+  open-pull-requests-limit: 1
+  groups:
+    all-dependencies:
+      patterns:
+      - '*'
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 7
+    include:
+    - '*'
+  open-pull-requests-limit: 1
+  groups:
+    all-dependencies:
+      patterns:
+      - '*'


### PR DESCRIPTION
Group ordinary dependency updates so the repository stays current without producing a PR storm.

This covers `nuget`, `github-actions`, checks daily, waits seven days before proposing ordinary releases, and keeps one grouped version-update PR open per ecosystem. Security updates remain immediate.