### PR TITLE
Preserve source column order in Excel report tables

### DIFF
--- a/Sources/PSWriteOffice/Cmdlets/Excel/OfficeExcelReportBlockCommands.cs
+++ b/Sources/PSWriteOffice/Cmdlets/Excel/OfficeExcelReportBlockCommands.cs
@@ -363,6 +363,12 @@ public sealed class AddOfficeExcelReportTableCommand : PSCmdlet
             copyExistingTables: true,
             normalizerOptions: normalizerOptions);
         var reportRows = ExcelTabularInputService.ToDictionaryRows(table);
+        var sourceColumns = table.Columns
+            .Cast<System.Data.DataColumn>()
+            .Select(static column => column.ColumnName)
+            .ToArray();
+        var requestedColumns = NormalizePropertyList(Property) ?? sourceColumns;
+        var excludedProperties = NormalizePropertyList(ExcludeProperty) ?? Array.Empty<string>();
 
         if (!Enum.TryParse(TableStyle, ignoreCase: true, out ExcelTableStyle style))
         {
@@ -375,8 +381,8 @@ public sealed class AddOfficeExcelReportTableCommand : PSCmdlet
             Title,
             configure: options =>
             {
-                options.Columns = NormalizePropertyList(Property);
-                options.ExcludeProperties = NormalizePropertyList(ExcludeProperty) ?? Array.Empty<string>();
+                options.Columns = requestedColumns;
+                options.ExcludeProperties = excludedProperties;
             },
             style: style,
             autoFilter: !NoAutoFilter.IsPresent,

--- a/Tests/TabularInputContracts.Tests.ps1
+++ b/Tests/TabularInputContracts.Tests.ps1
@@ -263,6 +263,24 @@ Describe 'Shared tabular input contracts' {
         $rows[0].Name | Should -Be 'Alpha'
     }
 
+    It 'preserves incoming column order on Excel report tables by default' {
+        $path = Join-Path $TestDrive 'Report-SourceOrder.xlsx'
+        $inputRow = [pscustomobject] [ordered] @{
+            Zulu   = 'First'
+            Alpha  = 'Second'
+            Middle = 'Third'
+        }
+
+        New-OfficeExcel -Path $path {
+            Add-OfficeExcelReportSheet -Name 'Report' {
+                Add-OfficeExcelReportTable -InputObject $inputRow
+            }
+        }
+
+        $rows = @(Import-OfficeExcel -Path $path -WorksheetName 'Report')
+        $rows[0].PSObject.Properties.Name | Should -Be @('Zulu', 'Alpha', 'Middle')
+    }
+
     It 'streams IDataReader rows with shared nested formatting into direct Excel exports' {
         $path = Join-Path $TestDrive 'DirectReader.xlsx'
         $reader = New-TestTabularContractReader


### PR DESCRIPTION
## Summary

- preserve the normalized source table's declared column order in `Add-OfficeExcelReportTable`
- continue honoring explicit `-Property` ordering as the caller override
- continue applying `-ExcludeProperty` after the requested/default schema is selected

## Behavior

PowerShell objects are normalized to a `DataTable` before report generation. The cmdlet now passes that table's definitive column order into OfficeIMO instead of discarding it and allowing dictionary-key inference to reorder the report alphabetically.

## Dependency note

The related large-workbook repair and table-header styling changes are tracked in EvotecIT/OfficeIMO#2307. This PR intentionally keeps the current public OfficeIMO 3.2.0 pin; repin PSWriteOffice after the OfficeIMO fix is released.