### PR TITLE
Fix PowerForge docs artifact root

### DIFF
--- a/Tests/WebsiteDocumentation.Tests.ps1
+++ b/Tests/WebsiteDocumentation.Tests.ps1
@@ -113,7 +113,9 @@ Describe 'PSWriteOffice website documentation catalog' {
         $project.surfaces.docs | Should -BeTrue
         $project.surfaces.examples | Should -BeTrue
         $project.surfaces.apiPowerShell | Should -BeTrue
+        $project.artifacts.docs | Should -Be 'Website/content/project-docs'
         Test-Path -LiteralPath (Join-Path $script:repoRoot $project.artifacts.docs) | Should -BeTrue
+        Test-Path -LiteralPath (Join-Path $script:repoRoot $project.artifacts.docs 'docs\_index.md') | Should -BeTrue
         Test-Path -LiteralPath (Join-Path $script:repoRoot $project.artifacts.examples) | Should -BeTrue
         Test-Path -LiteralPath (Join-Path $script:repoRoot $project.artifacts.documentationCatalog) | Should -BeTrue
     }

--- a/Tests/WebsiteDocumentation.Tests.ps1
+++ b/Tests/WebsiteDocumentation.Tests.ps1
@@ -115,7 +115,7 @@ Describe 'PSWriteOffice website documentation catalog' {
         $project.surfaces.apiPowerShell | Should -BeTrue
         $project.artifacts.docs | Should -Be 'Website/content/project-docs'
         Test-Path -LiteralPath (Join-Path $script:repoRoot $project.artifacts.docs) | Should -BeTrue
-        Test-Path -LiteralPath (Join-Path $script:repoRoot $project.artifacts.docs 'docs\_index.md') | Should -BeTrue
+        Test-Path -LiteralPath (Join-Path (Join-Path $script:repoRoot $project.artifacts.docs) 'docs\_index.md') | Should -BeTrue
         Test-Path -LiteralPath (Join-Path $script:repoRoot $project.artifacts.examples) | Should -BeTrue
         Test-Path -LiteralPath (Join-Path $script:repoRoot $project.artifacts.documentationCatalog) | Should -BeTrue
     }

--- a/WebsiteArtifacts/project-manifest.json
+++ b/WebsiteArtifacts/project-manifest.json
@@ -19,7 +19,7 @@
   },
   "artifacts": {
     "api": "WebsiteArtifacts/apidocs",
-    "docs": "Website/content/project-docs/docs",
+    "docs": "Website/content/project-docs",
     "examples": "Website/content/examples",
     "documentationCatalog": "WebsiteArtifacts/documentation/command-catalog.json"
   }


### PR DESCRIPTION
## Summary

- publish the PSWriteOffice documentation artifact from its section root
- preserve the `docs` folder when PowerForge ingests the artifact into a multi-project website
- protect the manifest shape with a focused documentation contract test

The previous artifact path pointed directly at the nested `docs` folder. A PowerForge website consumer therefore copied its `_index.md` to the project hub root, where it conflicted with the generated PSWriteOffice project page.

## Validation

- `Tests/WebsiteDocumentation.Tests.ps1` (9 passed)

This fix unblocks the shared Website deployment; no PSWriteOffice runtime API changes are included.
