### PR TITLE
Use canonical commands in Office benchmarks

### DIFF
--- a/Benchmarks/Csv/csv-performance.benchmark.ps1
+++ b/Benchmarks/Csv/csv-performance.benchmark.ps1
@@ -1,16 +1,16 @@
 . (Join-Path $PSScriptRoot '..\Excel\excel-performance.helpers.ps1')
 
 $repositoryRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..')).Path
-$suiteName = input Suite Standard
-$rowCounts = Assert-ExcelBenchmarkRowCount -RowCount (inputInt RowCount (Get-ExcelBenchmarkDefaultRowCount -Suite $suiteName))
+$suiteName = Get-BenchmarkInput Suite Standard
+$rowCounts = Assert-ExcelBenchmarkRowCount -RowCount (Get-BenchmarkInput RowCount (Get-ExcelBenchmarkDefaultRowCount -Suite $suiteName) -Int)
 
-benchmark 'csv-performance' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\CsvPerformance') {
-    policy -Warmup (Get-ExcelBenchmarkWarmupCount -Suite $suiteName) -Iterations (Get-CsvBenchmarkIterationCount -Suite $suiteName) -Order GroupedRotated -MemoryCleanup BeforeIteration -OutlierMode None
-    profile Current -Cleanup KeepOnFailure
-    caseSource (Get-CsvBenchmarkCase -Suite $suiteName)
-    axis RowCount $rowCounts
+New-BenchmarkSuite 'csv-performance' -OutputRoot (Join-Path $repositoryRoot 'Ignore\Benchmarks\CsvPerformance') {
+    Set-BenchmarkPolicy -Warmup (Get-ExcelBenchmarkWarmupCount -Suite $suiteName) -Iterations (Get-CsvBenchmarkIterationCount -Suite $suiteName) -Order GroupedRotated -MemoryCleanup BeforeIteration -OutlierMode None
+    Set-BenchmarkProfile Current -Cleanup KeepOnFailure
+    Add-BenchmarkCaseSource (Get-CsvBenchmarkCase -Suite $suiteName)
+    Add-BenchmarkAxis RowCount $rowCounts
 
-    setup {
+    Set-BenchmarkSetup {
         param($case, $run)
 
         $run.RepositoryRoot = $repositoryRoot
@@ -31,39 +31,39 @@ benchmark 'csv-performance' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\C
         Initialize-ExcelBenchmarkInput -Case $case -Run $run
     }
 
-    skip {
+    Add-BenchmarkSkipRule {
         param($case)
 
         -not (Test-CsvBenchmarkEngineSupport -Engine $case.Engine -Case $case)
     }
 
-    engine PSWriteOffice {
-        operation Run {
+    Add-BenchmarkEngine PSWriteOffice {
+        Add-BenchmarkOperation Run {
             param($case, $run)
             Invoke-ExcelBenchmarkOperation -Engine PSWriteOffice -Case $case -Run $run
         }
     }
 
-    engine NativeCsv {
-        operation Run {
+    Add-BenchmarkEngine NativeCsv {
+        Add-BenchmarkOperation Run {
             param($case, $run)
             Invoke-ExcelBenchmarkOperation -Engine NativeCsv -Case $case -Run $run
         }
     }
 
-    validate {
+    Add-BenchmarkValidation {
         param($case, $run)
 
         Test-CsvBenchmarkOutput -Case $case -Run $run
     }
 
-    metric RowsProcessed {
+    Add-BenchmarkMetric RowsProcessed {
         param($case, $run)
 
         $run.RowsProcessed
     }
 
-    metric RowsPerSecond {
+    Add-BenchmarkMetric RowsPerSecond {
         param($case, $run)
 
         if ($run.DurationMs -le 0) {
@@ -73,6 +73,6 @@ benchmark 'csv-performance' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\C
         [double] $case.RowCount / ($run.DurationMs / 1000)
     }
 
-    comparison Engine -Baseline PSWriteOffice -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
-    artifacts Json, Csv, Markdown
+    Add-BenchmarkComparison Engine -Baseline PSWriteOffice -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
+    Set-BenchmarkArtifacts Json, Csv, Markdown
 }

--- a/Benchmarks/Excel/excel-performance.benchmark.ps1
+++ b/Benchmarks/Excel/excel-performance.benchmark.ps1
@@ -1,19 +1,19 @@
 . (Join-Path $PSScriptRoot 'excel-performance.helpers.ps1')
 
 $repositoryRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..')).Path
-$suiteName = input Suite Standard
-$rowCounts = Assert-ExcelBenchmarkRowCount -RowCount (inputInt RowCount (Get-ExcelBenchmarkDefaultRowCount -Suite $suiteName))
-$skipWorkbookValidation = inputBool SkipWorkbookValidation false
-$skipImportExcelInstall = inputBool SkipImportExcelInstall false
-$skipExcelFastInstall = inputBool SkipExcelFastInstall false
+$suiteName = Get-BenchmarkInput Suite Standard
+$rowCounts = Assert-ExcelBenchmarkRowCount -RowCount (Get-BenchmarkInput RowCount (Get-ExcelBenchmarkDefaultRowCount -Suite $suiteName) -Int)
+$skipWorkbookValidation = Get-BenchmarkInput SkipWorkbookValidation false -Bool
+$skipImportExcelInstall = Get-BenchmarkInput SkipImportExcelInstall false -Bool
+$skipExcelFastInstall = Get-BenchmarkInput SkipExcelFastInstall false -Bool
 
-benchmark 'excel-performance' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks\ExcelPerformance') {
-    policy -Warmup (Get-ExcelBenchmarkWarmupCount -Suite $suiteName) -Iterations (Get-ExcelBenchmarkIterationCount -Suite $suiteName) -Order GroupedRotated -MemoryCleanup BeforeIteration -OutlierMode None
-    profile Current -Cleanup KeepOnFailure
-    caseSource (Get-ExcelBenchmarkCase -Suite $suiteName)
-    axis RowCount $rowCounts
+New-BenchmarkSuite 'excel-performance' -OutputRoot (Join-Path $repositoryRoot 'Ignore\Benchmarks\ExcelPerformance') {
+    Set-BenchmarkPolicy -Warmup (Get-ExcelBenchmarkWarmupCount -Suite $suiteName) -Iterations (Get-ExcelBenchmarkIterationCount -Suite $suiteName) -Order GroupedRotated -MemoryCleanup BeforeIteration -OutlierMode None
+    Set-BenchmarkProfile Current -Cleanup KeepOnFailure
+    Add-BenchmarkCaseSource (Get-ExcelBenchmarkCase -Suite $suiteName)
+    Add-BenchmarkAxis RowCount $rowCounts
 
-    setup {
+    Set-BenchmarkSetup {
         param($case, $run)
 
         $run.RepositoryRoot = $repositoryRoot
@@ -41,39 +41,39 @@ benchmark 'excel-performance' -out (Join-Path $repositoryRoot 'Ignore\Benchmarks
         Initialize-ExcelBenchmarkInput -Case $case -Run $run
     }
 
-    skip {
+    Add-BenchmarkSkipRule {
         param($case)
 
         return ([string] $case.SupportedEngines -split ',') -notcontains [string] $case.Engine
     }
 
-    engine PSWriteOffice {
-        operation Run {
+    Add-BenchmarkEngine PSWriteOffice {
+        Add-BenchmarkOperation Run {
             param($case, $run)
             Invoke-ExcelBenchmarkOperation -Engine PSWriteOffice -Case $case -Run $run
         }
     }
 
-    engine ImportExcel {
-        operation Run {
+    Add-BenchmarkEngine ImportExcel {
+        Add-BenchmarkOperation Run {
             param($case, $run)
             Invoke-ExcelBenchmarkOperation -Engine ImportExcel -Case $case -Run $run
         }
     }
 
-    engine ExcelFast {
-        operation Run {
+    Add-BenchmarkEngine ExcelFast {
+        Add-BenchmarkOperation Run {
             param($case, $run)
             Invoke-ExcelBenchmarkOperation -Engine ExcelFast -Case $case -Run $run
         }
     }
 
-    validate {
+    Add-BenchmarkValidation {
         param($case, $run)
 
         Test-ExcelBenchmarkOutput -Case $case -Run $run
     }
 
-    comparison Engine -Baseline PSWriteOffice -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
-    artifacts Json, Csv, Markdown
+    Add-BenchmarkComparison Engine -Baseline PSWriteOffice -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
+    Set-BenchmarkArtifacts Json, Csv, Markdown
 }

--- a/Benchmarks/Excel/excel-performance.validation.ps1
+++ b/Benchmarks/Excel/excel-performance.validation.ps1
@@ -63,7 +63,7 @@ function Test-ExcelBenchmarkOutput {
     param([object] $Case, [object] $Run)
 
     if ($Case.OperationKey -in @('WriteCsv', 'WriteCsvGZip', 'CsvToExcel', 'WriteWorkbook')) {
-        assertPath $Run.Path
+        Assert-BenchmarkPath $Run.Path
     }
 
     if ($Case.OperationKey -in @('ReadFullSheet', 'ReadRange', 'ReadNoHeaderRange')) {
@@ -72,22 +72,22 @@ function Test-ExcelBenchmarkOutput {
         } else {
             [int]$Run.ExpectedRows
         }
-        assertValue ([int]$Run.ActualRows) $expectedRows -Message "Expected $expectedRows rows returned by '$($Case.OperationKey)'."
+        Assert-BenchmarkValue ([int]$Run.ActualRows) $expectedRows -Message "Expected $expectedRows rows returned by '$($Case.OperationKey)'."
     }
 
     if ($Case.OperationKey -eq 'ReadUsedRangeDataTable') {
         $expectedRows = [int]$Run.ExpectedRows
-        assertValue ([int]$Run.ActualRows) $expectedRows -Message "Expected $expectedRows rows returned by '$($Case.OperationKey)'."
+        Assert-BenchmarkValue ([int]$Run.ActualRows) $expectedRows -Message "Expected $expectedRows rows returned by '$($Case.OperationKey)'."
     }
 
     if ($Case.OperationKey -eq 'ReadTableMetadata') {
-        assertValue ([int]$Run.ActualTableCount) 1 -Message 'Expected one workbook table metadata result.'
-        assertValue (@($Run.ActualTableNames) -contains 'Data') $true -Message "Expected table metadata to include 'Data'."
+        Assert-BenchmarkValue ([int]$Run.ActualTableCount) 1 -Message 'Expected one workbook table metadata result.'
+        Assert-BenchmarkValue (@($Run.ActualTableNames) -contains 'Data') $true -Message "Expected table metadata to include 'Data'."
     }
 
     if ($Case.OperationKey -eq 'ReadNamedRangeMetadata') {
-        assertValue ([int]$Run.ActualNamedRangeCount) 1 -Message 'Expected one workbook named range metadata result.'
-        assertValue (@($Run.ActualNamedRangeNames) -contains 'SalesData') $true -Message "Expected named range metadata to include 'SalesData'."
+        Assert-BenchmarkValue ([int]$Run.ActualNamedRangeCount) 1 -Message 'Expected one workbook named range metadata result.'
+        Assert-BenchmarkValue (@($Run.ActualNamedRangeNames) -contains 'SalesData') $true -Message "Expected named range metadata to include 'SalesData'."
     }
 
     if ([bool]$Run.SkipWorkbookValidation) {
@@ -115,7 +115,7 @@ function Test-ExcelBenchmarkTabularValues {
     $actualRows = @(Import-OfficeExcel -Path $Run.Path -WorksheetName $Run.WorksheetName)
     $isDataTable = $Run.Payload -is [Data.DataTable]
     $expectedRows = if ($isDataTable) { @($Run.Payload.Rows) } else { @($Run.Payload) }
-    assertValue $actualRows.Count $expectedRows.Count -Message "Expected '$($Case.Scenario)' to preserve every data row."
+    Assert-BenchmarkValue $actualRows.Count $expectedRows.Count -Message "Expected '$($Case.Scenario)' to preserve every data row."
     if ($expectedRows.Count -eq 0) {
         return
     }
@@ -141,7 +141,7 @@ function Test-ExcelBenchmarkTabularValues {
             }
 
             $actualValue = ConvertTo-ExcelBenchmarkComparableValue -Value $actualProperty.Value
-            assertValue $actualValue $expectedValue -Message "Expected '$($Case.Scenario)' row $index column '$($property.Name)' to preserve its value."
+            Assert-BenchmarkValue $actualValue $expectedValue -Message "Expected '$($Case.Scenario)' row $index column '$($property.Name)' to preserve its value."
         }
     }
 }
@@ -173,29 +173,29 @@ function Test-CsvBenchmarkOutput {
 
     $expectedRows = [int]$Run.ExpectedRows
     if ($Case.OperationKey -in @('ReadCsvSource', 'ReadCsvDataTable', 'ReadCsvGZipDataTable', 'ReadCsvQuickSingleColumn', 'ReadCsvQuickAllColumns')) {
-        assertValue ([int]$Run.ActualRows) $expectedRows -Message "Expected $expectedRows rows returned by '$($Case.OperationKey)'."
+        Assert-BenchmarkValue ([int]$Run.ActualRows) $expectedRows -Message "Expected $expectedRows rows returned by '$($Case.OperationKey)'."
         if ($Case.OperationKey -eq 'ReadCsvQuickSingleColumn') {
-            assertValue ([int]$Run.AccessedFields) $expectedRows -Message "Expected $expectedRows first-column values accessed by '$($Case.OperationKey)'."
-            assertValue ([string]$Run.LastValue) ([string]($expectedRows - 1)) -Message "Expected '$($Case.OperationKey)' to access the last Column0 value."
+            Assert-BenchmarkValue ([int]$Run.AccessedFields) $expectedRows -Message "Expected $expectedRows first-column values accessed by '$($Case.OperationKey)'."
+            Assert-BenchmarkValue ([string]$Run.LastValue) ([string]($expectedRows - 1)) -Message "Expected '$($Case.OperationKey)' to access the last Column0 value."
         }
         if ($Case.OperationKey -eq 'ReadCsvQuickAllColumns') {
             $expectedFields = $expectedRows * [int]$Run.ColumnCount
-            assertValue ([int]$Run.AccessedFields) $expectedFields -Message "Expected $expectedFields values accessed by '$($Case.OperationKey)'."
-            assertValue ([string]$Run.LastValue) ('Value{0}_{1}' -f ($expectedRows - 1), ([int]$Run.ColumnCount - 1)) -Message "Expected '$($Case.OperationKey)' to access the last field value."
+            Assert-BenchmarkValue ([int]$Run.AccessedFields) $expectedFields -Message "Expected $expectedFields values accessed by '$($Case.OperationKey)'."
+            Assert-BenchmarkValue ([string]$Run.LastValue) ('Value{0}_{1}' -f ($expectedRows - 1), ([int]$Run.ColumnCount - 1)) -Message "Expected '$($Case.OperationKey)' to access the last field value."
         }
         $Run.RowsProcessed = [int]$Run.ActualRows
         return
     }
 
     $path = $Run.Path
-    assertPath $path
+    Assert-BenchmarkPath $path
     $actualRows = if ($Case.OperationKey -eq 'WriteCsvGZip') {
         $table = ConvertFrom-NativeGZipCsvToDataTable -Path $path
         if ($table -and $table.Rows) { @($table.Select()) } else { @() }
     } else {
         @(Import-Csv -Path $path)
     }
-    assertValue $actualRows.Count $expectedRows -Message "Expected $expectedRows rows in '$path'."
+    Assert-BenchmarkValue $actualRows.Count $expectedRows -Message "Expected $expectedRows rows in '$path'."
     Test-CsvBenchmarkTabularValues -Case $Case -Run $Run -ActualRows $actualRows
     $Run.RowsProcessed = [int]$actualRows.Count
 }
@@ -209,14 +209,14 @@ function Test-CsvBenchmarkTabularValues {
         @($Run.Payload)
     }
 
-    assertValue $ActualRows.Count $expectedRows.Count -Message "Expected '$($Case.Scenario)' to preserve every CSV data row."
+    Assert-BenchmarkValue $ActualRows.Count $expectedRows.Count -Message "Expected '$($Case.Scenario)' to preserve every CSV data row."
     if ($expectedRows.Count -eq 0) {
         return
     }
 
     $expectedColumns = @(Get-CsvBenchmarkColumnNames -Row $expectedRows[0])
     $actualColumns = @(Get-CsvBenchmarkColumnNames -Row $ActualRows[0])
-    assertValue ($actualColumns -join [char]31) ($expectedColumns -join [char]31) -Message "Expected '$($Case.Scenario)' to preserve the CSV header and column order."
+    Assert-BenchmarkValue ($actualColumns -join [char]31) ($expectedColumns -join [char]31) -Message "Expected '$($Case.Scenario)' to preserve the CSV header and column order."
 
     for ($rowIndex = 0; $rowIndex -lt $expectedRows.Count; $rowIndex++) {
         $expectedRow = $expectedRows[$rowIndex]


### PR DESCRIPTION
## Summary

- migrate the Excel and CSV benchmark specifications to full PSPublishModule command names
- use explicit benchmark input switches and full parameter names
- keep the existing performance and validation scenarios unchanged

Related shared cleanup: EvotecIT/PSPublishModule#745.